### PR TITLE
Fixing server's exception always having `0` returned as exception code.

### DIFF
--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -43,7 +43,7 @@ class OAuthException extends \Exception
      */
     public function __construct($msg = 'An error occured')
     {
-        parent::__construct($msg);
+        parent::__construct($msg, $this->httpStatusCode);
     }
 
     /**


### PR DESCRIPTION
#325 

Fixing server's exception always having `0` in code returned.

Before:
![screen shot 2015-04-08 at 12 03 20 pm](https://cloud.githubusercontent.com/assets/150876/7049422/6473bec2-dde7-11e4-960d-dab9f7f92bbc.png)

After:
![screen shot 2015-04-08 at 12 03 46 pm](https://cloud.githubusercontent.com/assets/150876/7049429/6bf3feaa-dde7-11e4-8ecb-b8a75e84898f.png)

`phpunit`
![screen shot 2015-04-08 at 12 07 40 pm](https://cloud.githubusercontent.com/assets/150876/7049482/ed182470-dde7-11e4-849c-32242f7af69e.png)

Thanks.