### PR TITLE
Use utf8_unicode_ci as default collation

### DIFF
--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -5,7 +5,7 @@ CREATE TABLE `oauth_clients` (
   `auto_approve` TINYINT(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `u_oacl_clse_clid` (`secret`,`id`)
-) ENGINE=INNODB DEFAULT CHARSET=utf8;
+) ENGINE=INNODB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_client_endpoints` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -14,7 +14,7 @@ CREATE TABLE `oauth_client_endpoints` (
   PRIMARY KEY (`id`),
   KEY `i_oaclen_clid` (`client_id`),
   CONSTRAINT `f_oaclen_clid` FOREIGN KEY (`client_id`) REFERENCES `oauth_clients` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_sessions` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -24,7 +24,7 @@ CREATE TABLE `oauth_sessions` (
   PRIMARY KEY (`id`),
   KEY `i_uase_clid_owty_owid` (`client_id`,`owner_type`,`owner_id`),
   CONSTRAINT `f_oase_clid` FOREIGN KEY (`client_id`) REFERENCES `oauth_clients` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_access_tokens` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -35,7 +35,7 @@ CREATE TABLE `oauth_session_access_tokens` (
   UNIQUE KEY `u_oaseacto_acto_seid` (`access_token`,`session_id`),
   KEY `f_oaseto_seid` (`session_id`),
   CONSTRAINT `f_oaseto_seid` FOREIGN KEY (`session_id`) REFERENCES `oauth_sessions` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_authcodes` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
@@ -45,14 +45,14 @@ CREATE TABLE `oauth_session_authcodes` (
   PRIMARY KEY (`id`),
   KEY `session_id` (`session_id`),
   CONSTRAINT `oauth_session_authcodes_ibfk_1` FOREIGN KEY (`session_id`) REFERENCES `oauth_sessions` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_redirects` (
   `session_id` int(10) unsigned NOT NULL,
   `redirect_uri` varchar(255) NOT NULL,
   PRIMARY KEY (`session_id`),
   CONSTRAINT `f_oasere_seid` FOREIGN KEY (`session_id`) REFERENCES `oauth_sessions` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_refresh_tokens` (
   `session_access_token_id` int(10) unsigned NOT NULL,
@@ -63,7 +63,7 @@ CREATE TABLE `oauth_session_refresh_tokens` (
   KEY `client_id` (`client_id`),
   CONSTRAINT `oauth_session_refresh_tokens_ibfk_1` FOREIGN KEY (`client_id`) REFERENCES `oauth_clients` (`id`) ON DELETE CASCADE,
   CONSTRAINT `f_oasetore_setoid` FOREIGN KEY (`session_access_token_id`) REFERENCES `oauth_session_access_tokens` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_scopes` (
   `id` smallint(5) unsigned NOT NULL AUTO_INCREMENT,
@@ -72,7 +72,7 @@ CREATE TABLE `oauth_scopes` (
   `description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `u_oasc_sc` (`scope`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_token_scopes` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -83,7 +83,7 @@ CREATE TABLE `oauth_session_token_scopes` (
   KEY `f_oasetosc_scid` (`scope_id`),
   CONSTRAINT `f_oasetosc_scid` FOREIGN KEY (`scope_id`) REFERENCES `oauth_scopes` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `f_oasetosc_setoid` FOREIGN KEY (`session_access_token_id`) REFERENCES `oauth_session_access_tokens` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE `oauth_session_authcode_scopes` (
   `oauth_session_authcode_id` int(10) unsigned NOT NULL,
@@ -92,4 +92,4 @@ CREATE TABLE `oauth_session_authcode_scopes` (
   KEY `scope_id` (`scope_id`),
   CONSTRAINT `oauth_session_authcode_scopes_ibfk_2` FOREIGN KEY (`scope_id`) REFERENCES `oauth_scopes` (`id`) ON DELETE CASCADE,
   CONSTRAINT `oauth_session_authcode_scopes_ibfk_1` FOREIGN KEY (`oauth_session_authcode_id`) REFERENCES `oauth_session_authcodes` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;


### PR DESCRIPTION
I think the default table collation should be set to `utf8_unicode_ci` - it handles properly a much wider array of characters at a minuscule cost to performance.

An import with a default mysql setup will create tables with `utf8_general_ci` collation.

> utf8_general_ci is a legacy collation that does not support expansions, contractions, or ignorable characters. It can make only one-to-one comparisons between characters.
> -- http://dev.mysql.com/doc/refman/5.0/en/charset-unicode-sets.html
