### PR TITLE
Expose parameter passed to exceptions

### DIFF
--- a/src/Exception/InvalidGrantException.php
+++ b/src/Exception/InvalidGrantException.php
@@ -32,6 +32,7 @@ class InvalidGrantException extends OAuthException
 
     public function __construct($parameter)
     {
+        $this->parameter = parameter;
         parent::__construct(
             sprintf(
                 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. Check the "%s" parameter.',

--- a/src/Exception/InvalidGrantException.php
+++ b/src/Exception/InvalidGrantException.php
@@ -32,7 +32,7 @@ class InvalidGrantException extends OAuthException
 
     public function __construct($parameter)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         parent::__construct(
             sprintf(
                 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client. Check the "%s" parameter.',

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -32,6 +32,7 @@ class InvalidRequestException extends OAuthException
 
     public function __construct($parameter, $redirectUri = null)
     {
+        $this->parameter = parameter;
         parent::__construct(
             sprintf(
                 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Check the "%s" parameter.',

--- a/src/Exception/InvalidRequestException.php
+++ b/src/Exception/InvalidRequestException.php
@@ -32,7 +32,7 @@ class InvalidRequestException extends OAuthException
 
     public function __construct($parameter, $redirectUri = null)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         parent::__construct(
             sprintf(
                 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Check the "%s" parameter.',

--- a/src/Exception/InvalidScopeException.php
+++ b/src/Exception/InvalidScopeException.php
@@ -32,6 +32,7 @@ class InvalidScopeException extends OAuthException
 
     public function __construct($parameter, $redirectUri = null)
     {
+        $this->parameter = parameter;
         parent::__construct(
             sprintf(
                 'The requested scope is invalid, unknown, or malformed. Check the "%s" scope.',

--- a/src/Exception/InvalidScopeException.php
+++ b/src/Exception/InvalidScopeException.php
@@ -32,7 +32,7 @@ class InvalidScopeException extends OAuthException
 
     public function __construct($parameter, $redirectUri = null)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         parent::__construct(
             sprintf(
                 'The requested scope is invalid, unknown, or malformed. Check the "%s" scope.',

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -37,6 +37,11 @@ class OAuthException extends \Exception
     public $errorType = '';
 
     /**
+     * Parameter eventually passed to Exception
+     */
+    public $parameter = '';
+
+    /**
      * Throw a new exception
      *
      * @param string $msg Exception Message
@@ -70,6 +75,16 @@ class OAuthException extends \Exception
                 'message' =>  $this->getMessage(),
             ]
         );
+    }
+
+    /**
+     * Return parameter if set
+     *
+     * @return string
+     */
+    public function getParameter()
+    {
+        return $this->redirectUri;
     }
 
     /**

--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -84,7 +84,7 @@ class OAuthException extends \Exception
      */
     public function getParameter()
     {
-        return $this->redirectUri;
+        return $this->parameter;
     }
 
     /**

--- a/src/Exception/ServerErrorException.php
+++ b/src/Exception/ServerErrorException.php
@@ -31,7 +31,9 @@ class ServerErrorException extends OAuthException
      */
     public function __construct($parameter = null)
     {
+        $this->parameter = parameter;
         $parameter = is_null($parameter) ? 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.' : $parameter;
         parent::__construct($parameter);
+
     }
 }

--- a/src/Exception/ServerErrorException.php
+++ b/src/Exception/ServerErrorException.php
@@ -31,7 +31,7 @@ class ServerErrorException extends OAuthException
      */
     public function __construct($parameter = null)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         $parameter = is_null($parameter) ? 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.' : $parameter;
         parent::__construct($parameter);
 

--- a/src/Exception/UnsupportedGrantTypeException.php
+++ b/src/Exception/UnsupportedGrantTypeException.php
@@ -32,6 +32,7 @@ class UnsupportedGrantTypeException extends OAuthException
 
     public function __construct($parameter)
     {
+        $this->parameter = parameter;
         parent::__construct(
             sprintf(
                 'The authorization grant type "%s" is not supported by the authorization server.',

--- a/src/Exception/UnsupportedGrantTypeException.php
+++ b/src/Exception/UnsupportedGrantTypeException.php
@@ -32,7 +32,7 @@ class UnsupportedGrantTypeException extends OAuthException
 
     public function __construct($parameter)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         parent::__construct(
             sprintf(
                 'The authorization grant type "%s" is not supported by the authorization server.',

--- a/src/Exception/UnsupportedResponseTypeException.php
+++ b/src/Exception/UnsupportedResponseTypeException.php
@@ -31,6 +31,7 @@ class UnsupportedResponseTypeException extends OAuthException
      */
     public function __construct($parameter, $redirectUri = null)
     {
+        $this->parameter = parameter;
         parent::__construct('The authorization server does not support obtaining an access token using this method.');
         $this->redirectUri = $redirectUri;
     }

--- a/src/Exception/UnsupportedResponseTypeException.php
+++ b/src/Exception/UnsupportedResponseTypeException.php
@@ -31,7 +31,7 @@ class UnsupportedResponseTypeException extends OAuthException
      */
     public function __construct($parameter, $redirectUri = null)
     {
-        $this->parameter = parameter;
+        $this->parameter = $parameter;
         parent::__construct('The authorization server does not support obtaining an access token using this method.');
         $this->redirectUri = $redirectUri;
     }


### PR DESCRIPTION
When catching oauth-server exception you sometimes need to be able to get the parameter used to generate the exception message. (Examples: internationalization)