### PR TITLE
Remove base64 decoding of Authorization header

### DIFF
--- a/src/OAuth2/ResourceServer.php
+++ b/src/OAuth2/ResourceServer.php
@@ -216,7 +216,7 @@ class ResourceServer
     protected function determineAccessToken()
     {
         if ($header = $this->getRequest()->header('Authorization')) {
-            $access_token = base64_decode(trim(str_replace('Bearer', '', $header)));
+            $access_token = trim(str_replace('Bearer', '', $header));
         } else {
             $method = $this->getRequest()->server('REQUEST_METHOD');
             $access_token = $this->getRequest()->{$method}($this->tokenKey);


### PR DESCRIPTION
Base64 encoding of the Authorization header is implementation specific, not in the general specification. If you need to base64 decode your token string before use, you should be doing it in your SessionInterface::validateAccessToken implementation.
