### PR TITLE
Fix fluent client argument default

### DIFF
--- a/src/League/OAuth2/Server/Storage/Fluent/Client.php
+++ b/src/League/OAuth2/Server/Storage/Fluent/Client.php
@@ -7,7 +7,7 @@ use \League\OAuth2\Server\Storage\ClientInterface;
 
 class Client implements ClientInterface {
 
-    public function getClient($clientId, $clientSecret = null, $redirectUri = null, $grantType)
+    public function getClient($clientId, $clientSecret = null, $redirectUri = null, $grantType = null)
     {
         if ( ! is_null($redirectUri) && is_null($clientSecret)) {
             $result = DB::table('oauth_clients')


### PR DESCRIPTION
Fixed a small error where the Fluent Client class requires the $grantType to have a default of null
