### PR TITLE
Request interface cleanup

### DIFF
--- a/src/League/OAuth2/Server/Util/RequestInterface.php
+++ b/src/League/OAuth2/Server/Util/RequestInterface.php
@@ -14,10 +14,6 @@ namespace League\OAuth2\Server\Util;
 interface RequestInterface
 {
 
-    public static function buildFromGlobals();
-
-    public function __construct(array $get = array(), array $post = array(), array $cookies = array(), array $files = array(), array $server = array(), $headers = array());
-
     public function get($index = null);
 
     public function post($index = null);


### PR DESCRIPTION
Removing the constructor and buildFromGlobals from the RequestInterface so the library can play a lot nicer with Request classes from other libraries and frameworks.

This will fix issue #88.
