### PR TITLE
Normalize headers

### DIFF
--- a/src/League/OAuth2/Server/Util/Request.php
+++ b/src/League/OAuth2/Server/Util/Request.php
@@ -39,6 +39,8 @@ class Request implements RequestInterface
 
         if (empty($headers)) {
             $this->headers = $this->readHeaders();
+        } else {
+            $this->headers = $this->normalizeHeaders($headers);
         }
     }
 
@@ -88,7 +90,7 @@ class Request implements RequestInterface
             }
         }
 
-        return $headers;
+        return $this->normalizeHeaders($headers);
    }
 
     protected function getPropertyValue($property, $index = null, $default = null)
@@ -105,5 +107,40 @@ class Request implements RequestInterface
         }
 
         return $this->{$property}[$index];
+    }
+
+    /**
+     * Takes all of the headers and normalizes them in a canonical form.
+     *
+     * @param  array  $headers The request headers.
+     * @return array           An arry of headers with the header name normalized
+     */
+    protected function normalizeHeaders(array $headers)
+    {
+        $normalized = array();
+        foreach ($headers as $key => $value) {
+            $normalized[$this->normalizeKey($key)] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Transform header name into canonical form
+     *
+     * Taken from the Slim codebase...
+     *
+     * @param  string $key
+     * @return string
+     */
+    protected function normalizeKey($key)
+    {
+        $key = strtolower($key);
+        $key = str_replace(array('-', '_'), ' ', $key);
+        $key = preg_replace('#^http #', '', $key);
+        $key = ucwords($key);
+        $key = str_replace(' ', '-', $key);
+
+        return $key;
     }
 }

--- a/tests/util/RequestTest.php
+++ b/tests/util/RequestTest.php
@@ -59,6 +59,20 @@ class Request_test extends PHPUnit_Framework_TestCase
 		$this->assertEquals(array('Host' => 'foobar.com'), $this->request->header());
 	}
 
+	function test_canonical_header()
+	{
+		$request = new League\OAuth2\Server\Util\Request(
+			array('foo' => 'bar'),
+			array('foo' => 'bar'),
+			array('foo' => 'bar'),
+			array('foo' => 'bar'),
+			array('HTTP_HOST' => 'foobar.com'),
+			array('authorization' => 'Bearer ajdfkljadslfjasdlkj')
+		);
+
+		$this->assertEquals('Bearer ajdfkljadslfjasdlkj', $request->header('Authorization'));
+	}
+
 	/**
 	 * @expectedException InvalidArgumentException
 	 */


### PR DESCRIPTION
Recreating Pull request on develop branch...

---

After testing with Frisby.js I was noticing that my resource server grant was failing because node passes in the authorization header all lowercase and this library is looking for Authorization.

I did a little [spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) reading and header names are case insensitive. I took some code from Slim to make sure that request headers are in a Ucfirst-With-Dashes format.
