### PR TITLE
Develop - Added MongoDB example

### DIFF
--- a/examples/mongodb/Document/OAuthAccessToken.php
+++ b/examples/mongodb/Document/OAuthAccessToken.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthAccessToken implements AccessTokenEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 **/
+	public $id;
+    
+    /**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+	 */
+    protected $Session;
+    
+    /**
+     * @ODM\Field(name="expire_time",type="int")
+     */
+    protected $ExpireTime;
+    
+    /**
+     * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+     */
+    public $Scopes;
+    
+    public function __construct(){
+    	$this->Scopes = new ArrayCollection();
+    }
+    
+    public function getSession()
+    {
+    	if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
+    		$this->Session->__load();
+    	}
+    	return $this->Session;
+    }
+    
+    public function hasScope($scope){
+    	return $this->Scopes->contains($scope);
+    }
+    
+    public function getScopes(){
+    	return $this->Scopes;
+    }
+    
+    public function setSession(SessionEntityInterface $session)
+    {
+    	$this->Session = $session;
+    
+    	return $this;
+    }
+    
+    public function setExpireTime($expireTime)
+    {
+    	$this->ExpireTime = $expireTime;
+    
+    	return $this;
+    }
+
+    public function getExpireTime()
+    {
+    	return $this->ExpireTime;
+    }
+    
+    public function isExpired()
+    {
+    	return ((time() - $this->ExpireTime) > 0);
+    }
+    
+    public function setId($id = NULL)
+    {
+    	$this->id = $id;
+    
+    	return $this;
+    }
+    
+    public function getId()
+    {
+    	return $this->id;
+    }
+    
+    public function associateScope(ScopeEntityInterface $scope)
+    {
+    	if (!$this->Scopes->contains($scope)) {
+			$this->Scopes->add($scope);
+		}
+		
+		return $this;
+    }
+	
+	public function __toString(){
+		if ($this->id === null) {
+            return '';
+        }
+
+        return $this->id;
+	}
+
+    public function expire(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->remove($this);
+		$dm->flush();
+	}
+
+    public function save(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->persist($this);
+		$dm->flush();
+	}
+}

--- a/examples/mongodb/Document/OAuthAccessToken.php
+++ b/examples/mongodb/Document/OAuthAccessToken.php
@@ -12,109 +12,109 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @ODM\Document
  */
 class OAuthAccessToken implements AccessTokenEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 **/
-	public $id;
-    
+
     /**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
-	 */
+     * @ODM\Id(strategy="NONE")
+     **/
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+     */
     protected $Session;
-    
+
     /**
      * @ODM\Field(name="expire_time",type="int")
      */
     protected $ExpireTime;
-    
+
     /**
      * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
      */
     public $Scopes;
-    
+
     public function __construct(){
-    	$this->Scopes = new ArrayCollection();
+        $this->Scopes = new ArrayCollection();
     }
-    
+
     public function getSession()
     {
-    	if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
-    		$this->Session->__load();
-    	}
-    	return $this->Session;
+        if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
+            $this->Session->__load();
+        }
+        return $this->Session;
     }
-    
+
     public function hasScope($scope){
-    	return $this->Scopes->contains($scope);
+        return $this->Scopes->contains($scope);
     }
-    
+
     public function getScopes(){
-    	return $this->Scopes;
+        return $this->Scopes;
     }
-    
+
     public function setSession(SessionEntityInterface $session)
     {
-    	$this->Session = $session;
-    
-    	return $this;
+        $this->Session = $session;
+
+        return $this;
     }
-    
+
     public function setExpireTime($expireTime)
     {
-    	$this->ExpireTime = $expireTime;
-    
-    	return $this;
+        $this->ExpireTime = $expireTime;
+
+        return $this;
     }
 
     public function getExpireTime()
     {
-    	return $this->ExpireTime;
+        return $this->ExpireTime;
     }
-    
+
     public function isExpired()
     {
-    	return ((time() - $this->ExpireTime) > 0);
+        return ((time() - $this->ExpireTime) > 0);
     }
-    
+
     public function setId($id = NULL)
     {
-    	$this->id = $id;
-    
-    	return $this;
+        $this->id = $id;
+
+        return $this;
     }
-    
+
     public function getId()
     {
-    	return $this->id;
+        return $this->id;
     }
-    
+
     public function associateScope(ScopeEntityInterface $scope)
     {
-    	if (!$this->Scopes->contains($scope)) {
-			$this->Scopes->add($scope);
-		}
-		
-		return $this;
+        if (!$this->Scopes->contains($scope)) {
+            $this->Scopes->add($scope);
+        }
+
+        return $this;
     }
-	
-	public function __toString(){
-		if ($this->id === null) {
+
+    public function __toString(){
+        if ($this->id === null) {
             return '';
         }
 
         return $this->id;
-	}
+    }
 
     public function expire(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->remove($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->remove($this);
+        $dm->flush();
+    }
 
     public function save(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->persist($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->persist($this);
+        $dm->flush();
+    }
 }

--- a/examples/mongodb/Document/OAuthAccessToken.php
+++ b/examples/mongodb/Document/OAuthAccessToken.php
@@ -15,7 +15,7 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
 
     /**
      * @ODM\Id(strategy="NONE")
-     **/
+     */
     public $id;
 
     /**
@@ -33,10 +33,16 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
      */
     public $Scopes;
 
+    /**
+     * Constructor
+     */
     public function __construct(){
         $this->Scopes = new ArrayCollection();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getSession()
     {
         if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
@@ -45,14 +51,23 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this->Session;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function hasScope($scope){
         return $this->Scopes->contains($scope);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getScopes(){
         return $this->Scopes;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setSession(SessionEntityInterface $session)
     {
         $this->Session = $session;
@@ -60,6 +75,9 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setExpireTime($expireTime)
     {
         $this->ExpireTime = $expireTime;
@@ -67,16 +85,25 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getExpireTime()
     {
         return $this->ExpireTime;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function isExpired()
     {
         return ((time() - $this->ExpireTime) > 0);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id = NULL)
     {
         $this->id = $id;
@@ -84,11 +111,17 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateScope(ScopeEntityInterface $scope)
     {
         if (!$this->Scopes->contains($scope)) {
@@ -98,6 +131,9 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function __toString(){
         if ($this->id === null) {
             return '';
@@ -106,12 +142,18 @@ class OAuthAccessToken implements AccessTokenEntityInterface {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function expire(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->remove($this);
         $dm->flush();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function save(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->persist($this);

--- a/examples/mongodb/Document/OAuthAuthCode.php
+++ b/examples/mongodb/Document/OAuthAuthCode.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\Common\Collections\ArrayCollection;
+use League\OAuth2\Server\Entity\AuthCodeInterface as AuthCodeEntityInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthAuthCode implements AuthCodeEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 **/
+	public $id;
+	
+	/**
+	 * @ODM\Field(name="expire_time",type="int")
+	 */
+	protected $ExpireTime;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+	 */
+	protected $Session;
+	
+	/**
+	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+	 */
+	protected $Scopes;
+	
+	/**
+	 * @ODM\Field(name="redirect_uri")
+	 */
+	protected $RedirectURI;
+	
+	public function __construct(){
+		$this->Scopes = new ArrayCollection();
+	}
+	
+	public function setRedirectUri($redirectUri){
+		$this->RedirectURI = $redirectUri;
+		
+		return $this;
+	}
+
+    public function getRedirectUri(){
+    	return $this->RedirectURI;
+    }
+
+    public function generateRedirectUri($state = null, $queryDelimeter = '?'){
+    	$uri = $this->getRedirectUri();
+    	$uri .= (strstr($this->getRedirectUri(), $queryDelimeter) === false) ? $queryDelimeter : '&';
+    	
+    	return $uri.http_build_query([
+    			'code'  =>  $this->getId(),
+    			'state' =>  $state,
+    	]);
+    }
+
+    public function getSession(){
+    	if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
+    		$this->Session->__load();
+    	}
+    	return $this->Session;
+    }
+
+    public function getScopes(){
+    	return $this->Scopes;
+    }
+    
+    public function setSession(SessionEntityInterface $session)
+    {
+    	$this->Session = $session;
+    
+    	return $this;
+    }
+    
+    public function setExpireTime($expireTime)
+    {
+    	$this->ExpireTime = $expireTime;
+    
+    	return $this;
+    }
+    
+    public function getExpireTime()
+    {
+    	return $this->ExpireTime;
+    }
+    
+    public function isExpired()
+    {
+    	return ((time() - $this->ExpireTime) > 0);
+    }
+    
+    public function setId($id = NULL)
+    {
+    	$this->id = $id;
+    
+    	return $this;
+    }
+    
+    public function getId()
+    {
+    	return $this->id;
+    }
+    
+    public function associateScope(ScopeEntityInterface $scope)
+    {
+    	if (!$this->Scopes->contains($scope)) {
+			$this->Scopes->add($scope);
+		}
+		
+		return $this;
+    }
+	
+	public function __toString(){
+		if ($this->id === null) {
+            return '';
+        }
+
+        return $this->id;
+	}
+
+    public function expire(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->remove($this);
+		$dm->flush();
+	}
+
+    public function save(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->persist($this);
+		$dm->flush();
+	}
+}

--- a/examples/mongodb/Document/OAuthAuthCode.php
+++ b/examples/mongodb/Document/OAuthAuthCode.php
@@ -15,7 +15,7 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
 
     /**
      * @ODM\Id(strategy="NONE")
-     **/
+     */
     public $id;
 
     /**
@@ -38,20 +38,32 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
      */
     protected $RedirectURI;
 
+    /**
+     * Constructor
+     */
     public function __construct(){
         $this->Scopes = new ArrayCollection();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setRedirectUri($redirectUri){
         $this->RedirectURI = $redirectUri;
         
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getRedirectUri(){
         return $this->RedirectURI;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function generateRedirectUri($state = null, $queryDelimeter = '?'){
         $uri = $this->getRedirectUri();
         $uri .= (strstr($this->getRedirectUri(), $queryDelimeter) === false) ? $queryDelimeter : '&';
@@ -62,6 +74,9 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
         ]);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getSession(){
         if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
             $this->Session->__load();
@@ -69,34 +84,52 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
         return $this->Session;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getScopes(){
         return $this->Scopes;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setSession(SessionEntityInterface $session)
     {
         $this->Session = $session;
 
         return $this;
     }
-    
+
+    /**
+     * {@inheritDoc}
+     */
     public function setExpireTime($expireTime)
     {
         $this->ExpireTime = $expireTime;
 
         return $this;
     }
-    
+
+    /**
+     * {@inheritDoc}
+     */
     public function getExpireTime()
     {
         return $this->ExpireTime;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function isExpired()
     {
         return ((time() - $this->ExpireTime) > 0);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id = NULL)
     {
         $this->id = $id;
@@ -104,11 +137,17 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateScope(ScopeEntityInterface $scope)
     {
         if (!$this->Scopes->contains($scope)) {
@@ -118,6 +157,9 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function __toString(){
         if ($this->id === null) {
             return '';
@@ -126,12 +168,18 @@ class OAuthAuthCode implements AuthCodeEntityInterface {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function expire(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->remove($this);
         $dm->flush();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function save(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->persist($this);

--- a/examples/mongodb/Document/OAuthAuthCode.php
+++ b/examples/mongodb/Document/OAuthAuthCode.php
@@ -12,129 +12,129 @@ use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
  * @ODM\Document
  */
 class OAuthAuthCode implements AuthCodeEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 **/
-	public $id;
-	
-	/**
-	 * @ODM\Field(name="expire_time",type="int")
-	 */
-	protected $ExpireTime;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
-	 */
-	protected $Session;
-	
-	/**
-	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
-	 */
-	protected $Scopes;
-	
-	/**
-	 * @ODM\Field(name="redirect_uri")
-	 */
-	protected $RedirectURI;
-	
-	public function __construct(){
-		$this->Scopes = new ArrayCollection();
-	}
-	
-	public function setRedirectUri($redirectUri){
-		$this->RedirectURI = $redirectUri;
-		
-		return $this;
-	}
+
+    /**
+     * @ODM\Id(strategy="NONE")
+     **/
+    public $id;
+
+    /**
+     * @ODM\Field(name="expire_time",type="int")
+     */
+    protected $ExpireTime;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+     */
+    protected $Session;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+     */
+    protected $Scopes;
+
+    /**
+     * @ODM\Field(name="redirect_uri")
+     */
+    protected $RedirectURI;
+
+    public function __construct(){
+        $this->Scopes = new ArrayCollection();
+    }
+
+    public function setRedirectUri($redirectUri){
+        $this->RedirectURI = $redirectUri;
+        
+        return $this;
+    }
 
     public function getRedirectUri(){
-    	return $this->RedirectURI;
+        return $this->RedirectURI;
     }
 
     public function generateRedirectUri($state = null, $queryDelimeter = '?'){
-    	$uri = $this->getRedirectUri();
-    	$uri .= (strstr($this->getRedirectUri(), $queryDelimeter) === false) ? $queryDelimeter : '&';
-    	
-    	return $uri.http_build_query([
-    			'code'  =>  $this->getId(),
-    			'state' =>  $state,
-    	]);
+        $uri = $this->getRedirectUri();
+        $uri .= (strstr($this->getRedirectUri(), $queryDelimeter) === false) ? $queryDelimeter : '&';
+
+        return $uri.http_build_query([
+                'code'  =>  $this->getId(),
+                'state' =>  $state,
+        ]);
     }
 
     public function getSession(){
-    	if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
-    		$this->Session->__load();
-    	}
-    	return $this->Session;
+        if(isset($this->Session->__isInitialized__) && !$this->Session->__isInitialized__) {
+            $this->Session->__load();
+        }
+        return $this->Session;
     }
 
     public function getScopes(){
-    	return $this->Scopes;
+        return $this->Scopes;
     }
-    
+
     public function setSession(SessionEntityInterface $session)
     {
-    	$this->Session = $session;
-    
-    	return $this;
+        $this->Session = $session;
+
+        return $this;
     }
     
     public function setExpireTime($expireTime)
     {
-    	$this->ExpireTime = $expireTime;
-    
-    	return $this;
+        $this->ExpireTime = $expireTime;
+
+        return $this;
     }
     
     public function getExpireTime()
     {
-    	return $this->ExpireTime;
+        return $this->ExpireTime;
     }
-    
+
     public function isExpired()
     {
-    	return ((time() - $this->ExpireTime) > 0);
+        return ((time() - $this->ExpireTime) > 0);
     }
-    
+
     public function setId($id = NULL)
     {
-    	$this->id = $id;
-    
-    	return $this;
+        $this->id = $id;
+
+        return $this;
     }
-    
+
     public function getId()
     {
-    	return $this->id;
+        return $this->id;
     }
-    
+
     public function associateScope(ScopeEntityInterface $scope)
     {
-    	if (!$this->Scopes->contains($scope)) {
-			$this->Scopes->add($scope);
-		}
-		
-		return $this;
+        if (!$this->Scopes->contains($scope)) {
+            $this->Scopes->add($scope);
+        }
+
+        return $this;
     }
-	
-	public function __toString(){
-		if ($this->id === null) {
+
+    public function __toString(){
+        if ($this->id === null) {
             return '';
         }
 
         return $this->id;
-	}
+    }
 
     public function expire(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->remove($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->remove($this);
+        $dm->flush();
+    }
 
     public function save(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->persist($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->persist($this);
+        $dm->flush();
+    }
 }

--- a/examples/mongodb/Document/OAuthClient.php
+++ b/examples/mongodb/Document/OAuthClient.php
@@ -12,7 +12,7 @@ class OAuthClient implements ClientEntityInterface {
 
     /**
      * @ODM\Id(strategy="NONE")
-     **/
+     */
     public $id;
 
     /**
@@ -30,37 +30,61 @@ class OAuthClient implements ClientEntityInterface {
      */
     protected $RedirectURI;
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId() {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id){
         $this->id = $id;
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getSecret() {
         return $this->Secret;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setSecret($secret){
         $this->Secret = $secret;
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getName() {
         return $this->Name;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setName($name){
         $this->Name = $name;
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getRedirectUri() {
         return $this->RedirectURI;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setRedirectUri($redirectUri){
         $this->RedirectURI = $redirectUri;
         return $this;

--- a/examples/mongodb/Document/OAuthClient.php
+++ b/examples/mongodb/Document/OAuthClient.php
@@ -9,60 +9,60 @@ use League\OAuth2\Server\Entity\ClientInterface as ClientEntityInterface;
  * @ODM\Document
  */
 class OAuthClient implements ClientEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 **/
-	public $id;
-    
+
+    /**
+     * @ODM\Id(strategy="NONE")
+     **/
+    public $id;
+
     /**
      * @ODM\Field(name="secret")
      */
     protected $Secret;
-    
+
     /**
      * @ODM\Field(name="name")
      */
     protected $Name;
-    
+
     /**
      * @ODM\Field(name="redirect_uri")
      */
     protected $RedirectURI;
-    
+
     public function getId() {
-    	return $this->id;
-    }
-	
-	public function setId($id){
-		$this->id = $id;
-		return $this;
-	}
-    
-    public function getSecret() {
-    	return $this->Secret;
-    }
-    
-	public function setSecret($secret){
-		$this->Secret = $secret;
-		return $this;
-	}
-	
-    public function getName() {
-    	return $this->Name;
+        return $this->id;
     }
 
-	public function setName($name){
-		$this->Name = $name;
-		return $this;
-	}
-	
-    public function getRedirectUri() {
-    	return $this->RedirectURI;
+    public function setId($id){
+        $this->id = $id;
+        return $this;
     }
-	
-	public function setRedirectUri($redirectUri){
-		$this->RedirectURI = $redirectUri;
-		return $this;
-	}
+
+    public function getSecret() {
+        return $this->Secret;
+    }
+
+    public function setSecret($secret){
+        $this->Secret = $secret;
+        return $this;
+    }
+
+    public function getName() {
+        return $this->Name;
+    }
+
+    public function setName($name){
+        $this->Name = $name;
+        return $this;
+    }
+
+    public function getRedirectUri() {
+        return $this->RedirectURI;
+    }
+
+    public function setRedirectUri($redirectUri){
+        $this->RedirectURI = $redirectUri;
+        return $this;
+    }
 }

--- a/examples/mongodb/Document/OAuthClient.php
+++ b/examples/mongodb/Document/OAuthClient.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\ClientInterface as ClientEntityInterface;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthClient implements ClientEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 **/
+	public $id;
+    
+    /**
+     * @ODM\Field(name="secret")
+     */
+    protected $Secret;
+    
+    /**
+     * @ODM\Field(name="name")
+     */
+    protected $Name;
+    
+    /**
+     * @ODM\Field(name="redirect_uri")
+     */
+    protected $RedirectURI;
+    
+    public function getId() {
+    	return $this->id;
+    }
+	
+	public function setId($id){
+		$this->id = $id;
+		return $this;
+	}
+    
+    public function getSecret() {
+    	return $this->Secret;
+    }
+    
+	public function setSecret($secret){
+		$this->Secret = $secret;
+		return $this;
+	}
+	
+    public function getName() {
+    	return $this->Name;
+    }
+
+	public function setName($name){
+		$this->Name = $name;
+		return $this;
+	}
+	
+    public function getRedirectUri() {
+    	return $this->RedirectURI;
+    }
+	
+	public function setRedirectUri($redirectUri){
+		$this->RedirectURI = $redirectUri;
+		return $this;
+	}
+}

--- a/examples/mongodb/Document/OAuthMacToken.php
+++ b/examples/mongodb/Document/OAuthMacToken.php
@@ -9,42 +9,42 @@ use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterfa
  * @ODM\Document
  */
 class OAuthMacToken{
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 */
-	public $id;    
-    
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
-	 */
-	protected $AccessToken;
-	
-	public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
-	{
-		$this->AccessToken = $accessTokenEntity;
-	
-		return $this;
-	}
-	
-	public function getAccessToken()
-	{
-		if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
-			$this->AccessToken->__load();
-		}
-	
-		return $this->AccessToken;
-	}
-	
-	public function setId($id)
-	{
-		$this->id = $id;
-	
-		return $this;
-	}
-	
-	public function getId()
-	{
-		return $this->id;
-	}
+
+    /**
+     * @ODM\Id(strategy="NONE")
+     */
+    public $id;    
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+     */
+    protected $AccessToken;
+
+    public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+    {
+        $this->AccessToken = $accessTokenEntity;
+
+        return $this;
+    }
+
+    public function getAccessToken()
+    {
+        if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
+            $this->AccessToken->__load();
+        }
+
+        return $this->AccessToken;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
 }

--- a/examples/mongodb/Document/OAuthMacToken.php
+++ b/examples/mongodb/Document/OAuthMacToken.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthMacToken{
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 */
+	public $id;    
+    
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+	 */
+	protected $AccessToken;
+	
+	public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+	{
+		$this->AccessToken = $accessTokenEntity;
+	
+		return $this;
+	}
+	
+	public function getAccessToken()
+	{
+		if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
+			$this->AccessToken->__load();
+		}
+	
+		return $this->AccessToken;
+	}
+	
+	public function setId($id)
+	{
+		$this->id = $id;
+	
+		return $this;
+	}
+	
+	public function getId()
+	{
+		return $this->id;
+	}
+}

--- a/examples/mongodb/Document/OAuthMacToken.php
+++ b/examples/mongodb/Document/OAuthMacToken.php
@@ -20,6 +20,9 @@ class OAuthMacToken{
      */
     protected $AccessToken;
 
+    /**
+     * {@inheritDoc}
+     */
     public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
         $this->AccessToken = $accessTokenEntity;
@@ -27,6 +30,9 @@ class OAuthMacToken{
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getAccessToken()
     {
         if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
@@ -36,6 +42,9 @@ class OAuthMacToken{
         return $this->AccessToken;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id)
     {
         $this->id = $id;
@@ -43,6 +52,9 @@ class OAuthMacToken{
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId()
     {
         return $this->id;

--- a/examples/mongodb/Document/OAuthRefreshToken.php
+++ b/examples/mongodb/Document/OAuthRefreshToken.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\RefreshTokenInterface as RefreshTokenEntityInterface;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthRefreshToken implements RefreshTokenEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 */
+	public $id;    
+    
+	/**
+	 * @ODM\Field(name="expire_time",type="int")
+	 */
+	protected $ExpireTime;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+	 */
+	protected $AccessToken;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+	 */
+	protected $Session;
+	
+	/**
+	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+	 */
+	public $Scopes;
+	
+	public function setAccessTokenId($accessTokenId){
+		return $this;
+	}
+	
+	public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+	{
+		$this->AccessToken = $accessTokenEntity;
+	
+		return $this;
+	}
+	
+	public function getAccessToken()
+	{
+		if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
+			$this->AccessToken->__load();
+		}
+	
+		return $this->AccessToken;
+	}
+	
+	public function setSession(SessionEntityInterface $session)
+	{
+		$this->Session = $session;
+	
+		return $this;
+	}
+	
+	public function setExpireTime($expireTime)
+	{
+		$this->ExpireTime = $expireTime;
+	
+		return $this;
+	}
+	
+	public function getExpireTime()
+	{
+		return $this->ExpireTime;
+	}
+	
+	public function isExpired()
+	{
+		return ((time() - $this->ExpireTime) > 0);
+	}
+		
+	public function setId($id = NULL)
+	{
+		$this->id = $id;
+	
+		return $this;
+	}
+	
+	public function getId()
+	{
+		return $this->id;
+	}
+	
+	public function associateScope(ScopeEntityInterface $scope)
+	{
+		if (!$this->Scopes->contains($scope)) {
+			$this->Scopes->add($scope);
+		}
+	
+		return $this;
+	}
+	
+	public function __toString(){
+		if ($this->id === null) {
+            return '';
+        }
+
+        return $this->id;
+	}
+
+    public function expire(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->remove($this);
+		$dm->flush();
+	}
+
+    public function save(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->persist($this);
+		$dm->flush();
+	}
+}

--- a/examples/mongodb/Document/OAuthRefreshToken.php
+++ b/examples/mongodb/Document/OAuthRefreshToken.php
@@ -12,114 +12,114 @@ use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
  * @ODM\Document
  */
 class OAuthRefreshToken implements RefreshTokenEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 */
-	public $id;    
-    
-	/**
-	 * @ODM\Field(name="expire_time",type="int")
-	 */
-	protected $ExpireTime;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
-	 */
-	protected $AccessToken;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
-	 */
-	protected $Session;
-	
-	/**
-	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
-	 */
-	public $Scopes;
-	
-	public function setAccessTokenId($accessTokenId){
-		return $this;
-	}
-	
-	public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
-	{
-		$this->AccessToken = $accessTokenEntity;
-	
-		return $this;
-	}
-	
-	public function getAccessToken()
-	{
-		if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
-			$this->AccessToken->__load();
-		}
-	
-		return $this->AccessToken;
-	}
-	
-	public function setSession(SessionEntityInterface $session)
-	{
-		$this->Session = $session;
-	
-		return $this;
-	}
-	
-	public function setExpireTime($expireTime)
-	{
-		$this->ExpireTime = $expireTime;
-	
-		return $this;
-	}
-	
-	public function getExpireTime()
-	{
-		return $this->ExpireTime;
-	}
-	
-	public function isExpired()
-	{
-		return ((time() - $this->ExpireTime) > 0);
-	}
-		
-	public function setId($id = NULL)
-	{
-		$this->id = $id;
-	
-		return $this;
-	}
-	
-	public function getId()
-	{
-		return $this->id;
-	}
-	
-	public function associateScope(ScopeEntityInterface $scope)
-	{
-		if (!$this->Scopes->contains($scope)) {
-			$this->Scopes->add($scope);
-		}
-	
-		return $this;
-	}
-	
-	public function __toString(){
-		if ($this->id === null) {
+
+    /**
+     * @ODM\Id(strategy="NONE")
+     */
+    public $id;    
+
+    /**
+     * @ODM\Field(name="expire_time",type="int")
+     */
+    protected $ExpireTime;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+     */
+    protected $AccessToken;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthSession",simple=true)
+     */
+    protected $Session;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+     */
+    public $Scopes;
+
+    public function setAccessTokenId($accessTokenId){
+        return $this;
+    }
+
+    public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+    {
+        $this->AccessToken = $accessTokenEntity;
+
+        return $this;
+    }
+
+    public function getAccessToken()
+    {
+        if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
+            $this->AccessToken->__load();
+        }
+
+        return $this->AccessToken;
+    }
+
+    public function setSession(SessionEntityInterface $session)
+    {
+        $this->Session = $session;
+
+        return $this;
+    }
+
+    public function setExpireTime($expireTime)
+    {
+        $this->ExpireTime = $expireTime;
+
+        return $this;
+    }
+
+    public function getExpireTime()
+    {
+        return $this->ExpireTime;
+    }
+
+    public function isExpired()
+    {
+        return ((time() - $this->ExpireTime) > 0);
+    }
+
+    public function setId($id = NULL)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function associateScope(ScopeEntityInterface $scope)
+    {
+        if (!$this->Scopes->contains($scope)) {
+            $this->Scopes->add($scope);
+        }
+
+        return $this;
+    }
+
+    public function __toString(){
+        if ($this->id === null) {
             return '';
         }
 
         return $this->id;
-	}
+    }
 
     public function expire(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->remove($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->remove($this);
+        $dm->flush();
+    }
 
     public function save(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->persist($this);
-		$dm->flush();
-	}
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->persist($this);
+        $dm->flush();
+    }
 }

--- a/examples/mongodb/Document/OAuthRefreshToken.php
+++ b/examples/mongodb/Document/OAuthRefreshToken.php
@@ -38,10 +38,16 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
      */
     public $Scopes;
 
+    /**
+     * {@inheritDoc}
+     */
     public function setAccessTokenId($accessTokenId){
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setAccessToken(AccessTokenEntityInterface $accessTokenEntity)
     {
         $this->AccessToken = $accessTokenEntity;
@@ -49,6 +55,9 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getAccessToken()
     {
         if(isset($this->AccessToken->__isInitialized__) && !$this->AccessToken->__isInitialized__) {
@@ -58,6 +67,9 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this->AccessToken;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setSession(SessionEntityInterface $session)
     {
         $this->Session = $session;
@@ -65,6 +77,9 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setExpireTime($expireTime)
     {
         $this->ExpireTime = $expireTime;
@@ -72,16 +87,25 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getExpireTime()
     {
         return $this->ExpireTime;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function isExpired()
     {
         return ((time() - $this->ExpireTime) > 0);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id = NULL)
     {
         $this->id = $id;
@@ -89,11 +113,17 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateScope(ScopeEntityInterface $scope)
     {
         if (!$this->Scopes->contains($scope)) {
@@ -103,6 +133,9 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function __toString(){
         if ($this->id === null) {
             return '';
@@ -111,12 +144,18 @@ class OAuthRefreshToken implements RefreshTokenEntityInterface {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function expire(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->remove($this);
         $dm->flush();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function save(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->persist($this);

--- a/examples/mongodb/Document/OAuthScope.php
+++ b/examples/mongodb/Document/OAuthScope.php
@@ -12,7 +12,7 @@ class OAuthScope implements ScopeEntityInterface {
 
     /**
      * @ODM\Id(strategy="NONE")
-     **/
+     */
     public $id;
 
     /**
@@ -20,30 +20,40 @@ class OAuthScope implements ScopeEntityInterface {
      */
     protected $Description;
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id){
         $this->id = $id;
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getDescription()
     {
         return $this->Description;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setDescription($description){
         $this->Description = $description;
         return $this;
     }
 
     /**
-     * Returns a JSON object when entity is passed into json_encode
-     *
-     * @return array
+     * {@inheritDoc}
      */
     public function jsonSerialize()
     {

--- a/examples/mongodb/Document/OAuthScope.php
+++ b/examples/mongodb/Document/OAuthScope.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthScope implements ScopeEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 **/
+	public $id;
+	
+	/**
+	 * @ODM\Field(name="description")
+	 */
+	protected $Description;
+	
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	public function setId($id){
+		$this->id = $id;
+		return $this;
+	}
+	
+	public function getDescription()
+	{
+		return $this->Description;
+	}
+	
+	public function setDescription($description){
+		$this->Description = $description;
+		return $this;
+	}
+	
+	/**
+     * Returns a JSON object when entity is passed into json_encode
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id'    =>  $this->getId(),
+            'description'   =>  $this->getDescription()
+        ];
+    }
+}

--- a/examples/mongodb/Document/OAuthScope.php
+++ b/examples/mongodb/Document/OAuthScope.php
@@ -9,38 +9,38 @@ use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
  * @ODM\Document
  */
 class OAuthScope implements ScopeEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 **/
-	public $id;
-	
-	/**
-	 * @ODM\Field(name="description")
-	 */
-	protected $Description;
-	
-	public function getId()
-	{
-		return $this->id;
-	}
 
-	public function setId($id){
-		$this->id = $id;
-		return $this;
-	}
-	
-	public function getDescription()
-	{
-		return $this->Description;
-	}
-	
-	public function setDescription($description){
-		$this->Description = $description;
-		return $this;
-	}
-	
-	/**
+    /**
+     * @ODM\Id(strategy="NONE")
+     **/
+    public $id;
+
+    /**
+     * @ODM\Field(name="description")
+     */
+    protected $Description;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id){
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getDescription()
+    {
+        return $this->Description;
+    }
+
+    public function setDescription($description){
+        $this->Description = $description;
+        return $this;
+    }
+
+    /**
      * Returns a JSON object when entity is passed into json_encode
      *
      * @return array

--- a/examples/mongodb/Document/OAuthSession.php
+++ b/examples/mongodb/Document/OAuthSession.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+use League\OAuth2\Server\Entity\ClientInterface as ClientEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+use League\OAuth2\Server\Entity\RefreshTokenInterface as RefreshTokenEntityInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/** 
+ * @ODM\Document
+ */
+class OAuthSession implements SessionEntityInterface {
+	
+	/**
+	 * @ODM\Id(strategy="AUTO")
+	 **/
+	public $id;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthClient",simple=true)
+	 */
+	private $Client;
+	
+	/**
+	 * @ODM\Field(name="owner_id")
+	 */
+	protected $OwnerId;
+	
+	/**
+	 * @ODM\Field(name="owner_type")
+	 */
+	protected $OwnerType;
+	
+	/**
+	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+	 */
+	protected $Scopes;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+	 */
+	protected $AccessToken;
+	
+	/**
+	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthRefreshToken",simple=true)
+	 */
+	protected $RefreshToken;
+	
+	public function __construct(){
+		$this->Scopes = new ArrayCollection();
+	}
+	
+	public function setId($id) {
+		$this->id = $id;
+		return $this;
+	}
+	
+	public function getId(){
+		return $this->id;
+	}
+	
+	public function associateScope(ScopeEntityInterface $scope){
+		if (!$this->Scopes->contains($scope)) {
+			$this->Scopes->add($scope);
+		}
+		
+		return $this;
+	}
+	
+	public function hasScope($scope){
+		return $this->Scopes->contains($scope);
+	}
+	
+	public function getScopes(){
+		return $this->Scopes;
+	}
+	
+	public function associateAccessToken(AccessTokenEntityInterface $accessToken){
+		$this->AccessToken = $accessToken;
+		
+		return $this;
+	}
+	
+	public function associateRefreshToken(RefreshTokenEntityInterface $refreshToken){
+		$this->RefreshToken = $refreshToken;
+		
+		return $this;
+	}
+	
+	public function associateClient(ClientEntityInterface $client)
+	{
+		$this->Client = $client;
+	
+		return $this;
+	}
+	
+	public function getClient()
+	{
+		return $this->Client;
+	}
+	
+	public function setOwner($type, $id)
+	{
+		$this->OwnerType = $type;
+		$this->OwnerId = $id;
+	}
+	
+	public function getOwnerId()
+	{
+		return $this->OwnerId;
+	}
+
+	public function getOwnerType()
+	{
+		return $this->OwnerType;
+	}
+	
+	public function save(){
+		$dm = \MongoDBExample\Config\DM::get();
+		$dm->persist($this);
+		$dm->flush();
+	}
+}

--- a/examples/mongodb/Document/OAuthSession.php
+++ b/examples/mongodb/Document/OAuthSession.php
@@ -14,114 +14,114 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @ODM\Document
  */
 class OAuthSession implements SessionEntityInterface {
-	
-	/**
-	 * @ODM\Id(strategy="AUTO")
-	 **/
-	public $id;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthClient",simple=true)
-	 */
-	private $Client;
-	
-	/**
-	 * @ODM\Field(name="owner_id")
-	 */
-	protected $OwnerId;
-	
-	/**
-	 * @ODM\Field(name="owner_type")
-	 */
-	protected $OwnerType;
-	
-	/**
-	 * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
-	 */
-	protected $Scopes;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
-	 */
-	protected $AccessToken;
-	
-	/**
-	 * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthRefreshToken",simple=true)
-	 */
-	protected $RefreshToken;
-	
-	public function __construct(){
-		$this->Scopes = new ArrayCollection();
-	}
-	
-	public function setId($id) {
-		$this->id = $id;
-		return $this;
-	}
-	
-	public function getId(){
-		return $this->id;
-	}
-	
-	public function associateScope(ScopeEntityInterface $scope){
-		if (!$this->Scopes->contains($scope)) {
-			$this->Scopes->add($scope);
-		}
-		
-		return $this;
-	}
-	
-	public function hasScope($scope){
-		return $this->Scopes->contains($scope);
-	}
-	
-	public function getScopes(){
-		return $this->Scopes;
-	}
-	
-	public function associateAccessToken(AccessTokenEntityInterface $accessToken){
-		$this->AccessToken = $accessToken;
-		
-		return $this;
-	}
-	
-	public function associateRefreshToken(RefreshTokenEntityInterface $refreshToken){
-		$this->RefreshToken = $refreshToken;
-		
-		return $this;
-	}
-	
-	public function associateClient(ClientEntityInterface $client)
-	{
-		$this->Client = $client;
-	
-		return $this;
-	}
-	
-	public function getClient()
-	{
-		return $this->Client;
-	}
-	
-	public function setOwner($type, $id)
-	{
-		$this->OwnerType = $type;
-		$this->OwnerId = $id;
-	}
-	
-	public function getOwnerId()
-	{
-		return $this->OwnerId;
-	}
 
-	public function getOwnerType()
-	{
-		return $this->OwnerType;
-	}
-	
-	public function save(){
-		$dm = \MongoDBExample\Config\DM::get();
-		$dm->persist($this);
-		$dm->flush();
-	}
+    /**
+     * @ODM\Id(strategy="AUTO")
+     **/
+    public $id;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthClient",simple=true)
+     */
+    private $Client;
+
+    /**
+     * @ODM\Field(name="owner_id")
+     */
+    protected $OwnerId;
+
+    /**
+     * @ODM\Field(name="owner_type")
+     */
+    protected $OwnerType;
+
+    /**
+     * @ODM\ReferenceMany(targetDocument="MongoDBExample\Document\OAuthScope",simple=true)
+     */
+    protected $Scopes;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthAccessToken",simple=true)
+     */
+    protected $AccessToken;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument="MongoDBExample\Document\OAuthRefreshToken",simple=true)
+     */
+    protected $RefreshToken;
+
+    public function __construct(){
+        $this->Scopes = new ArrayCollection();
+    }
+
+    public function setId($id) {
+        $this->id = $id;
+        return $this;
+    }
+
+    public function getId(){
+        return $this->id;
+    }
+
+    public function associateScope(ScopeEntityInterface $scope){
+        if (!$this->Scopes->contains($scope)) {
+            $this->Scopes->add($scope);
+        }
+
+        return $this;
+    }
+
+    public function hasScope($scope){
+        return $this->Scopes->contains($scope);
+    }
+
+    public function getScopes(){
+        return $this->Scopes;
+    }
+
+    public function associateAccessToken(AccessTokenEntityInterface $accessToken){
+        $this->AccessToken = $accessToken;
+
+        return $this;
+    }
+
+    public function associateRefreshToken(RefreshTokenEntityInterface $refreshToken){
+        $this->RefreshToken = $refreshToken;
+
+        return $this;
+    }
+
+    public function associateClient(ClientEntityInterface $client)
+    {
+        $this->Client = $client;
+
+        return $this;
+    }
+
+    public function getClient()
+    {
+        return $this->Client;
+    }
+
+    public function setOwner($type, $id)
+    {
+        $this->OwnerType = $type;
+        $this->OwnerId = $id;
+    }
+
+    public function getOwnerId()
+    {
+        return $this->OwnerId;
+    }
+
+    public function getOwnerType()
+    {
+        return $this->OwnerType;
+    }
+
+    public function save(){
+        $dm = \MongoDBExample\Config\DM::get();
+        $dm->persist($this);
+        $dm->flush();
+    }
 }

--- a/examples/mongodb/Document/OAuthSession.php
+++ b/examples/mongodb/Document/OAuthSession.php
@@ -17,7 +17,7 @@ class OAuthSession implements SessionEntityInterface {
 
     /**
      * @ODM\Id(strategy="AUTO")
-     **/
+     */
     public $id;
 
     /**
@@ -50,19 +50,31 @@ class OAuthSession implements SessionEntityInterface {
      */
     protected $RefreshToken;
 
+    /**
+     * Constructor
+     */
     public function __construct(){
         $this->Scopes = new ArrayCollection();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setId($id) {
         $this->id = $id;
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getId(){
         return $this->id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateScope(ScopeEntityInterface $scope){
         if (!$this->Scopes->contains($scope)) {
             $this->Scopes->add($scope);
@@ -71,26 +83,41 @@ class OAuthSession implements SessionEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function hasScope($scope){
         return $this->Scopes->contains($scope);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getScopes(){
         return $this->Scopes;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateAccessToken(AccessTokenEntityInterface $accessToken){
         $this->AccessToken = $accessToken;
 
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateRefreshToken(RefreshTokenEntityInterface $refreshToken){
         $this->RefreshToken = $refreshToken;
 
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function associateClient(ClientEntityInterface $client)
     {
         $this->Client = $client;
@@ -98,27 +125,42 @@ class OAuthSession implements SessionEntityInterface {
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getClient()
     {
         return $this->Client;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setOwner($type, $id)
     {
         $this->OwnerType = $type;
         $this->OwnerId = $id;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getOwnerId()
     {
         return $this->OwnerId;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getOwnerType()
     {
         return $this->OwnerType;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function save(){
         $dm = \MongoDBExample\Config\DM::get();
         $dm->persist($this);

--- a/examples/mongodb/Document/User.php
+++ b/examples/mongodb/Document/User.php
@@ -12,7 +12,7 @@ class User
 {
     /**
      * @ODM\Id(strategy="NONE")
-     **/
+     */
     public $id;
 
     /** 

--- a/examples/mongodb/Document/User.php
+++ b/examples/mongodb/Document/User.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MongoDBExample\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/** 
+ * @ODM\Document
+ */
+class User
+{
+	/**
+	 * @ODM\Id(strategy="NONE")
+	 **/
+	public $id;
+    
+    /** 
+     * @ODM\Field(name="password") 
+     */
+    public $Password;
+	
+	/** 
+     * @ODM\Field(name="name") 
+     */
+    public $Name;
+	
+	/** 
+     * @ODM\Field(name="email") 
+     */
+    public $Email;
+	
+	/** 
+     * @ODM\Field(name="photo") 
+     */
+    public $Photo;
+}

--- a/examples/mongodb/Document/User.php
+++ b/examples/mongodb/Document/User.php
@@ -10,27 +10,27 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class User
 {
-	/**
-	 * @ODM\Id(strategy="NONE")
-	 **/
-	public $id;
-    
+    /**
+     * @ODM\Id(strategy="NONE")
+     **/
+    public $id;
+
     /** 
      * @ODM\Field(name="password") 
      */
     public $Password;
-	
-	/** 
+
+    /** 
      * @ODM\Field(name="name") 
      */
     public $Name;
-	
-	/** 
+
+    /** 
      * @ODM\Field(name="email") 
      */
     public $Email;
-	
-	/** 
+
+    /** 
      * @ODM\Field(name="photo") 
      */
     public $Photo;

--- a/examples/mongodb/Storage/AccessTokenStorage.php
+++ b/examples/mongodb/Storage/AccessTokenStorage.php
@@ -7,10 +7,13 @@ use MongoDBExample\Document\OAuthAccessToken;
 use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
 use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
 
+/**
+ * Storage class for access tokens
+ */
 class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
 {
     /**
-     * Get an instance of Entity\AccessTokenEntity
+     * {@inheritDoc}
      */
     public function get($token){
 
@@ -21,7 +24,7 @@ class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
     }
 
     /**
-     * Get the scopes for an access token
+     * {@inheritDoc}
      */
     public function getScopes(AccessTokenEntityInterface $token){
 
@@ -32,7 +35,7 @@ class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
     }
 
     /**
-     * Creates a new access token
+     * {@inheritDoc}
      */
     public function create($token, $expireTime, $sessionId){
         $accessToken = new OAuthAccessToken();
@@ -44,14 +47,14 @@ class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
     }
 
     /**
-     * Associate a scope with an acess token
+     * {@inheritDoc}
      */
     public function associateScope(AccessTokenEntityInterface $token, ScopeEntityInterface $scope){
         $token->getScopes()->add($scope);
     }
 
     /**
-     * Delete an access token
+     * {@inheritDoc}
      */
     public function delete(AccessTokenEntityInterface $token){
         $this->documentManager->remove($token);

--- a/examples/mongodb/Storage/AccessTokenStorage.php
+++ b/examples/mongodb/Storage/AccessTokenStorage.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\AccessTokenInterface;
+use MongoDBExample\Document\OAuthAccessToken;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+
+class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
+{
+	/**
+	 * Get an instance of Entity\AccessTokenEntity
+	 */
+	public function get($token){
+		
+		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token))
+			return $AccessToken;
+		else 
+			return;
+	}
+	
+	/**
+	 * Get the scopes for an access token
+	*/
+	public function getScopes(AccessTokenEntityInterface $token){
+		
+		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token->getId()))
+			return $AccessToken->getScopes();
+		
+		return array();
+	}
+	
+	/**
+	 * Creates a new access token
+	*/
+	public function create($token, $expireTime, $sessionId){
+		$accessToken = new OAuthAccessToken();
+		$accessToken->setId($token);
+		$accessToken->setExpireTime($expireTime);
+		$accessToken->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
+		$this->documentManager->persist($accessToken);
+		$this->documentManager->flush();
+	}
+	
+	/**
+	 * Associate a scope with an acess token
+	*/
+	public function associateScope(AccessTokenEntityInterface $token, ScopeEntityInterface $scope){
+		$token->getScopes()->add($scope);
+	}
+	
+	/**
+	 * Delete an access token
+	*/
+	public function delete(AccessTokenEntityInterface $token){
+		$this->documentManager->remove($token);
+		$this->documentManager->flush();
+	}
+}

--- a/examples/mongodb/Storage/AccessTokenStorage.php
+++ b/examples/mongodb/Storage/AccessTokenStorage.php
@@ -9,52 +9,52 @@ use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
 
 class AccessTokenStorage extends BaseStorage implements AccessTokenInterface
 {
-	/**
-	 * Get an instance of Entity\AccessTokenEntity
-	 */
-	public function get($token){
-		
-		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token))
-			return $AccessToken;
-		else 
-			return;
-	}
-	
-	/**
-	 * Get the scopes for an access token
-	*/
-	public function getScopes(AccessTokenEntityInterface $token){
-		
-		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token->getId()))
-			return $AccessToken->getScopes();
-		
-		return array();
-	}
-	
-	/**
-	 * Creates a new access token
-	*/
-	public function create($token, $expireTime, $sessionId){
-		$accessToken = new OAuthAccessToken();
-		$accessToken->setId($token);
-		$accessToken->setExpireTime($expireTime);
-		$accessToken->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
-		$this->documentManager->persist($accessToken);
-		$this->documentManager->flush();
-	}
-	
-	/**
-	 * Associate a scope with an acess token
-	*/
-	public function associateScope(AccessTokenEntityInterface $token, ScopeEntityInterface $scope){
-		$token->getScopes()->add($scope);
-	}
-	
-	/**
-	 * Delete an access token
-	*/
-	public function delete(AccessTokenEntityInterface $token){
-		$this->documentManager->remove($token);
-		$this->documentManager->flush();
-	}
+    /**
+     * Get an instance of Entity\AccessTokenEntity
+     */
+    public function get($token){
+
+        if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token))
+            return $AccessToken;
+        else 
+            return;
+    }
+
+    /**
+     * Get the scopes for an access token
+     */
+    public function getScopes(AccessTokenEntityInterface $token){
+
+        if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($token->getId()))
+            return $AccessToken->getScopes();
+        
+        return array();
+    }
+
+    /**
+     * Creates a new access token
+     */
+    public function create($token, $expireTime, $sessionId){
+        $accessToken = new OAuthAccessToken();
+        $accessToken->setId($token);
+        $accessToken->setExpireTime($expireTime);
+        $accessToken->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
+        $this->documentManager->persist($accessToken);
+        $this->documentManager->flush();
+    }
+
+    /**
+     * Associate a scope with an acess token
+     */
+    public function associateScope(AccessTokenEntityInterface $token, ScopeEntityInterface $scope){
+        $token->getScopes()->add($scope);
+    }
+
+    /**
+     * Delete an access token
+     */
+    public function delete(AccessTokenEntityInterface $token){
+        $this->documentManager->remove($token);
+        $this->documentManager->flush();
+    }
 }

--- a/examples/mongodb/Storage/AuthCodeStorage.php
+++ b/examples/mongodb/Storage/AuthCodeStorage.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\AuthCodeInterface;
+use MongoDBExample\Document\OAuthAuthCode;
+use League\OAuth2\Server\Entity\AuthCodeInterface as AuthCodeEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+
+class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
+{
+	/**
+	 * Get the auth code
+	 *
+	 * @param string $code
+	 *
+	 * @return \League\OAuth2\Server\Entity\AuthCodeEntity
+	 */
+	public function get($code){
+		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($code))
+			return $AccessToken;
+		else 
+			return;
+	}
+	
+	/**
+	 * Create an auth code.
+	 *
+	 * @param string  $token       The token ID
+	 * @param integer $expireTime  Token expire time
+	 * @param integer $sessionId   Session identifier
+	 * @param string  $redirectUri Client redirect uri
+	 *
+	 * @return void
+	*/
+	public function create($token, $expireTime, $sessionId, $redirectUri){
+		$authCode = new OAuthAuthCode();
+        $authCode->setId($token);
+        $authCode->setRedirectUri($redirectUri);
+        $authCode->setExpireTime($expireTime);
+		$authCode->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
+		$this->documentManager->persist($authCode);
+		$this->documentManager->flush();
+	}
+	
+	/**
+	 * Get the scopes for an access token
+	 *
+	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+	 *
+	 * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
+	*/
+	public function getScopes(AuthCodeEntityInterface $token){
+		if($AuthCode = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($token->getId()))
+			return $AuthCode->getScopes();
+		
+		return array();
+	}
+	
+	/**
+	 * Associate a scope with an acess token
+	 *
+	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+	 * @param \League\OAuth2\Server\Entity\ScopeEntity    $scope The scope
+	 *
+	 * @return void
+	*/
+	public function associateScope(AuthCodeEntityInterface $token, ScopeEntityInterface $scope){
+		$token->getScopes()->add($scope);
+	}
+	
+	/**
+	 * Delete an access token
+	 *
+	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The access token to delete
+	 *
+	 * @return void
+	*/
+	public function delete(AuthCodeEntityInterface $token){
+		$this->documentManager->remove($token);
+		$this->documentManager->flush();
+	}
+}

--- a/examples/mongodb/Storage/AuthCodeStorage.php
+++ b/examples/mongodb/Storage/AuthCodeStorage.php
@@ -7,14 +7,13 @@ use MongoDBExample\Document\OAuthAuthCode;
 use League\OAuth2\Server\Entity\AuthCodeInterface as AuthCodeEntityInterface;
 use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
 
+/**
+ * Storage class for auth codes
+ */
 class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
 {
     /**
-     * Get the auth code
-     *
-     * @param string $code
-     *
-     * @return \League\OAuth2\Server\Entity\AuthCodeEntity
+     * {@inheritDoc}
      */
     public function get($code){
         if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($code))
@@ -24,14 +23,7 @@ class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
     }
 
     /**
-     * Create an auth code.
-     *
-     * @param string  $token       The token ID
-     * @param integer $expireTime  Token expire time
-     * @param integer $sessionId   Session identifier
-     * @param string  $redirectUri Client redirect uri
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function create($token, $expireTime, $sessionId, $redirectUri){
         $authCode = new OAuthAuthCode();
@@ -44,12 +36,8 @@ class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
     }
 
     /**
-     * Get the scopes for an access token
-     *
-     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
-     *
-     * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
-    */
+     * {@inheritDoc}
+     */
     public function getScopes(AuthCodeEntityInterface $token){
         if($AuthCode = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($token->getId()))
             return $AuthCode->getScopes();
@@ -58,23 +46,14 @@ class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
     }
 
     /**
-     * Associate a scope with an acess token
-     *
-     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
-     * @param \League\OAuth2\Server\Entity\ScopeEntity    $scope The scope
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function associateScope(AuthCodeEntityInterface $token, ScopeEntityInterface $scope){
         $token->getScopes()->add($scope);
     }
 
     /**
-     * Delete an access token
-     *
-     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The access token to delete
-     *
-     * @return void
+     * {@inheritDoc}
      */
     public function delete(AuthCodeEntityInterface $token){
         $this->documentManager->remove($token);

--- a/examples/mongodb/Storage/AuthCodeStorage.php
+++ b/examples/mongodb/Storage/AuthCodeStorage.php
@@ -9,75 +9,75 @@ use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
 
 class AuthCodeStorage extends BaseStorage implements AuthCodeInterface
 {
-	/**
-	 * Get the auth code
-	 *
-	 * @param string $code
-	 *
-	 * @return \League\OAuth2\Server\Entity\AuthCodeEntity
-	 */
-	public function get($code){
-		if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($code))
-			return $AccessToken;
-		else 
-			return;
-	}
-	
-	/**
-	 * Create an auth code.
-	 *
-	 * @param string  $token       The token ID
-	 * @param integer $expireTime  Token expire time
-	 * @param integer $sessionId   Session identifier
-	 * @param string  $redirectUri Client redirect uri
-	 *
-	 * @return void
-	*/
-	public function create($token, $expireTime, $sessionId, $redirectUri){
-		$authCode = new OAuthAuthCode();
+    /**
+     * Get the auth code
+     *
+     * @param string $code
+     *
+     * @return \League\OAuth2\Server\Entity\AuthCodeEntity
+     */
+    public function get($code){
+        if($AccessToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($code))
+            return $AccessToken;
+        else 
+            return;
+    }
+
+    /**
+     * Create an auth code.
+     *
+     * @param string  $token       The token ID
+     * @param integer $expireTime  Token expire time
+     * @param integer $sessionId   Session identifier
+     * @param string  $redirectUri Client redirect uri
+     *
+     * @return void
+     */
+    public function create($token, $expireTime, $sessionId, $redirectUri){
+        $authCode = new OAuthAuthCode();
         $authCode->setId($token);
         $authCode->setRedirectUri($redirectUri);
         $authCode->setExpireTime($expireTime);
-		$authCode->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
-		$this->documentManager->persist($authCode);
-		$this->documentManager->flush();
-	}
-	
-	/**
-	 * Get the scopes for an access token
-	 *
-	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
-	 *
-	 * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
-	*/
-	public function getScopes(AuthCodeEntityInterface $token){
-		if($AuthCode = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($token->getId()))
-			return $AuthCode->getScopes();
-		
-		return array();
-	}
-	
-	/**
-	 * Associate a scope with an acess token
-	 *
-	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
-	 * @param \League\OAuth2\Server\Entity\ScopeEntity    $scope The scope
-	 *
-	 * @return void
-	*/
-	public function associateScope(AuthCodeEntityInterface $token, ScopeEntityInterface $scope){
-		$token->getScopes()->add($scope);
-	}
-	
-	/**
-	 * Delete an access token
-	 *
-	 * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The access token to delete
-	 *
-	 * @return void
-	*/
-	public function delete(AuthCodeEntityInterface $token){
-		$this->documentManager->remove($token);
-		$this->documentManager->flush();
-	}
+        $authCode->setSession($this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($sessionId));
+        $this->documentManager->persist($authCode);
+        $this->documentManager->flush();
+    }
+
+    /**
+     * Get the scopes for an access token
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+     *
+     * @return array Array of \League\OAuth2\Server\Entity\ScopeEntity
+    */
+    public function getScopes(AuthCodeEntityInterface $token){
+        if($AuthCode = $this->documentManager->getRepository("MongoDBExample\Document\OAuthAuthCode")->find($token->getId()))
+            return $AuthCode->getScopes();
+
+        return array();
+    }
+
+    /**
+     * Associate a scope with an acess token
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The auth code
+     * @param \League\OAuth2\Server\Entity\ScopeEntity    $scope The scope
+     *
+     * @return void
+     */
+    public function associateScope(AuthCodeEntityInterface $token, ScopeEntityInterface $scope){
+        $token->getScopes()->add($scope);
+    }
+
+    /**
+     * Delete an access token
+     *
+     * @param \League\OAuth2\Server\Entity\AuthCodeEntity $token The access token to delete
+     *
+     * @return void
+     */
+    public function delete(AuthCodeEntityInterface $token){
+        $this->documentManager->remove($token);
+        $this->documentManager->flush();
+    }
 }

--- a/examples/mongodb/Storage/BaseStorage.php
+++ b/examples/mongodb/Storage/BaseStorage.php
@@ -7,18 +7,18 @@ use League\OAuth2\Server\AbstractServer;
 
 class BaseStorage implements StorageInterface
 {
-	protected $documentManager;
-	
-	public function __construct($documentManager){
-		$this->documentManager = $documentManager;
-	}
-	
-	protected $server;
-	
-	/**
-	 * Set the server
-	 */
-	public function setServer(AbstractServer $server){
-		$this->server = $server;
-	}
+    protected $documentManager;
+
+    public function __construct($documentManager){
+        $this->documentManager = $documentManager;
+    }
+
+    protected $server;
+
+    /**
+     * Set the server
+     */
+    public function setServer(AbstractServer $server){
+        $this->server = $server;
+    }
 }

--- a/examples/mongodb/Storage/BaseStorage.php
+++ b/examples/mongodb/Storage/BaseStorage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\StorageInterface;
+use League\OAuth2\Server\AbstractServer;
+
+class BaseStorage implements StorageInterface
+{
+	protected $documentManager;
+	
+	public function __construct($documentManager){
+		$this->documentManager = $documentManager;
+	}
+	
+	protected $server;
+	
+	/**
+	 * Set the server
+	 */
+	public function setServer(AbstractServer $server){
+		$this->server = $server;
+	}
+}

--- a/examples/mongodb/Storage/BaseStorage.php
+++ b/examples/mongodb/Storage/BaseStorage.php
@@ -5,18 +5,31 @@ namespace MongoDBExample\Storage;
 use League\OAuth2\Server\Storage\StorageInterface;
 use League\OAuth2\Server\AbstractServer;
 
+/**
+ * Base storage class for all Sotrage implementations
+ */
 class BaseStorage implements StorageInterface
 {
+    /**
+     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     */
     protected $documentManager;
 
+    /**
+     * Constructor
+     * @param \Doctrine\ODM\MongoDB\DocumentManager $documentManager
+     */
     public function __construct($documentManager){
         $this->documentManager = $documentManager;
     }
 
+    /**
+     * @var \League\OAuth2\Server\AbstractServer
+     */
     protected $server;
 
     /**
-     * Set the server
+     * {@inheritDoc}
      */
     public function setServer(AbstractServer $server){
         $this->server = $server;

--- a/examples/mongodb/Storage/ClientStorage.php
+++ b/examples/mongodb/Storage/ClientStorage.php
@@ -8,7 +8,7 @@ use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
 class ClientStorage extends BaseStorage implements ClientInterface
 {
     /**
-     * Validate a client
+     * {@inheritDoc}
      */
     public function get($clientId, $clientSecret = null, $redirectUri = null, $grantType = null){
         $filter = array(
@@ -30,7 +30,7 @@ class ClientStorage extends BaseStorage implements ClientInterface
     }
 
     /**
-     * Get the client associated with a session
+     * {@inheritDoc}
      */
     public function getBySession(SessionEntityInterface $session){
         return $session->getClient();

--- a/examples/mongodb/Storage/ClientStorage.php
+++ b/examples/mongodb/Storage/ClientStorage.php
@@ -7,32 +7,32 @@ use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
 
 class ClientStorage extends BaseStorage implements ClientInterface
 {
-	/**
-	 * Validate a client
-	 */
-	public function get($clientId, $clientSecret = null, $redirectUri = null, $grantType = null){
-		$filter = array(
-			"_id" => $clientId
-		);
-		
-		if ($clientSecret !== null)
-			$filter['Secret'] = md5($clientSecret);
-		
-		if ($redirectUri)
-			$filter['RedirectURI'] = $redirectUri;
-		
-		
-		$Client = $this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->findOneBy($filter);
-		if($Client)
-			return $Client;
-		else
-			return;
-	}
-	
-	/**
-	 * Get the client associated with a session
-	*/
-	public function getBySession(SessionEntityInterface $session){
-		return $session->getClient();
-	}
+    /**
+     * Validate a client
+     */
+    public function get($clientId, $clientSecret = null, $redirectUri = null, $grantType = null){
+        $filter = array(
+            "_id" => $clientId
+        );
+
+        if ($clientSecret !== null)
+            $filter['Secret'] = md5($clientSecret);
+
+        if ($redirectUri)
+            $filter['RedirectURI'] = $redirectUri;
+
+
+        $Client = $this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->findOneBy($filter);
+        if($Client)
+            return $Client;
+        else
+            return;
+    }
+
+    /**
+     * Get the client associated with a session
+     */
+    public function getBySession(SessionEntityInterface $session){
+        return $session->getClient();
+    }
 }

--- a/examples/mongodb/Storage/ClientStorage.php
+++ b/examples/mongodb/Storage/ClientStorage.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\ClientInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+
+class ClientStorage extends BaseStorage implements ClientInterface
+{
+	/**
+	 * Validate a client
+	 */
+	public function get($clientId, $clientSecret = null, $redirectUri = null, $grantType = null){
+		$filter = array(
+			"_id" => $clientId
+		);
+		
+		if ($clientSecret !== null)
+			$filter['Secret'] = md5($clientSecret);
+		
+		if ($redirectUri)
+			$filter['RedirectURI'] = $redirectUri;
+		
+		
+		$Client = $this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->findOneBy($filter);
+		if($Client)
+			return $Client;
+		else
+			return;
+	}
+	
+	/**
+	 * Get the client associated with a session
+	*/
+	public function getBySession(SessionEntityInterface $session){
+		return $session->getClient();
+	}
+}

--- a/examples/mongodb/Storage/MacTokenStorage.php
+++ b/examples/mongodb/Storage/MacTokenStorage.php
@@ -5,9 +5,14 @@ namespace MongoDBExample\Storage;
 use League\OAuth2\Server\Storage\MacTokenInterface;
 use MongoDBExample\Document\OAuthMacToken;
 
+/**
+ * Storage class for mac tokens
+ */
 class MacTokenStorage extends BaseStorage implements MacTokenInterface
 {
-
+    /**
+     * {@inheritDoc}
+     */
     public function create($macKey, $accessToken){
         $macToken = new OAuthMacToken();
         $macToken->id = $macKey;
@@ -17,6 +22,9 @@ class MacTokenStorage extends BaseStorage implements MacTokenInterface
         $this->documentManager->flush();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getByAccessToken($accessToken){
         if($macToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthMacToken")->findOneBy(array("AccessToken" => $accessToken)))
             return $macToken;

--- a/examples/mongodb/Storage/MacTokenStorage.php
+++ b/examples/mongodb/Storage/MacTokenStorage.php
@@ -7,20 +7,20 @@ use MongoDBExample\Document\OAuthMacToken;
 
 class MacTokenStorage extends BaseStorage implements MacTokenInterface
 {
-	
-	public function create($macKey, $accessToken){
-		$macToken = new OAuthMacToken();
-		$macToken->id = $macKey;
-		$macToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
-		
-		$this->documentManager->persist($macToken);
-		$this->documentManager->flush();
-	}
-	
-	public function getByAccessToken($accessToken){
-		if($macToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthMacToken")->findOneBy(array("AccessToken" => $accessToken)))
-			return $macToken;
-		else
-			return;
-	}
+
+    public function create($macKey, $accessToken){
+        $macToken = new OAuthMacToken();
+        $macToken->id = $macKey;
+        $macToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
+
+        $this->documentManager->persist($macToken);
+        $this->documentManager->flush();
+    }
+
+    public function getByAccessToken($accessToken){
+        if($macToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthMacToken")->findOneBy(array("AccessToken" => $accessToken)))
+            return $macToken;
+        else
+            return;
+    }
 }

--- a/examples/mongodb/Storage/MacTokenStorage.php
+++ b/examples/mongodb/Storage/MacTokenStorage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\MacTokenInterface;
+use MongoDBExample\Document\OAuthMacToken;
+
+class MacTokenStorage extends BaseStorage implements MacTokenInterface
+{
+	
+	public function create($macKey, $accessToken){
+		$macToken = new OAuthMacToken();
+		$macToken->id = $macKey;
+		$macToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
+		
+		$this->documentManager->persist($macToken);
+		$this->documentManager->flush();
+	}
+	
+	public function getByAccessToken($accessToken){
+		if($macToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthMacToken")->findOneBy(array("AccessToken" => $accessToken)))
+			return $macToken;
+		else
+			return;
+	}
+}

--- a/examples/mongodb/Storage/RefreshTokenStorage.php
+++ b/examples/mongodb/Storage/RefreshTokenStorage.php
@@ -6,8 +6,14 @@ use League\OAuth2\Server\Storage\RefreshTokenInterface;
 use MongoDBExample\Document\OAuthRefreshToken;
 use League\OAuth2\Server\Entity\RefreshTokenInterface as RefreshTokenEntityInterface;
 
+/**
+ * Storage class for refresh tokens
+ */
 class RefreshTokenStorage extends BaseStorage implements RefreshTokenInterface
 {
+    /**
+     * {@inheritDoc}
+     */
     public function get($token){
         if($RefreshToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthRefreshToken")->find($token))
             return $RefreshToken;
@@ -15,6 +21,9 @@ class RefreshTokenStorage extends BaseStorage implements RefreshTokenInterface
             return;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function create($token, $expireTime, $accessToken){
         $refreshToken = new OAuthRefreshToken();
         $refreshToken->setId($token);
@@ -24,6 +33,9 @@ class RefreshTokenStorage extends BaseStorage implements RefreshTokenInterface
         $this->documentManager->flush();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function delete(RefreshTokenEntityInterface $token){
         $this->documentManager->remove($token);
         $this->documentManager->flush();

--- a/examples/mongodb/Storage/RefreshTokenStorage.php
+++ b/examples/mongodb/Storage/RefreshTokenStorage.php
@@ -8,24 +8,24 @@ use League\OAuth2\Server\Entity\RefreshTokenInterface as RefreshTokenEntityInter
 
 class RefreshTokenStorage extends BaseStorage implements RefreshTokenInterface
 {
-	public function get($token){
-		if($RefreshToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthRefreshToken")->find($token))
-			return $RefreshToken;
-		else 
-			return;
-	}
-	
-	public function create($token, $expireTime, $accessToken){
-		$refreshToken = new OAuthRefreshToken();
-		$refreshToken->setId($token);
-		$refreshToken->setExpireTime($expireTime);
-		$refreshToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
-		$this->documentManager->persist($refreshToken);
-		$this->documentManager->flush();
-	}
-	
-	public function delete(RefreshTokenEntityInterface $token){
-		$this->documentManager->remove($token);
-		$this->documentManager->flush();
-	}
+    public function get($token){
+        if($RefreshToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthRefreshToken")->find($token))
+            return $RefreshToken;
+        else 
+            return;
+    }
+
+    public function create($token, $expireTime, $accessToken){
+        $refreshToken = new OAuthRefreshToken();
+        $refreshToken->setId($token);
+        $refreshToken->setExpireTime($expireTime);
+        $refreshToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
+        $this->documentManager->persist($refreshToken);
+        $this->documentManager->flush();
+    }
+
+    public function delete(RefreshTokenEntityInterface $token){
+        $this->documentManager->remove($token);
+        $this->documentManager->flush();
+    }
 }

--- a/examples/mongodb/Storage/RefreshTokenStorage.php
+++ b/examples/mongodb/Storage/RefreshTokenStorage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\RefreshTokenInterface;
+use MongoDBExample\Document\OAuthRefreshToken;
+use League\OAuth2\Server\Entity\RefreshTokenInterface as RefreshTokenEntityInterface;
+
+class RefreshTokenStorage extends BaseStorage implements RefreshTokenInterface
+{
+	public function get($token){
+		if($RefreshToken = $this->documentManager->getRepository("MongoDBExample\Document\OAuthRefreshToken")->find($token))
+			return $RefreshToken;
+		else 
+			return;
+	}
+	
+	public function create($token, $expireTime, $accessToken){
+		$refreshToken = new OAuthRefreshToken();
+		$refreshToken->setId($token);
+		$refreshToken->setExpireTime($expireTime);
+		$refreshToken->setAccessToken($this->documentManager->getRepository("MongoDBExample\Document\OAuthAccessToken")->find($accessToken));
+		$this->documentManager->persist($refreshToken);
+		$this->documentManager->flush();
+	}
+	
+	public function delete(RefreshTokenEntityInterface $token){
+		$this->documentManager->remove($token);
+		$this->documentManager->flush();
+	}
+}

--- a/examples/mongodb/Storage/ScopeStorage.php
+++ b/examples/mongodb/Storage/ScopeStorage.php
@@ -5,13 +5,13 @@ namespace MongoDBExample\Storage;
 use League\OAuth2\Server\Storage\ScopeInterface;
 class ScopeStorage extends BaseStorage implements ScopeInterface
 {
-	/**
-	 * Return information about a scope
-	 */
-	public function get($scope, $grantType = null, $clientId = null){
-		if($Scope = $this->documentManager->getRepository("MongoDBExample\Document\OAuthScope")->find($scope))
-			return $Scope;
-		else 
-			return;
-	}
+    /**
+     * Return information about a scope
+     */
+    public function get($scope, $grantType = null, $clientId = null){
+        if($Scope = $this->documentManager->getRepository("MongoDBExample\Document\OAuthScope")->find($scope))
+            return $Scope;
+        else 
+            return;
+    }
 }

--- a/examples/mongodb/Storage/ScopeStorage.php
+++ b/examples/mongodb/Storage/ScopeStorage.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\ScopeInterface;
+class ScopeStorage extends BaseStorage implements ScopeInterface
+{
+	/**
+	 * Return information about a scope
+	 */
+	public function get($scope, $grantType = null, $clientId = null){
+		if($Scope = $this->documentManager->getRepository("MongoDBExample\Document\OAuthScope")->find($scope))
+			return $Scope;
+		else 
+			return;
+	}
+}

--- a/examples/mongodb/Storage/ScopeStorage.php
+++ b/examples/mongodb/Storage/ScopeStorage.php
@@ -3,10 +3,14 @@
 namespace MongoDBExample\Storage;
 
 use League\OAuth2\Server\Storage\ScopeInterface;
+
+/**
+ * Storage class for scopes
+ */
 class ScopeStorage extends BaseStorage implements ScopeInterface
 {
     /**
-     * Return information about a scope
+     * {@inheritDoc}
      */
     public function get($scope, $grantType = null, $clientId = null){
         if($Scope = $this->documentManager->getRepository("MongoDBExample\Document\OAuthScope")->find($scope))

--- a/examples/mongodb/Storage/SessionStorage.php
+++ b/examples/mongodb/Storage/SessionStorage.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace MongoDBExample\Storage;
+
+use League\OAuth2\Server\Storage\SessionInterface;
+use MongoDBExample\Document\OAuthSession;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
+use League\OAuth2\Server\Entity\AuthCodeInterface as AuthCodeEntityInterface;
+use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
+
+class SessionStorage extends BaseStorage implements SessionInterface
+{
+	/**
+	 * Get a session from an access token
+	 */
+	public function getByAccessToken(AccessTokenEntityInterface $accessToken){
+		return $accessToken->getSession();
+	}
+	
+	/**
+	 * Get a session from an auth code
+	*/
+	public function getByAuthCode(AuthCodeEntityInterface $authCode){
+		return $authCode->getSession();
+	}
+	
+	/**
+	 * Get a session's scopes
+	*/
+	public function getScopes(SessionEntityInterface $session){
+		
+		if($Session = $this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($session->getId()))
+			return $Session->getScopes();
+		
+		return array();
+	}
+	
+	/**
+	 * Create a new session
+	*/
+	public function create($ownerType, $ownerId, $clientId, $clientRedirectUri = null){
+		$session = new OAuthSession();
+		$session->setOwner($ownerType, $ownerId);
+		$session->associateClient($this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->find($clientId));
+		$this->documentManager->persist($session);
+		$this->documentManager->flush();
+		return $session->id;
+	}
+	
+	/**
+	 * Associate a scope with a session
+	*/
+	public function associateScope(SessionEntityInterface $session, ScopeEntityInterface $scope){
+		$session->getScopes()->add($scope);
+	}
+}

--- a/examples/mongodb/Storage/SessionStorage.php
+++ b/examples/mongodb/Storage/SessionStorage.php
@@ -9,24 +9,27 @@ use League\OAuth2\Server\Entity\AuthCodeInterface as AuthCodeEntityInterface;
 use League\OAuth2\Server\Entity\ScopeInterface as ScopeEntityInterface;
 use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
 
+/**
+ * Storage class for sessions
+ */
 class SessionStorage extends BaseStorage implements SessionInterface
 {
     /**
-     * Get a session from an access token
+     * {@inheritDoc}
      */
     public function getByAccessToken(AccessTokenEntityInterface $accessToken){
         return $accessToken->getSession();
     }
 
     /**
-     * Get a session from an auth code
+     * {@inheritDoc}
      */
     public function getByAuthCode(AuthCodeEntityInterface $authCode){
         return $authCode->getSession();
     }
 
     /**
-     * Get a session's scopes
+     * {@inheritDoc}
      */
     public function getScopes(SessionEntityInterface $session){
 
@@ -37,7 +40,7 @@ class SessionStorage extends BaseStorage implements SessionInterface
     }
 
     /**
-     * Create a new session
+     * {@inheritDoc}
      */
     public function create($ownerType, $ownerId, $clientId, $clientRedirectUri = null){
         $session = new OAuthSession();
@@ -49,7 +52,7 @@ class SessionStorage extends BaseStorage implements SessionInterface
     }
 
     /**
-     * Associate a scope with a session
+     * {@inheritDoc}
      */
     public function associateScope(SessionEntityInterface $session, ScopeEntityInterface $scope){
         $session->getScopes()->add($scope);

--- a/examples/mongodb/Storage/SessionStorage.php
+++ b/examples/mongodb/Storage/SessionStorage.php
@@ -11,47 +11,47 @@ use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
 
 class SessionStorage extends BaseStorage implements SessionInterface
 {
-	/**
-	 * Get a session from an access token
-	 */
-	public function getByAccessToken(AccessTokenEntityInterface $accessToken){
-		return $accessToken->getSession();
-	}
-	
-	/**
-	 * Get a session from an auth code
-	*/
-	public function getByAuthCode(AuthCodeEntityInterface $authCode){
-		return $authCode->getSession();
-	}
-	
-	/**
-	 * Get a session's scopes
-	*/
-	public function getScopes(SessionEntityInterface $session){
-		
-		if($Session = $this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($session->getId()))
-			return $Session->getScopes();
-		
-		return array();
-	}
-	
-	/**
-	 * Create a new session
-	*/
-	public function create($ownerType, $ownerId, $clientId, $clientRedirectUri = null){
-		$session = new OAuthSession();
-		$session->setOwner($ownerType, $ownerId);
-		$session->associateClient($this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->find($clientId));
-		$this->documentManager->persist($session);
-		$this->documentManager->flush();
-		return $session->id;
-	}
-	
-	/**
-	 * Associate a scope with a session
-	*/
-	public function associateScope(SessionEntityInterface $session, ScopeEntityInterface $scope){
-		$session->getScopes()->add($scope);
-	}
+    /**
+     * Get a session from an access token
+     */
+    public function getByAccessToken(AccessTokenEntityInterface $accessToken){
+        return $accessToken->getSession();
+    }
+
+    /**
+     * Get a session from an auth code
+     */
+    public function getByAuthCode(AuthCodeEntityInterface $authCode){
+        return $authCode->getSession();
+    }
+
+    /**
+     * Get a session's scopes
+     */
+    public function getScopes(SessionEntityInterface $session){
+
+        if($Session = $this->documentManager->getRepository("MongoDBExample\Document\OAuthSession")->find($session->getId()))
+            return $Session->getScopes();
+
+        return array();
+    }
+
+    /**
+     * Create a new session
+     */
+    public function create($ownerType, $ownerId, $clientId, $clientRedirectUri = null){
+        $session = new OAuthSession();
+        $session->setOwner($ownerType, $ownerId);
+        $session->associateClient($this->documentManager->getRepository("MongoDBExample\Document\OAuthClient")->find($clientId));
+        $this->documentManager->persist($session);
+        $this->documentManager->flush();
+        return $session->id;
+    }
+
+    /**
+     * Associate a scope with a session
+     */
+    public function associateScope(SessionEntityInterface $session, ScopeEntityInterface $scope){
+        $session->getScopes()->add($scope);
+    }
 }

--- a/examples/mongodb/api.php
+++ b/examples/mongodb/api.php
@@ -1,0 +1,137 @@
+<?php
+
+use League\OAuth2\Server\ResourceServer;
+use Orno\Http\Exception\NotFoundException;
+use Orno\Http\Request;
+use Orno\Http\Response;
+use MongoDBExample\Document;
+use MongoDBExample\Storage;
+
+include __DIR__.'/vendor/autoload.php';
+
+$dm = MongoDBExample\Config\DM::get();
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+$router->setStrategy(\Orno\Route\RouteStrategyInterface::RESTFUL_STRATEGY);
+
+// Set up the OAuth 2.0 resource server
+$sessionStorage = new Storage\SessionStorage($dm);
+$accessTokenStorage = new Storage\AccessTokenStorage($dm);
+$clientStorage = new Storage\ClientStorage($dm);
+$scopeStorage = new Storage\ScopeStorage($dm);
+
+$server = new ResourceServer(
+    $sessionStorage,
+    $accessTokenStorage,
+    $clientStorage,
+    $scopeStorage
+);
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+
+// GET /tokeninfo
+$router->get('/tokeninfo', function (Request $request) use ($server) {
+
+    $accessToken = $server->getAccessToken();
+    $session = $server->getSessionStorage()->getByAccessToken($accessToken);
+    $token = [
+        'owner_id' => $session->getOwnerId(),
+        'owner_type' => $session->getOwnerType(),
+        'access_token' => $accessToken,
+        'client_id' => $session->getClient()->getId(),
+        'scopes' => $accessToken->getScopes(),
+    ];
+
+    return new Response(json_encode($token));
+
+});
+
+// GET /users
+$router->get('/users', function (Request $request) use ($server,$dm) {
+
+    $results = $dm->getRepository("MongoDBExample\Document\User")->findAll();
+
+    $users = [];
+
+    foreach ($results as $result) {
+        $user = [
+            'username'  =>  $result->id,
+            'name'      =>  $result->Name,
+        ];
+
+        if ($server->getAccessToken()->hasScope('email')) {
+            $user['email'] = $result->Email;
+        }
+
+        if ($server->getAccessToken()->hasScope('photo')) {
+            $user['photo'] = $result->Photo;
+        }
+
+        $users[] = $user;
+    }
+
+    return new Response(json_encode($users));
+});
+
+// GET /users/{username}
+$router->get('/users/{username}', function (Request $request, Response $response, array $args) use ($server,$dm) {
+
+    $result = $dm->getRepository("MongoDBExample\Document\User")->find($args['username']);
+
+    if (count($result) === 0) {
+        throw new NotFoundException();
+    }
+
+    $user = [
+        'username'  =>  $result->id,
+        'name'      =>  $result->Name,
+    ];
+
+    if ($server->getAccessToken()->hasScope('email')) {
+        $user['email'] = $result->Email;
+    }
+
+    if ($server->getAccessToken()->hasScope('photo')) {
+        $user['photo'] = $result->Photo;
+    }
+
+    return new Response(json_encode($user));
+});
+
+$dispatcher = $router->getDispatcher();
+
+try {
+    // Check that access token is present
+    $server->isValidRequest(false);
+
+    // A successful response
+    $response = $dispatcher->dispatch(
+        $request->getMethod(),
+        $request->getPathInfo()
+    );
+} catch (\Orno\Http\Exception $e) {
+    // A failed response
+    $response = $e->getJsonResponse();
+    $response->setContent(json_encode(['status_code' => $e->getStatusCode(), 'message' => $e->getMessage()]));
+} catch (\League\OAuth2\Server\Exception\OAuthException $e) {
+    $response = new Response(json_encode([
+        'error'     =>  $e->errorType,
+        'message'   =>  $e->getMessage(),
+    ]), $e->httpStatusCode);
+
+    foreach ($e->getHttpHeaders() as $header) {
+        $response->headers($header);
+    }
+} catch (\Exception $e) {
+    $response = new Orno\Http\Response();
+    $response->setStatusCode(500);
+    $response->setContent(json_encode(['status_code' => 500, 'message' => $e->getMessage()]));
+} finally {
+    // Return the response
+    $response->headers->set('Content-type', 'application/json');
+    $response->send();
+}

--- a/examples/mongodb/authcode_grant.php
+++ b/examples/mongodb/authcode_grant.php
@@ -1,0 +1,126 @@
+<?php
+
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Entity\EntityFactory;
+use League\OAuth2\Server\Exception\OAuthException;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
+use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use Orno\Http\Request;
+use Orno\Http\Response;
+use MongoDBExample\Storage;
+
+include __DIR__.'/vendor/autoload.php';
+
+$dm = MongoDBExample\Config\DM::get();
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+$router->setStrategy(\Orno\Route\RouteStrategyInterface::RESTFUL_STRATEGY);
+
+// Set up the OAuth 2.0 authorization server
+$server = new AuthorizationServer();
+$server->setSessionStorage(new Storage\SessionStorage($dm));
+$server->setAccessTokenStorage(new Storage\AccessTokenStorage($dm));
+$server->setRefreshTokenStorage(new Storage\RefreshTokenStorage($dm));
+$server->setClientStorage(new Storage\ClientStorage($dm));
+$server->setScopeStorage(new Storage\ScopeStorage($dm));
+$server->setAuthCodeStorage(new Storage\AuthCodeStorage($dm));
+
+$entityFactory = new EntityFactory($server);
+
+$authCodeGrant = new AuthCodeGrant($entityFactory);
+$server->addGrantType($authCodeGrant);
+
+$refrehTokenGrant = new RefreshTokenGrant($entityFactory);
+$server->addGrantType($refrehTokenGrant);
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+
+$router->get('/authorize', function (Request $request) use ($server) {
+
+    // First ensure the parameters in the query string are correct
+
+    try {
+        $authParams = $server->getGrantType('authorization_code')->checkAuthorizeParams();
+    } catch (Exception $e) {
+        return new Response(
+            json_encode([
+                'error'     =>  $e->errorType,
+                'message'   =>  $e->getMessage(),
+            ]),
+            $e->httpStatusCode,
+            $e->getHttpHeaders()
+        );
+    }
+
+    // Normally at this point you would show the user a sign-in screen and ask them to authorize the requested scopes
+
+    // ...
+
+    // ...
+
+    // ...
+
+    // Create a new authorize request which will respond with a redirect URI that the user will be redirected to
+
+    $redirectUri = $server->getGrantType('authorization_code')->newAuthorizeRequest('user', 1, $authParams);
+
+    $response = new Response('', 200, [
+        'Location'  =>  $redirectUri
+    ]);
+
+    return $response;
+});
+
+$router->post('/access_token', function (Request $request) use ($server) {
+
+    try {
+        $response = $server->issueAccessToken();
+
+        return new Response(json_encode($response), 200);
+    } catch (Exception $e) {
+        return new Response(
+            json_encode([
+                'error'     =>  $e->errorType,
+                'message'   =>  $e->getMessage(),
+            ]),
+            $e->httpStatusCode,
+            $e->getHttpHeaders()
+        );
+    }
+
+});
+
+$dispatcher = $router->getDispatcher();
+
+try {
+    // A successful response
+    $response = $dispatcher->dispatch(
+        $request->getMethod(),
+        $request->getPathInfo()
+    );
+} catch (\Orno\Http\Exception $e) {
+    // A failed response
+    $response = $e->getJsonResponse();
+    $response->setContent(json_encode(['status_code' => $e->getStatusCode(), 'message' => $e->getMessage()]));
+} catch (OAuthException $e) {
+    $response = new Response(json_encode([
+        'error'     =>  $e->errorType,
+        'message'   =>  $e->getMessage(),
+    ]), $e->httpStatusCode);
+
+    foreach ($e->getHttpHeaders() as $header) {
+        $response->headers($header);
+    }
+} catch (Exception $e) {
+    $response = new Orno\Http\Response();
+    $response->setStatusCode(500);
+    $response->setContent(json_encode(['status_code' => 500, 'message' => $e->getMessage()]));
+} finally {
+    // Return the response
+    $response->headers->set('Content-type', 'application/json');
+    $response->send();
+}

--- a/examples/mongodb/composer.json
+++ b/examples/mongodb/composer.json
@@ -3,7 +3,7 @@
         "orno/route": "1.*",
         "ircmaxell/password-compat": "1.0.2",
         "league/event": "0.2.0",
-		"doctrine/mongodb-odm": "1.0.0-BETA11"
+        "doctrine/mongodb-odm": "1.0.0-BETA11"
     },
     "autoload": {
         "psr-4": {

--- a/examples/mongodb/composer.json
+++ b/examples/mongodb/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "orno/route": "1.*",
+        "ircmaxell/password-compat": "1.0.2",
+        "league/event": "0.2.0",
+		"doctrine/mongodb-odm": "1.0.0-BETA11"
+    },
+    "autoload": {
+        "psr-4": {
+            "League\\OAuth2\\Server\\": "../../src/",
+            "MongoDBExample\\": "."
+        },
+        "files": [
+            "config/mongodb.php"
+        ]
+    }
+}

--- a/examples/mongodb/config/mongodb.php
+++ b/examples/mongodb/config/mongodb.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace MongoDBExample\Config;
+
+use Doctrine\MongoDB\Connection;
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+
+class DM {
+
+	private static $dm;
+
+	public static function get() {
+		
+		if(!self::$dm) {
+			if ( ! file_exists($file = dirname(__DIR__).'/vendor/autoload.php')) {
+				throw new RuntimeException('Install dependencies to run this script.');
+			}
+
+			$connection = new Connection();
+
+			$config = new Configuration();
+			$config->setProxyDir(dirname(__DIR__) . '/Proxies');
+			$config->setProxyNamespace('Proxies');
+			$config->setHydratorDir(dirname(__DIR__) . '/Hydrators');
+			$config->setHydratorNamespace('Hydrators');
+			$config->setDefaultDB('oauth2');
+			$config->setMetadataDriverImpl(AnnotationDriver::create(dirname(__DIR__) . '/Documents'));
+
+			AnnotationDriver::registerAnnotationClasses();
+
+			self::$dm = DocumentManager::create($connection, $config);
+		}
+		
+		return self::$dm;
+	}
+
+}

--- a/examples/mongodb/config/mongodb.php
+++ b/examples/mongodb/config/mongodb.php
@@ -9,31 +9,31 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 
 class DM {
 
-	private static $dm;
+    private static $dm;
 
-	public static function get() {
-		
-		if(!self::$dm) {
-			if ( ! file_exists($file = dirname(__DIR__).'/vendor/autoload.php')) {
-				throw new RuntimeException('Install dependencies to run this script.');
-			}
+    public static function get() {
 
-			$connection = new Connection();
+        if(!self::$dm) {
+            if ( ! file_exists($file = dirname(__DIR__).'/vendor/autoload.php')) {
+                throw new RuntimeException('Install dependencies to run this script.');
+            }
 
-			$config = new Configuration();
-			$config->setProxyDir(dirname(__DIR__) . '/Proxies');
-			$config->setProxyNamespace('Proxies');
-			$config->setHydratorDir(dirname(__DIR__) . '/Hydrators');
-			$config->setHydratorNamespace('Hydrators');
-			$config->setDefaultDB('oauth2');
-			$config->setMetadataDriverImpl(AnnotationDriver::create(dirname(__DIR__) . '/Documents'));
+            $connection = new Connection();
 
-			AnnotationDriver::registerAnnotationClasses();
+            $config = new Configuration();
+            $config->setProxyDir(dirname(__DIR__) . '/Proxies');
+            $config->setProxyNamespace('Proxies');
+            $config->setHydratorDir(dirname(__DIR__) . '/Hydrators');
+            $config->setHydratorNamespace('Hydrators');
+            $config->setDefaultDB('oauth2');
+            $config->setMetadataDriverImpl(AnnotationDriver::create(dirname(__DIR__) . '/Documents'));
 
-			self::$dm = DocumentManager::create($connection, $config);
-		}
-		
-		return self::$dm;
-	}
+            AnnotationDriver::registerAnnotationClasses();
+
+            self::$dm = DocumentManager::create($connection, $config);
+        }
+
+        return self::$dm;
+    }
 
 }

--- a/examples/mongodb/config/mongodb.php
+++ b/examples/mongodb/config/mongodb.php
@@ -7,10 +7,18 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 
+/**
+ * Doctrine DocumentManager for MongoDB
+ */
 class DM {
-
+    /**
+     * @var \Doctrine\ODM\MongoDB\DocumentManager
+     */
     private static $dm;
 
+    /**
+     * get a DocumentManager instance
+     */
     public static function get() {
 
         if(!self::$dm) {
@@ -35,5 +43,4 @@ class DM {
 
         return self::$dm;
     }
-
 }

--- a/examples/mongodb/curl_requests.txt
+++ b/examples/mongodb/curl_requests.txt
@@ -1,0 +1,17 @@
+// REQUEST AN ACCESS TOKEN WITH PASSWORD GRANT
+curl -v --data "grant_type=password&username=test&password=cmd" -u "cmdline:curl" http://localhost/oauth2-server/examples/mongodb/other_grants.php/access_token
+
+// GET INFO ABOUT ACCESS TOKEN
+curl -v http://localhost/oauth2-server/examples/mongodb/api.php/tokeninfo?access_token=66ESv4khgIb7dRoa09aZ48V9QRS2XWbBHE8nu4Ua
+
+// GET ALL USERS
+curl -v http://localhost/oauth2-server/examples/mongodb/api.php/users?access_token=p0fPrJKPITj8Ee3NDOYJNsgEWBaOFsBw6GxBp6Oc
+
+// GET A USER
+curl -v http://localhost/oauth2-server/examples/mongodb/api.php/users/test?access_token=p0fPrJKPITj8Ee3NDOYJNsgEWBaOFsBw6GxBp6Oc
+
+// REQUEST AN AUTH CODE
+curl -v "http://localhost/oauth2-server/examples/mongodb/authcode_grant.php/authorize?client_id=cmdline&redirect_uri=/users&response_type=code"
+
+// REQUEST ACCESS TOKEN WITH AUTHORIZATION CODE GRANT
+curl -v -d "grant_type=authorization_code&redirect_uri=/users&code=HcYiSELHVl1v9BXX5r0WQ0Tf4atmEpNj4i8UDywe" -u "cmdline:curl" "http://localhost/oauth2-server/examples/mongodb/authcode_grant.php/access_token"

--- a/examples/mongodb/other_grants.php
+++ b/examples/mongodb/other_grants.php
@@ -1,0 +1,102 @@
+<?php
+
+use League\OAuth2\Server\Entity\EntityFactory;
+use Orno\Http\Request;
+use Orno\Http\Response;
+use MongoDBExample\Document;
+use MongoDBExample\Storage;
+
+include __DIR__.'/vendor/autoload.php';
+
+$dm = MongoDBExample\Config\DM::get();
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+$router->setStrategy(\Orno\Route\RouteStrategyInterface::RESTFUL_STRATEGY);
+
+// Set up the OAuth 2.0 authorization server
+$server = new \League\OAuth2\Server\AuthorizationServer();
+$server->setSessionStorage(new Storage\SessionStorage($dm));
+$server->setAccessTokenStorage(new Storage\AccessTokenStorage($dm));
+$server->setRefreshTokenStorage(new Storage\RefreshTokenStorage($dm));
+$server->setClientStorage(new Storage\ClientStorage($dm));
+$server->setScopeStorage(new Storage\ScopeStorage($dm));
+$server->setAuthCodeStorage(new Storage\AuthCodeStorage($dm));
+
+$entityFactory = new EntityFactory($server);
+
+$clientCredentials = new \League\OAuth2\Server\Grant\ClientCredentialsGrant($entityFactory);
+$server->addGrantType($clientCredentials);
+
+$passwordGrant = new \League\OAuth2\Server\Grant\PasswordGrant($entityFactory);
+$passwordGrant->setVerifyCredentialsCallback(function ($username, $password) use($dm) {
+
+	$User = $dm->getRepository("MongoDBExample\Document\User")->find($username);
+	if(!$User)
+		return false;
+		
+	if (password_verify($password, $User->Password)) {
+        return $username;
+    }
+
+    return false;
+});
+$server->addGrantType($passwordGrant);
+
+$refrehTokenGrant = new \League\OAuth2\Server\Grant\RefreshTokenGrant($entityFactory);
+$server->addGrantType($refrehTokenGrant);
+
+// Routing setup
+$request = (new Request())->createFromGlobals();
+$router = new \Orno\Route\RouteCollection();
+
+$router->post('/access_token', function (Request $request) use ($server) {
+
+    try {
+        $response = $server->issueAccessToken();
+
+        return new Response(json_encode($response), 200);
+    } catch (Exception $e) {
+        return new Response(
+            json_encode([
+                'error'     =>  $e->errorType,
+                'message'   =>  $e->getMessage(),
+            ]),
+            $e->httpStatusCode,
+            $e->getHttpHeaders()
+        );
+    }
+
+});
+
+$dispatcher = $router->getDispatcher();
+
+try {
+    // A successful response
+    $response = $dispatcher->dispatch(
+        $request->getMethod(),
+        $request->getPathInfo()
+    );
+} catch (\Orno\Http\Exception $e) {
+    // A failed response
+    $response = $e->getJsonResponse();
+    $response->setContent(json_encode(['status_code' => $e->getStatusCode(), 'message' => $e->getMessage()]));
+} catch (\League\OAuth2\Server\Exception\OAuthException $e) {
+    $response = new Response(json_encode([
+        'error'     =>  $e->errorType,
+        'message'   =>  $e->getMessage(),
+    ]), $e->httpStatusCode);
+
+    foreach ($e->getHttpHeaders() as $header) {
+        $response->headers($header);
+    }
+} catch (Exception $e) {
+    $response = new Orno\Http\Response();
+    $response->setStatusCode(500);
+    $response->setContent(json_encode(['status_code' => 500, 'message' => $e->getMessage()]));
+} finally {
+    // Return the response
+    $response->headers->set('Content-type', 'application/json');
+    $response->send();
+}

--- a/examples/mongodb/other_grants.php
+++ b/examples/mongodb/other_grants.php
@@ -32,11 +32,11 @@ $server->addGrantType($clientCredentials);
 $passwordGrant = new \League\OAuth2\Server\Grant\PasswordGrant($entityFactory);
 $passwordGrant->setVerifyCredentialsCallback(function ($username, $password) use($dm) {
 
-	$User = $dm->getRepository("MongoDBExample\Document\User")->find($username);
-	if(!$User)
-		return false;
-		
-	if (password_verify($password, $User->Password)) {
+    $User = $dm->getRepository("MongoDBExample\Document\User")->find($username);
+    if(!$User)
+        return false;
+        
+    if (password_verify($password, $User->Password)) {
         return $username;
     }
 

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -50,21 +50,21 @@ class RefreshTokenGrant extends AbstractGrant
         $this->entityFactory = $entityFactory;
     }
 
-	/**
+    /**
      * {@inheritdoc}
      */
     public function setAuthorizationServer(AuthorizationServer $server)
     {
         parent::setAuthorizationServer($server);
-		
-		// Attach to the event emitter so that refresh tokens will automatically be created
-		$RTClass = $this;
-		$this->server->addEventListener('oauth.accesstoken.created', function(Event $event, AccessTokenInterface $accessToken, GrantTypeInterface $grant) use($RTClass) {
-			$RTClass->accessTokenCreated($event, $accessToken, $grant);
-		});
+
+        // Attach to the event emitter so that refresh tokens will automatically be created
+        $RTClass = $this;
+        $this->server->addEventListener('oauth.accesstoken.created', function(Event $event, AccessTokenInterface $accessToken, GrantTypeInterface $grant) use($RTClass) {
+            $RTClass->accessTokenCreated($event, $accessToken, $grant);
+        });
         return $this;
     }
-	
+
     /**
      * When an access token is created also create a refresh token (as appropriate)
      * @param \League\Event\Event                               $event
@@ -73,7 +73,7 @@ class RefreshTokenGrant extends AbstractGrant
      */
     public function accessTokenCreated(Event $event, AccessTokenInterface $accessToken, GrantTypeInterface $grant)
     {
-		// Refresh tokens are only supported for certain grant types
+        // Refresh tokens are only supported for certain grant types
         if (in_array($grant->getIdentifier(), ['authorization_code', 'password']) === false) {
             return;
         }

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -12,6 +12,7 @@
 namespace League\OAuth2\Server;
 
 use League\OAuth2\Server\Entity\AccessTokenEntity;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
 use League\OAuth2\Server\Storage\AccessTokenInterface;
 use League\OAuth2\Server\Storage\ClientInterface;
 use League\OAuth2\Server\Storage\ScopeInterface;
@@ -110,7 +111,7 @@ class ResourceServer extends AbstractServer
         $this->accessToken = $this->getAccessTokenStorage()->get($accessTokenString);
 
         // Ensure the access token exists
-        if (!$this->accessToken instanceof AccessTokenEntity) {
+        if (!$this->accessToken instanceof AccessTokenEntityInterface) {
             throw new Exception\AccessDeniedException();
         }
 

--- a/src/Storage/ClientInterface.php
+++ b/src/Storage/ClientInterface.php
@@ -11,7 +11,7 @@
 
 namespace League\OAuth2\Server\Storage;
 
-use League\OAuth2\Server\Entity\SessionInterface;
+use League\OAuth2\Server\Entity\SessionInterface as SessionEntityInterface;
 
 /**
  * Client storage interface
@@ -33,5 +33,5 @@ interface ClientInterface extends StorageInterface
      * @param  \League\OAuth2\Server\Entity\SessionInterface $session The session
      * @return \League\OAuth2\Server\Entity\ClientInterface
      */
-    public function getBySession(SessionInterface $session);
+    public function getBySession(SessionEntityInterface $session);
 }

--- a/src/Storage/MacTokenInterface.php
+++ b/src/Storage/MacTokenInterface.php
@@ -11,7 +11,7 @@
 
 namespace League\OAuth2\Server\Storage;
 
-use League\OAuth2\Server\Entity\AccessTokenInterface;
+use League\OAuth2\Server\Entity\AccessTokenInterface as AccessTokenEntityInterface;
 use League\OAuth2\Server\Entity\MacKeyInterface;
 
 /**
@@ -24,7 +24,7 @@ interface MacTokenInterface extends StorageInterface
      * @param string                                            $macKey
      * @param \League\OAuth2\Server\Entity\AccessTokenInterface $accessToken
      */
-    public function create($macKey, AccessTokenInterface $accessToken);
+    public function create($macKey, AccessTokenEntityInterface $accessToken);
 
     /**
      * Get a MAC key by access token


### PR DESCRIPTION
I've added an example using MongoDB with Doctrine ODM taken from a project i was working on. All Doctrine entities implement OAuth interfaces. I've fixed some issues: 
 - addEventListener on RefreshTokenGrant gives me that the object is not a callable with php 5.5.12
 - ResourceServer should check for AccessTokenEntityInterface
 - there is a conflict due to the same class name between entity interfaces and storage
interfaces in Storage\ClientInterface and Storage\MacTokenInterface

Hope this helps.