### PR TITLE
Fix to docblocks

### DIFF
--- a/src/League/OAuth2/Server/Storage/SessionInterface.php
+++ b/src/League/OAuth2/Server/Storage/SessionInterface.php
@@ -315,7 +315,8 @@ interface SessionInterface
      * <code>
      * array (
      *     array(
-     *         'key'    =>  (string),
+     *         'id'     =>  (int),
+     *         'scope'  =>  (string),
      *         'name'   =>  (string),
      *         'description'    =>  (string)
      *     ),


### PR DESCRIPTION
League\OAuth2\Server\Storage\SessionInterface::associateAccessToken() should return an integer that represents the access token ID, not void.
