### PR TITLE
Send HTTP 401 for invalid_token, rather than insufficient_scope

### DIFF
--- a/src/League/OAuth2/Server/Resource.php
+++ b/src/League/OAuth2/Server/Resource.php
@@ -163,7 +163,7 @@ class Resource
         // include the "WWW-Authenticate" response header field
         // matching the authentication scheme used by the client.
         // @codeCoverageIgnoreStart
-        if ($error === 'insufficient_scope') {
+        if ($error === 'invalid_token') {
             $authScheme = null;
             $request = new Request();
             if ($request->server('PHP_AUTH_USER') !== null) {

--- a/tests/resource/ResourceServerTest.php
+++ b/tests/resource/ResourceServerTest.php
@@ -38,8 +38,8 @@ class Resource_Server_test extends PHPUnit_Framework_TestCase
     public function test_getExceptionHttpHeaders()
     {
         $this->assertEquals(array('HTTP/1.1 400 Bad Request'), League\OAuth2\Server\Resource::getExceptionHttpHeaders('invalid_request'));
-        $this->assertEquals(array('HTTP/1.1 401 Unauthorized'), League\OAuth2\Server\Resource::getExceptionHttpHeaders('invalid_token'));
-        $this->assertContains('HTTP/1.1 403 Forbidden', League\OAuth2\Server\Resource::getExceptionHttpHeaders('insufficient_scope'));
+        $this->assertContains('HTTP/1.1 401 Unauthorized', League\OAuth2\Server\Resource::getExceptionHttpHeaders('invalid_token'));
+        $this->assertEquals(array('HTTP/1.1 403 Forbidden'), League\OAuth2\Server\Resource::getExceptionHttpHeaders('insufficient_scope'));
     }
 
     public function test_setRequest()


### PR DESCRIPTION
Incorrectly read [the spec](http://tools.ietf.org/html/rfc6750#section-3.1) or possibly copy/paste fail, but the new resource server error handling should be using 403 for scope and 401 for token.
