### PR TITLE
Make determineAccessToken() public

### DIFF
--- a/src/League/OAuth2/Server/Resource.php
+++ b/src/League/OAuth2/Server/Resource.php
@@ -242,7 +242,7 @@ class Resource
      * @throws Exception\MissingAccessTokenException  Thrown if there is no access token presented
      * @return string
      */
-    protected function determineAccessToken($headersOnly = false)
+    public function determineAccessToken($headersOnly = false)
     {
         if ($header = $this->getRequest()->header('Authorization')) {
             // Check for special case, because cURL sometimes does an


### PR DESCRIPTION
Make determineAccessToken() public in order to check if an access token was sent before checking its validity.
