### PR TITLE
Associate Scopes to Session in AuthCode Grant.

### DIFF
--- a/src/Entity/SessionEntity.php
+++ b/src/Entity/SessionEntity.php
@@ -299,8 +299,15 @@ class SessionEntity
         );
 
         $this->setId($id);
+        $this->applyScopes();
+    }
 
-        // Associate the scope with the session
+    /**
+     * Apply any scope changes
+     *
+     * @return void
+     */
+    public function applyScopes() {
         foreach ($this->getScopes() as $scope) {
             $this->server->getSessionStorage()->associateScope($this, $scope);
         }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -263,6 +263,8 @@ class AuthCodeGrant extends AbstractGrant
         $accessToken->setSession($session);
         $accessToken->save();
 
+        $session->applyScopes();
+
         if (isset($refreshToken) && $this->server->hasGrantType('refresh_token')) {
             $refreshToken->setAccessToken($accessToken);
             $refreshToken->save();


### PR DESCRIPTION
Scopes assigned to the $session for AuthCode grant completeFlow() are never actually triggering a write in the StorageContainer.

associateScope() only adds the scope into the scopes array.  Through the AuthCode complete, we never call save() on the $session.  Save would be wrong as well, since it's a wrapper for create, not update.  So new method is needed to correctly issue a write to the Storage to associate the scope to the session.