### PR TITLE
Fix bug: hash_hmac() should output raw binary data, not hexits

### DIFF
--- a/src/TokenType/MAC.php
+++ b/src/TokenType/MAC.php
@@ -114,7 +114,14 @@ class MAC extends AbstractTokenType implements TokenTypeInterface
             $calculatedSignatureParts[] = $params->get('ext');
         }
 
-        $calculatedSignature = base64_encode(hash_hmac('sha256', implode("\n", $calculatedSignatureParts), $macKey));
+        $calculatedSignature = base64_encode(
+            hash_hmac(
+                'sha256',
+                implode("\n", $calculatedSignatureParts),
+                $macKey,
+                true  // raw_output: outputs raw binary data
+            )
+        );
 
         // Return the access token if the signature matches
         return ($this->hash_equals($calculatedSignature, $signature)) ? $accessToken : null;

--- a/tests/unit/TokenType/MacTest.php
+++ b/tests/unit/TokenType/MacTest.php
@@ -57,7 +57,7 @@ class MacTest extends \PHPUnit_Framework_TestCase
             $request->getPort(),
             'ext'
         ];
-        $calculatedSignature = base64_encode(hash_hmac('sha256', implode("\n", $calculatedSignatureParts), 'abcdef'));
+        $calculatedSignature = base64_encode(hash_hmac('sha256', implode("\n", $calculatedSignatureParts), 'abcdef', true));
 
         $request->headers->set('Authorization',  sprintf('MAC id="foo", nonce="foo", ts="%s", mac="%s", ext="ext"', $ts, $calculatedSignature));
 


### PR DESCRIPTION
This is a bug fix for the [`determineAccessTokenInHeader()`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L45) method in the [`TokenType\MAC`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php) class.

Here is the current code:

```php
$calculatedSignature = base64_encode(hash_hmac('sha256', implode("\n", $calculatedSignatureParts), $macKey));
```

`hash_hmac()` is returning lowercase hexits, eg:

```php
'f491e2fd76a48be0f2b7cc82cdca948bd907fcb64ce957db522e4a40e2a57d3b'
```

which are then being passed to `base64_encode()`, eg:

```php
$calculatedSignature = base64_encode('f491e2fd76a48be0f2b7cc82cdca948bd907fcb64ce957db522e4a40e2a57d3b');
```

From the [OAuth 2.0 Message Authentication Code (MAC) Tokens](https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-05) draft spec, [section 5.3.2](https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-05#section-5.3.2):

> "hmac-sha-256" uses the HMAC algorithm, as defined in [RFC2104](https://tools.ietf.org/html/rfc2104)
>
> `mac` is used to set the value of the "mac" attribute, after the result string is base64-encoded

:x: Neither the draft spec nor RFC2104 mention anything about formatting the HMAC hash as **hexits** before Base64-encoding.

RFC2104 indicates that the output of the HMAC algorithm is a **binary string**.

So the raw bytes returned by the HMAC algorithm need to be Base64-encoded.

:white_check_mark: This can be done by setting the `raw_output` parameter of [`hash_hmac()`](http://php.net/hash_hmac) to `true`, so that the function outputs raw binary data instead of lowercase hexits.

See this article: ["Examples of creating base64 hashes using HMAC SHA256 in different languages"](http://www.jokecamp.com/blog/examples-of-creating-base64-hashes-using-hmac-sha256-in-different-languages/#php):

```php
$s = hash_hmac('sha256', 'Message', 'secret', true);
echo base64_encode($s);
```

Also see [this example](https://github.com/tuxis-ie/nsedit/blob/9d47229fe7086be7aaa5d1010f93ae38c71a4d40/includes/session.inc.php#L38) from a different project:

```php
$csrf_token = base64_encode(hash_hmac('sha256', $userinfo, $csrf_hmac_secret, true));
```
