### PR TITLE
Patch for auth code client id check.

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -227,8 +227,11 @@ class AuthCodeGrant extends AbstractGrant
             throw new Exception\InvalidRequestException('redirect_uri');
         }
 
+        // Check client ID presented matches client ID originally used in authorize request
         $session = $code->getSession();
-        $session->associateClient($client);
+        if ($session->getClient()->getId() !== $client->getId()) {
+            throw new Exception\InvalidRequestException('code');
+        }
 
         $authCodeScopes = $code->getScopes();
 


### PR DESCRIPTION
* add check for client id against the client id of the auth code's owner
* remove client session association (should be associated).

Access token requests's client ID wasn't being checked against the
original client ID of the auth code.  I've added this check.  I don't
think the old session association did anything useful.

http://tools.ietf.org/html/rfc6749#section-4.1.3
> ensure that the authorization code was issued to the authenticated
> confidential client, or if the client is public, ensure that the
> code was issued to "client_id" in the request,

