### PR TITLE
Conditional isValid flag to check for Authorization header only. Fixes #57

### DIFF
--- a/src/League/OAuth2/Server/Resource.php
+++ b/src/League/OAuth2/Server/Resource.php
@@ -173,12 +173,13 @@ class Resource
     /**
      * Checks if the access token is valid or not.
      *
+     * @param $headersOnly Limit Access Token to Authorization header only
      * @throws Exception\InvalidAccessTokenException Thrown if the presented access token is not valid
      * @return bool
      */
-    public function isValid()
+    public function isValid($headersOnly = false)
     {
-        $accessToken = $this->determineAccessToken();
+        $accessToken = $this->determineAccessToken($headersOnly);
 
         $result = $this->storages['session']->validateAccessToken($accessToken);
 
@@ -237,10 +238,11 @@ class Resource
     /**
      * Reads in the access token from the headers.
      *
+     * @param $headersOnly Limit Access Token to Authorization header only
      * @throws Exception\MissingAccessTokenException  Thrown if there is no access token presented
      * @return string
      */
-    protected function determineAccessToken()
+    protected function determineAccessToken($headersOnly = false)
     {
         if ($header = $this->getRequest()->header('Authorization')) {
             // Check for special case, because cURL sometimes does an
@@ -256,7 +258,7 @@ class Resource
                 $accessToken = trim(preg_replace('/^(?:\s+)?Bearer\s/', '', $header));
             }
             $accessToken = ($accessToken === 'Bearer') ? '' : $accessToken;
-        } else {
+        } elseif ($headersOnly === false) {
             $method = $this->getRequest()->server('REQUEST_METHOD');
             $accessToken = $this->getRequest()->{$method}($this->tokenKey);
         }


### PR DESCRIPTION
By passing in a conditional flag referring to Authorization Headers only the library will still respect RFC6749 Section 7 and RFC6750 Section 2.
