### PR TITLE
Fixed bearer token retrieval in conformity with RFC

### DIFF
--- a/src/OAuth2/ResourceServer.php
+++ b/src/OAuth2/ResourceServer.php
@@ -215,7 +215,7 @@ class ResourceServer
     protected function determineAccessToken()
     {
         if ($header = $this->getRequest()->header('Authorization')) {
-            $access_token = base64_decode(trim(str_replace('Bearer', '', $header)));
+            $access_token = trim(str_replace('Bearer', '', $header));
         } else {
             $method = $this->getRequest()->server('REQUEST_METHOD');
             $access_token = $this->getRequest()->{$method}($this->tokenKey);


### PR DESCRIPTION
I'm pretty sure the base64 decoding in the ResourceServer::determineAccessToken() method is a mistake.

According to the [7.1](http://tools.ietf.org/html/rfc6749#section-7.1) section of the [RFC6749](http://tools.ietf.org/html/rfc6749):

> The "bearer" token type defined in [RFC6750] is utilized by simply including the access token string in the request:
>      GET /resource/1 HTTP/1.1
>      Host: example.com
>      Authorization: Bearer mF_9.B5f-4.1JqM
