### PR TITLE
Fix: access_token doesn't read grant_type parameter

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -230,7 +230,7 @@ class AuthorizationServer extends AbstractServer
      */
     public function issueAccessToken()
     {
-        $grantType = $this->getRequest()->request->get('grant_type');
+        $grantType = $this->getRequest()->get('grant_type');
         if (is_null($grantType)) {
             throw new Exception\InvalidRequestException('grant_type');
         }


### PR DESCRIPTION
The access_token endpoint in the example doesn't parse the grant_type parameter (or any other for that matter).

After applying this patch it will work again.
