### PR TITLE
Save the new access token into the old refresh token

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -186,6 +186,8 @@ class RefreshTokenGrant extends AbstractGrant
             $this->server->getTokenType()->setParam('refresh_token', $newRefreshToken->getId());
         } else {
             $this->server->getTokenType()->setParam('refresh_token', $oldRefreshToken->getId());
+            $oldRefreshToken->getAccessToken($newAccessToken);
+            $oldRefreshToken->save();
         }
 
         return $this->server->getTokenType()->generateResponse();

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -186,7 +186,7 @@ class RefreshTokenGrant extends AbstractGrant
             $this->server->getTokenType()->setParam('refresh_token', $newRefreshToken->getId());
         } else {
             $this->server->getTokenType()->setParam('refresh_token', $oldRefreshToken->getId());
-            $oldRefreshToken->getAccessToken($newAccessToken);
+            $oldRefreshToken->setAccessToken($newAccessToken);
             $oldRefreshToken->save();
         }
 


### PR DESCRIPTION
With my change for preventing RefreshTokens from being rotated, a potential problem exists with storage.

In the RefreshToken complete flow, we go ahead and expire the old Access Token.  Since the library doesn't define what expire entails one might delete the old access token from the storage.  If this is the case, then once we issue a new Access Token, we never update the Access Token the Refresh Token relates to.  So the second time requesting a new Access Token via Refresh Token, we attempt to pull the Access Token from storage, but can't (since it -may- have been deleted).

This change sets the new Access Token to the old Refresh Token, and calls save.  However, and maybe this is kinda goofy, save(), is more of a wrapper for storage::create().  So it would be up to the user to have create do updates as well. (Read: rather than an `insert into` storage containers could do a `replace into`, since refresh_token_id, is the primary key it's ok)