### PR TITLE
Fixed client_id and client_secret retrieval from request

### DIFF
--- a/src/OAuth2/AuthServer.php
+++ b/src/OAuth2/AuthServer.php
@@ -446,7 +446,13 @@ class AuthServer
     public function getParam($param = '', $method = 'get', $inputParams = array(), $default = null)
     {
         if (is_string($param)) {
-            return (isset($inputParams[$param])) ? $inputParams[$param] : $this->getRequest()->{$method}($param, $default);
+            if(isset($inputParams[$param])) {
+                return $inputParams[$param];
+            } elseif($param == 'client_id' && !is_null($client_id = $this->getRequest()->server('PHP_AUTH_USER'))) {
+                return $client_id;
+            } elseif($param == 'client_secret' && !is_null($client_secret = $this->getRequest()->server('PHP_AUTH_PW'))) {
+                return $client_secret;
+            } else return $this->getRequest()->{$method}($param, $default);
         } else {
             $response = array();
             foreach ($param as $p) {


### PR DESCRIPTION
As the [RFC6749](http://tools.ietf.org/html/rfc6749) states in its [2.3.1](http://tools.ietf.org/html/rfc6749#section-2.3.1) section:

>  Clients in possession of a client password **MAY** use the HTTP Basic authentication scheme as defined in RFC2617 to authenticate with the authorization server
> 
> The authorization server **MUST** support the HTTP Basic authentication scheme for authenticating clients that were issued a client password.

I've added this usecase in the AuthServer::getParam() method.
