### PR TITLE
Fixing Bearer case for consistency

### DIFF
--- a/src/League/OAuth2/Server/Grant/RefreshToken.php
+++ b/src/League/OAuth2/Server/Grant/RefreshToken.php
@@ -192,7 +192,7 @@ class RefreshToken implements GrantTypeInterface {
 
         $response = array(
             'access_token'  =>  $accessToken,
-            'token_type'    =>  'bearer',
+            'token_type'    =>  'Bearer',
             'expires'       =>  $accessTokenExpires,
             'expires_in'    =>  $accessTokenExpiresIn
         );


### PR DESCRIPTION
Case-sensitive issue.
Results in differences to token_type responses between issuing a token and refreshing one.
