### PR TITLE
Fix typo in SessionInterface::validateAuthCode docblock

### DIFF
--- a/src/OAuth2/Storage/SessionInterface.php
+++ b/src/OAuth2/Storage/SessionInterface.php
@@ -182,7 +182,12 @@ interface SessionInterface
      * @param  int    $accessTokenExpires    The UNIX timestamp of when the new token expires
      * @return void
      */
-    public function updateRefreshToken($sessionId, $newAccessToken, $newRefreshToken, $accessTokenExpires);
+    public function updateRefreshToken(
+        $sessionId,
+        $newAccessToken,
+        $newRefreshToken,
+        $accessTokenExpires
+    );
 
     /**
      * Associates a session with a scope


### PR DESCRIPTION
Docblock lists an array response format, but the @return specifies int|bool.
Actual implementation in the AuthServer uses the @return specification.
