### PR TITLE
Prevent duplicate session in auth code grant

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -260,7 +260,6 @@ class AuthCodeGrant extends AbstractGrant
         $code->expire();
 
         // Save all the things
-        $session->save();
         $accessToken->setSession($session);
         $accessToken->save();
 


### PR DESCRIPTION
The session already exists in the database, so we don't need to save it again. Doing so results in the session used for the auth code hanging around in the database with nothing associated to it, while the access token is associated to a new session caused by the `save()` method creating a duplicate. Fixes #266.
