### PR TITLE
Request implementation doesn't consider that HTTP headers are case-insensitive

### DIFF
--- a/src/League/OAuth2/Server/Util/Request.php
+++ b/src/League/OAuth2/Server/Util/Request.php
@@ -77,7 +77,6 @@ class Request implements RequestInterface
         if (function_exists('getallheaders')) {
             // @codeCoverageIgnoreStart
             $headers = getallheaders();
-            $headers = array_change_key_case($headers);
         } else {
             // @codeCoverageIgnoreEnd
             $headers = array();
@@ -101,10 +100,13 @@ class Request implements RequestInterface
             return $this->{$property};
         }
 
-        if ( ! array_key_exists(strtolower($index), $this->{$property})) {
+        $array_lowcase=array_change_key_case($this->{$property});
+        $index_lowcase=strtolower($index);
+
+        if ( ! array_key_exists($index_lowcase, $array_lowcase)) {
             return $default;
         }
 
-        return $this->{$property}[strtolower($index)];
+        return $array_lowcase[$index_lowcase];
     }
 }


### PR DESCRIPTION
According to RFC2616, HTTP headers are case-insensitive.

For example, when using Google OAuth2 Playground to test my server, it fails because Google OAuth2 Playground send the "Authorization" header as "authorization".
