### PR TITLE
Associate the $client with $session.

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -215,6 +215,8 @@ class AuthCodeGrant extends AbstractGrant
         }
 
         $session = $code->getSession();
+        $session->associateClient($client);
+
         $authCodeScopes = $code->getScopes();
 
         // Generate the access token


### PR DESCRIPTION
Copied from #239:

This could be an implementation issue…

The `AuthCodeGrant::completeFlow()` method:
- loads a `ClientEntity` on [Line 189](https://github.com/thephpleague/oauth2-server/blob/develop/src/Grant/AuthCodeGrant.php#L217) 
- loads a `SessionEntity` on [Line 217](https://github.com/thephpleague/oauth2-server/blob/develop/src/Grant/AuthCodeGrant.php#L217)
- saves the `SessionEntity` on [Line 249](https://github.com/thephpleague/oauth2-server/blob/develop/src/Grant/AuthCodeGrant.php#L249)

However the `ClientEntity` is never explicitly associated with the `Session` via `$session->associateClient($client);`.

Is this deliberate? If so the only place I can see that the `Session` can associate the `Client` is in the `SessionStorage::getByAuthCode()`. This doesn't seem to make much sense given the client is already loaded in the `AuthCodeGrant::completeFlow()` method?
