### PR TITLE
Fixed two problems in access token check 

### DIFF
--- a/src/League/OAuth2/Server/Resource.php
+++ b/src/League/OAuth2/Server/Resource.php
@@ -243,7 +243,22 @@ class Resource
     protected function determineAccessToken()
     {
         if ($header = $this->getRequest()->header('Authorization')) {
-            $accessToken = trim(str_replace('Bearer', '', $header));
+            // Check for special case, because cURL sometimes does an
+            // internal second request and doubles the authorization header,
+            // which always resulted in an error.
+            //
+            // 1st request: Authorization: Bearer XXX
+            // 2nd request: Authorization: Bearer XXX, Bearer XXX
+            if (strpos($header, ',') !== false) {
+                $accessTokens = array();
+                foreach (explode(',', $header) as $header_part) {
+                    $accessTokens[] = trim(preg_replace('/^(?:\s+)?Bearer\s+/', '', $header_part));
+                }
+                // take always the first one
+                $accessToken = $accessTokens[0];
+            } else {
+                $accessToken = trim(preg_replace('/^(?:\s+)?Bearer\s+/', '', $header));
+            }
         } else {
             $method = $this->getRequest()->server('REQUEST_METHOD');
             $accessToken = $this->getRequest()->{$method}($this->tokenKey);


### PR DESCRIPTION
1) The method returned the wrong result in case when the access token itself contained the string "Bearer".

2) When using cURL, the request is sometimes send twice (in my case when the first request returned a 404 error), and the Authorization header of the second request is doubled, so that you get a "Authorization: Bearer XXX, Bearer XXX". This case is checked now. (BTW: Tested with the current PHP version 5.4.15 on Windows.)
