### PR TITLE
Small bug in ResourceServer.php

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -134,7 +134,7 @@ class ResourceServer extends AbstractServer
      */
     public function determineAccessToken($headersOnly = false)
     {
-        if ($this->getRequest()->headers->get('Authorization') !== null) {
+        if ($this->getRequest()->headers->get('Authorization')) {
             $accessToken = $this->getTokenType()->determineAccessTokenInHeader($this->getRequest());
         } elseif ($headersOnly === false) {
             $accessToken = ($this->getRequest()->server->get('REQUEST_METHOD') === 'GET')
@@ -143,7 +143,7 @@ class ResourceServer extends AbstractServer
         }
 
         if (empty($accessToken)) {
-            throw new Exception\InvalidRequestException('access token');
+            throw new Exception\InvalidRequestException($this->tokenKey);
         }
 
         return $accessToken;


### PR DESCRIPTION
1. Using 5.4.31 (Windows NT VWORK 6.2 build 9200 (Windows 8.1 Home Premium Edition) i586) - Apache 2.0 Handler - the expression "$this->getRequest()->headers->get('Authorization')" returns empty but not "null", so it fails to move to the elseif.
2. The blank space between the two works in the tokenKey confused me when I got prompted by the error message, and there is no reason to hard code that if its defined as a constant.

P.S. Thank you for an awesome library! Keep up the good work!