### PR TITLE
Update Adapter to AbstractStorage in examples/relational

### DIFF
--- a/examples/relational/Storage/AccessTokenStorage.php
+++ b/examples/relational/Storage/AccessTokenStorage.php
@@ -6,10 +6,10 @@ use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\Entity\AbstractTokenEntity;
 use League\OAuth2\Server\Entity\AccessTokenEntity;
 use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\AccessTokenInterface;
-use League\OAuth2\Server\Storage\Adapter;
 
-class AccessTokenStorage extends Adapter implements AccessTokenInterface
+class AccessTokenStorage extends AbstractStorage implements AccessTokenInterface
 {
     /**
      * {@inheritdoc}

--- a/examples/relational/Storage/AuthCodeStorage.php
+++ b/examples/relational/Storage/AuthCodeStorage.php
@@ -5,10 +5,10 @@ namespace RelationalExample\Storage;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\Entity\AuthCodeEntity;
 use League\OAuth2\Server\Entity\ScopeEntity;
-use League\OAuth2\Server\Storage\Adapter;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\AuthCodeInterface;
 
-class AuthCodeStorage extends Adapter implements AuthCodeInterface
+class AuthCodeStorage extends AbstractStorage implements AuthCodeInterface
 {
     /**
      * {@inheritdoc}

--- a/examples/relational/Storage/ClientStorage.php
+++ b/examples/relational/Storage/ClientStorage.php
@@ -5,10 +5,10 @@ namespace RelationalExample\Storage;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\Entity\ClientEntity;
 use League\OAuth2\Server\Entity\SessionEntity;
-use League\OAuth2\Server\Storage\Adapter;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\ClientInterface;
 
-class ClientStorage extends Adapter implements ClientInterface
+class ClientStorage extends AbstractStorage implements ClientInterface
 {
     /**
      * {@inheritdoc}

--- a/examples/relational/Storage/RefreshTokenStorage.php
+++ b/examples/relational/Storage/RefreshTokenStorage.php
@@ -4,10 +4,10 @@ namespace RelationalExample\Storage;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\Entity\RefreshTokenEntity;
-use League\OAuth2\Server\Storage\Adapter;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\RefreshTokenInterface;
 
-class RefreshTokenStorage extends Adapter implements RefreshTokenInterface
+class RefreshTokenStorage extends AbstractStorage implements RefreshTokenInterface
 {
     /**
      * {@inheritdoc}

--- a/examples/relational/Storage/ScopeStorage.php
+++ b/examples/relational/Storage/ScopeStorage.php
@@ -4,10 +4,10 @@ namespace RelationalExample\Storage;
 
 use Illuminate\Database\Capsule\Manager as Capsule;
 use League\OAuth2\Server\Entity\ScopeEntity;
-use League\OAuth2\Server\Storage\Adapter;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\ScopeInterface;
 
-class ScopeStorage extends Adapter implements ScopeInterface
+class ScopeStorage extends AbstractStorage implements ScopeInterface
 {
     /**
      * {@inheritdoc}

--- a/examples/relational/Storage/SessionStorage.php
+++ b/examples/relational/Storage/SessionStorage.php
@@ -7,10 +7,10 @@ use League\OAuth2\Server\Entity\AccessTokenEntity;
 use League\OAuth2\Server\Entity\AuthCodeEntity;
 use League\OAuth2\Server\Entity\ScopeEntity;
 use League\OAuth2\Server\Entity\SessionEntity;
-use League\OAuth2\Server\Storage\Adapter;
+use League\OAuth2\Server\Storage\AbstractStorage;
 use League\OAuth2\Server\Storage\SessionInterface;
 
-class SessionStorage extends Adapter implements SessionInterface
+class SessionStorage extends AbstractStorage implements SessionInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Not too sure if the examples are staying or not, however, where I referenced the examples dir for usage, thought would be useful to update to the new AbstractStorage class
