### PR TITLE
New Invalid Token exception.

### DIFF
--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * OAuth 2.0 Invalid Token Exception
+ *
+ * @package     league/oauth2-server
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Exception;
+
+/**
+ * Exception class
+ */
+class InvalidTokenException extends OAuthException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public $httpStatusCode = 401;
+
+    /**
+     * {@inheritdoc}
+     */
+    public $errorType = 'invalid_token';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct()
+    {
+        parent::__construct('The access token provided is expired, revoked, malformed, or invalid for other reasons.');
+    }
+}

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -114,13 +114,13 @@ class ResourceServer extends AbstractServer
 
         // Ensure the access token exists
         if (!$this->accessToken instanceof AccessTokenEntity) {
-            throw new AccessDeniedException();
+            throw new InvalidTokenException();
         }
 
         // Check the access token hasn't expired
         // Ensure the auth code hasn't expired
         if ($this->accessToken->isExpired() === true) {
-            throw new AccessDeniedException();
+            throw new InvalidTokenException();
         }
 
         return true;


### PR DESCRIPTION
Adding **invalid_token** error type. I think that it missing in v4 too, but I don't know if it's dangerous for existings apps over v4.

https://tools.ietf.org/html/rfc6750#section-3.1
https://tools.ietf.org/html/rfc6750#section-6.2.2