### PR TITLE
Remove ambiguity in implementation of resource and authorization servers

### DIFF
--- a/implementing-storage-classes.md
+++ b/implementing-storage-classes.md
@@ -8,14 +8,7 @@ permalink: /implementing-storage-interfaces/
 
 In order to use both the resource server and authorization server you need need to implement a number of interfaces.
 
-If you are using the resource server you need to implement the following interfaces:
-
-* `League\OAuth2\Server\Storage\SessionInterface` - contains methods for retrieving and setting sessions
-* `League\OAuth2\Server\Storage\AccessTokenInterface` - contains methods for retrieving, creating and deleting access tokens
-* `League\OAuth2\Server\Storage\ClientStorage` - single method to get a client
-* `League\OAuth2\Server\Storage\ScopeStorage` - single method to get a scope
-
-If you are using the authorization server you need to implement the following interfaces:
+Both the Resource and Authorization servers require the implementation of the following interfaces:
 
 * `League\OAuth2\Server\Storage\SessionInterface` - contains methods for retrieving and setting sessions
 * `League\OAuth2\Server\Storage\AccessTokenInterface` - contains methods for retrieving, creating and deleting access tokens


### PR DESCRIPTION
Both require that the same interfaces be implemented, and thus there is no reason to have a sections for each.