### PR TITLE
Fixed typo of session_id instead of id on Resource Server

### DIFF
--- a/src/League/OAuth2/Server/Resource.php
+++ b/src/League/OAuth2/Server/Resource.php
@@ -190,7 +190,7 @@ class Resource
         }
 
         $this->accessToken = $accessToken;
-        $this->sessionId = $result['session_id'];
+        $this->sessionId = $result['id'];
         $this->clientId = $result['client_id'];
         $this->ownerType = $result['owner_type'];
         $this->ownerId = $result['owner_id'];

--- a/tests/resource/ResourceServerTest.php
+++ b/tests/resource/ResourceServerTest.php
@@ -189,7 +189,7 @@ class Resource_Server_test extends PHPUnit_Framework_TestCase
     public function test_isValid_valid()
     {
     	$this->session->shouldReceive('validateAccessToken')->andReturn(array(
-    		'session_id'  =>	1,
+    		'id'  	      =>	1,
     		'owner_type'  =>	'user',
     		'owner_id'    =>	123,
             'client_id' =>  'testapp'


### PR DESCRIPTION
There was a typo: the real "column name" is **id** instead of **session_id**
