### PR TITLE
Fix bug: regex doesn't match all Base64 characters

### DIFF
--- a/src/TokenType/MAC.php
+++ b/src/TokenType/MAC.php
@@ -61,7 +61,7 @@ class MAC extends AbstractTokenType implements TokenTypeInterface
         array_map(function ($param) use (&$params) {
             $param = trim($param);
 
-            preg_match_all('/([a-zA-Z]*)="([\w=]*)"/', $param, $matches);
+            preg_match_all('/([a-zA-Z]*)="([\w=\/+]*)"/', $param, $matches);
 
             // @codeCoverageIgnoreStart
             if (count($matches) !== 3) {


### PR DESCRIPTION
This is a bug fix for the [`determineAccessTokenInHeader()`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L45) method in the [`TokenType\MAC`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php) class.

Here is the relevant code:

```php
array_map(function ($param) use (&$params) {
    $param = trim($param);

    preg_match_all('/([a-zA-Z]*)="([\w=]*)"/', $param, $matches);
    ...
```

:x: There is a bug in [the regex](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L64):

```
/([a-zA-Z]*)="([\w=]*)"/
```

![Visualisation by Debuggex](https://www.debuggex.com/i/8yAe3FvQ9NAjcXkj.png)
([Visualisation by Debuggex](https://www.debuggex.com/r/8yAe3FvQ9NAjcXkj))

It should be able to match:

```
mac="9JHi/Xaki+Dyt8yCzcqUi9kH/LZM6VfbUi5KQOKlfTs="
```

where the quoted value is a Base64-encoded HMAC hash.

:x: Currently, the regex doesn't match `/` or `+`, which are valid characters in [the Base64 alphabet](https://tools.ietf.org/html/rfc4648#section-4).

When the regex fails to match, then [`$params->has('mac')`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L83) returns `false`, and so the `determineAccessTokenInHeader()` method [returns prematurely](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L84).

:white_check_mark: Here's a correct regex:

```
/([a-zA-Z]*)="([\w=\/+]*)"/
```

![Visualisation by Debuggex](https://www.debuggex.com/i/_h9dYDSmCJLuicfJ.png)
([Visualisation by Debuggex](https://www.debuggex.com/r/_h9dYDSmCJLuicfJ))
