### PR TITLE
Remove side-effects in hash_equals()

### DIFF
--- a/src/TokenType/MAC.php
+++ b/src/TokenType/MAC.php
@@ -128,22 +128,18 @@ class MAC extends AbstractTokenType implements TokenTypeInterface
      */
     private function hash_equals($knownString, $userString)
     {
-        if (!function_exists('hash_equals')) {
-            function hash_equals($knownString, $userString)
-            {
-                if (strlen($knownString) !== strlen($userString)) {
-                    return false;
-                }
-                $len = strlen($knownString);
-                $result = 0;
-                for ($i = 0; $i < $len; $i++) {
-                    $result |= (ord($knownString[$i]) ^ ord($userString[$i]));
-                }
-                // They are only identical strings if $result is exactly 0...
-                return 0 === $result;
-            }
+        if (function_exists('\hash_equals')) {
+            return \hash_equals($knownString, $userString);
         }
-
-        return hash_equals($knownString, $userString);
+        if (strlen($knownString) !== strlen($userString)) {
+            return false;
+        }
+        $len = strlen($knownString);
+        $result = 0;
+        for ($i = 0; $i < $len; $i++) {
+            $result |= (ord($knownString[$i]) ^ ord($userString[$i]));
+        }
+        // They are only identical strings if $result is exactly 0...
+        return 0 === $result;
     }
 }


### PR DESCRIPTION
This is functionally identical, but without the side-effect of defining a function in the current namespace.

Also, it uses absolute function reference (`\hash_equals` instead of `hash_equals`) because if someone defined `League\OAuth2\Server\TokenType\hash_equals()` elsewhere, it would try that first.

Kudos for using `hash_equals()` in your original design for this feature. Many OAuth2 implementations neglect this nuance :)