### PR TITLE
Update ResourceServer.php

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -77,11 +77,11 @@ class ResourceServer extends AbstractServer
 
     /**
      * Gets the access token
-     * @return string
+     * @return \League\OAuth2\Server\Entity\AccessTokenEntity
      */
     public function getAccessToken()
     {
-        return $this->accessToken->getId();
+        return $this->accessToken;
     }
 
     /**


### PR DESCRIPTION
The getAccessToken method should return an AccessTokenEntity object instead of a string in order to allow users to access the session associated with the token, 
