### PR TITLE
Add new Implicit Grant type

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * OAuth 2.0 Implicit code grant
+ *
+ * @package     league/oauth2-server
+ * @author      David Walker <dwalker@symplicity.com>
+ * @copyright   Copyright (c) David Walker
+ * @license     http://mit-license.org/
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Grant;
+
+use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Event;
+use League\OAuth2\Server\Exception;
+use League\OAuth2\Server\Util\SecureKey;
+
+/**
+ * Implicit grant class
+ */
+class ImplicitGrant extends AbstractGrant
+{
+    /**
+     * Grant identifier
+     *
+     * @var string
+     */
+    protected $identifier = 'implicit';
+
+    /**
+     * Response type
+     *
+     * @var string
+     */
+    protected $responseType = 'token';
+
+    /**
+     * AuthServer instance
+     *
+     * @var \League\OAuth2\Server\AuthorizationServer
+     */
+    protected $server = null;
+
+    /**
+     * Access token expires in override
+     *
+     * @var int
+     */
+    protected $accessTokenTTL = null;
+
+    /**
+     * Check authorize parameters
+     *
+     * @return array Authorize request parameters
+     *
+     * @throws
+     */
+    public function checkAuthorizeParams()
+    {
+        // Get required params
+        $clientId = $this->server->getRequest()->query->get('client_id', null);
+        if (is_null($clientId)) {
+            throw new Exception\InvalidRequestException('client_id');
+        }
+
+        $redirectUri = $this->server->getRequest()->query->get('redirect_uri', null);
+        if (is_null($redirectUri)) {
+            throw new Exception\InvalidRequestException('redirect_uri');
+        }
+
+        // Validate client ID and redirect URI
+        $client = $this->server->getClientStorage()->get(
+            $clientId,
+            null,
+            $redirectUri,
+            $this->getIdentifier()
+        );
+
+        if (($client instanceof ClientEntity) === false) {
+            $this->server->getEventEmitter()->emit(new Event\ClientAuthenticationFailedEvent($this->server->getRequest()));
+            throw new Exception\InvalidClientException();
+        }
+
+        $state = $this->server->getRequest()->query->get('state', null);
+        if ($this->server->stateParamRequired() === true && is_null($state)) {
+            throw new Exception\InvalidRequestException('state', $redirectUri);
+        }
+
+        $responseType = $this->server->getRequest()->query->get('response_type', null);
+        if (is_null($responseType)) {
+            throw new Exception\InvalidRequestException('response_type', $redirectUri);
+        }
+
+        // Ensure response type is one that is recognised
+        if (!in_array($responseType, $this->server->getResponseTypes())) {
+            throw new Exception\UnsupportedResponseTypeException($responseType, $redirectUri);
+        }
+
+        // Validate any scopes that are in the request
+        $scopeParam = $this->server->getRequest()->query->get('scope', '');
+        $scopes = $this->validateScopes($scopeParam, $client, $redirectUri);
+
+        return [
+            'client'        => $client,
+            'redirect_uri'  => $redirectUri,
+            'state'         => $state,
+            'response_type' => $responseType,
+            'scopes'        => $scopes
+        ];
+    }
+
+    /**
+     * Complete the flow. - invalid for this case
+     *
+     * @return null
+     */
+    public function completeFlow()
+    {
+    }
+
+    /**
+     * Generate the redirect URI for the Implicit grant
+     *
+     * @param array $params
+     *
+     * @return null
+     */
+    public function getRedirectUri($params)
+    {
+        // Get required params
+        if (!isset($params['client']) || ($params['client'] instanceof ClientEntity) === false) {
+            $this->server->getEventEmitter()->emit(new Event\ClientAuthenticationFailedEvent($this->server->getRequest()));
+            throw new Exception\InvalidClientException();
+        }
+        $client = $params['client'];
+
+        if (!isset($params['redirect_uri']) || is_null($params['redirect_uri'])) {
+            throw new Exception\InvalidRequestException('redirect_uri');
+        }
+        $redirectUri = $params['redirect_uri'];
+
+        // Create a new session
+        $session = new SessionEntity($this->server);
+        $session->setOwner('implicit', $client->getId());
+        $session->associateClient($client);
+
+        // Generate the access token
+        $accessToken = new AccessTokenEntity($this->server);
+        $accessToken->setId(SecureKey::generate());
+        $accessToken->setExpireTime($this->getAccessTokenTTL() + time());
+
+        if (isset($params['scopes'])) {
+            foreach ($params['scopes'] as $implicitScope) {
+                $session->associateScope($implicitScope);
+            }
+
+            foreach ($session->getScopes() as $scope) {
+                $accessToken->associateScope($scope);
+            }
+        }
+
+        $this->server->getTokenType()->setSession($session);
+        $this->server->getTokenType()->setParam('access_token', $accessToken->getId());
+        $this->server->getTokenType()->setParam('expires_in', $this->getAccessTokenTTL());
+
+        // Save all the things
+        $session->save();
+        $accessToken->setSession($session);
+        $accessToken->save();
+
+        $token = $this->server->getTokenType()->generateResponse();
+        if (isset($params['state']) && $params['state']) {
+            $token['state'] = $params['state'];
+        }
+
+        return $params['redirect_uri'] . '#' . join('&', array_map(function($v, $k){return $k.'='.$v;}, $token, array_keys($token)));
+    }
+}

--- a/tests/unit/Grant/ImplicitGrantTest.php
+++ b/tests/unit/Grant/ImplicitGrantTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace LeagueTests\Grant;
+
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\ClientEntity;
+use League\OAuth2\Server\Entity\ScopeEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
+use League\OAuth2\Server\Grant\ImplicitGrant;
+use Mockery as M;
+
+class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCheckAuthorizeParamsMissingClientId()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+
+        $_GET = [];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthorizeParamsMissingRedirectUri()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+
+        $_GET = [
+            'client_id' =>  'testapp',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParamsInvalidClient()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidClientException');
+
+        $_GET = [
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+            'response_type' =>  'token',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(null);
+        $server->setClientStorage($clientStorage);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParamsMissingStateParam()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+
+        $_GET = [
+            'client_id' =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+        $server->setClientStorage($clientStorage);
+
+        $server->requireStateParam(true);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParamsMissingResponseType()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+
+        $_GET = [
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+        $server->setClientStorage($clientStorage);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParamsInvalidResponseType()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\UnsupportedResponseTypeException');
+
+        $_GET = [
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+            'response_type' =>  'foobar',
+        ];
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+        $server->setClientStorage($clientStorage);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParamsInvalidScope()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidScopeException');
+
+        $_GET = [
+            'response_type' =>  'token',
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+            'scope'         =>  'foo',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+
+        $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
+        $sessionStorage->shouldReceive('setServer');
+        $sessionStorage->shouldReceive('create');
+        $sessionStorage->shouldReceive('getScopes')->andReturn([]);
+
+        $accessTokenStorage = M::mock('League\OAuth2\Server\Storage\AccessTokenInterface');
+        $accessTokenStorage->shouldReceive('setServer');
+        $accessTokenStorage->shouldReceive('create');
+        $accessTokenStorage->shouldReceive('getScopes')->andReturn([]);
+
+        $scopeStorage = M::mock('League\OAuth2\Server\Storage\ScopeInterface');
+        $scopeStorage->shouldReceive('setServer');
+        $scopeStorage->shouldReceive('get')->andReturn(null);
+
+        $server->setClientStorage($clientStorage);
+        $server->setScopeStorage($scopeStorage);
+        $server->setSessionStorage($sessionStorage);
+        $server->setAccessTokenStorage($accessTokenStorage);
+
+        $grant->checkAuthorizeParams();
+    }
+
+    public function testCheckAuthoriseParams()
+    {
+        $_GET = [
+            'response_type' =>  'token',
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+            'scope'         =>  'foo',
+            ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+
+        $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
+        $sessionStorage->shouldReceive('setServer');
+        $sessionStorage->shouldReceive('create')->andreturn(123);
+        $sessionStorage->shouldReceive('getScopes')->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $sessionStorage->shouldReceive('associateScope');
+
+        $accessTokenStorage = M::mock('League\OAuth2\Server\Storage\AccessTokenInterface');
+        $accessTokenStorage->shouldReceive('setServer');
+        $accessTokenStorage->shouldReceive('create');
+        $accessTokenStorage->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $accessTokenStorage->shouldReceive('associateScope');
+
+        $scopeStorage = M::mock('League\OAuth2\Server\Storage\ScopeInterface');
+        $scopeStorage->shouldReceive('setServer');
+        $scopeStorage->shouldReceive('get')->andReturn(
+            (new ScopeEntity($server))->hydrate(['id' => 'foo'])
+        );
+
+        $server->setClientStorage($clientStorage);
+        $server->setScopeStorage($scopeStorage);
+        $server->setSessionStorage($sessionStorage);
+        $server->setAccessTokenStorage($accessTokenStorage);
+
+        $result = $grant->checkAuthorizeParams();
+
+        $this->assertTrue($result['client'] instanceof ClientEntity);
+        $this->assertTrue($result['redirect_uri'] === $_GET['redirect_uri']);
+        $this->assertTrue($result['state'] === null);
+        $this->assertTrue($result['response_type'] === 'token');
+        $this->assertTrue($result['scopes']['foo'] instanceof ScopeEntity);
+    }
+
+    public function testGetRedirectURIMissingClient()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidClientException');
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $params = [
+            'client' => null,
+        ];
+
+        $grant->getRedirectUri($params);
+    }
+
+    public function testGetRedirectURIMissingRedirectURI()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+        $server->setClientStorage($clientStorage);
+
+        $params = [
+            'client' => $clientStorage->get('testapp'),
+        ];
+
+        $grant->getRedirectUri($params);
+    }
+
+    public function testGetRedirectURI()
+    {
+        $_GET = [
+            'response_type' =>  'token',
+            'client_id'     =>  'testapp',
+            'redirect_uri'  =>  'http://foo/bar',
+            'scope'         =>  'foo',
+            ];
+
+        $server = new AuthorizationServer();
+        $grant = new ImplicitGrant();
+        $server->addGrantType($grant);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+
+        $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
+        $sessionStorage->shouldReceive('setServer');
+        $sessionStorage->shouldReceive('create')->andreturn(123);
+        $sessionStorage->shouldReceive('getScopes')->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $sessionStorage->shouldReceive('associateScope');
+
+        $accessTokenStorage = M::mock('League\OAuth2\Server\Storage\AccessTokenInterface');
+        $accessTokenStorage->shouldReceive('setServer');
+        $accessTokenStorage->shouldReceive('create');
+        $accessTokenStorage->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $accessTokenStorage->shouldReceive('associateScope');
+
+        $scopeStorage = M::mock('League\OAuth2\Server\Storage\ScopeInterface');
+        $scopeStorage->shouldReceive('setServer');
+        $scopeStorage->shouldReceive('get')->andReturn(
+            (new ScopeEntity($server))->hydrate(['id' => 'foo'])
+        );
+
+        $server->setClientStorage($clientStorage);
+        $server->setScopeStorage($scopeStorage);
+        $server->setSessionStorage($sessionStorage);
+        $server->setAccessTokenStorage($accessTokenStorage);
+
+        $result = $grant->checkAuthorizeParams();
+        $uri = $grant->getRedirectUri($result);
+        $this->assertGreaterThanOrEqual(1, preg_match('#http://foo/bar\#access_token=[a-zA-Z0-9]{40}&token_type=Bearer&expires_in=3600#', $uri));
+    }
+}


### PR DESCRIPTION
Although I'm sure this has been on someones radar, and y'all may have other means of implementing: I'm at least submitting a working Implicit grant type.

It doesn't fit, perfectly cleanly into the AuthorizationServer setup in here (with the abstract method).  Since we're going to be issuing the access_token when we authorize the request, we're getting a POST from the auth form.  So we can't use the issueAccessToken(), as we don't have a _GET nor do we have a grant_type.

So to achieve this, here, I just ignore the completeFlow, and the application, when needing the redirect URI with the access_token will call ImplicitGrant::getRedirectUri($AuthParams) [auth params from checkAuthorizeParams].  This will get the redirect back to the requesting Application.
