### PR TITLE
Fix bug: incorrect signature parameter

### DIFF
--- a/src/TokenType/MAC.php
+++ b/src/TokenType/MAC.php
@@ -105,7 +105,7 @@ class MAC extends AbstractTokenType implements TokenTypeInterface
             $timestamp,
             $nonce,
             strtoupper($request->getMethod()),
-            $request->getUri(),
+            $request->getRequestUri(),
             $request->getHost(),
             $request->getPort(),
         ];

--- a/tests/unit/TokenType/MacTest.php
+++ b/tests/unit/TokenType/MacTest.php
@@ -52,7 +52,7 @@ class MacTest extends \PHPUnit_Framework_TestCase
             $ts,
             'foo',
             strtoupper($request->getMethod()),
-            $request->getUri(),
+            $request->getRequestUri(),
             $request->getHost(),
             $request->getPort(),
             'ext'


### PR DESCRIPTION
This is a bug fix for the [`determineAccessTokenInHeader()`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php#L45) method in the [`TokenType\MAC`](https://github.com/thephpleague/oauth2-server/blob/2496653968c3373c30f28db02e5a9e8ede079a97/src/TokenType/MAC.php) class.

Here is the relevant code:

```php
$calculatedSignatureParts = [
    $timestamp,
    $nonce,
    strtoupper($request->getMethod()),
    $request->getUri(),
    $request->getHost(),
    $request->getPort(),
];
```

The [library documentation](http://oauth2.thephpleague.com/token-types/#mac-tokens) states that the 4th signature parameter must be:

> The full HTTP request URI (as specified in [RFC2616](https://tools.ietf.org/html/rfc2616) section [5.1.2](https://tools.ietf.org/html/rfc2616#section-5.1.2))

The [`getUri()`](https://github.com/symfony/HttpFoundation/blob/v2.7.3/Request.php#L1132) method belongs to the [`Symfony\Component\HttpFoundation\Request`](https://github.com/symfony/HttpFoundation/blob/v2.7.3/Request.php) class.

There are 2 problems with using `getUri()`:

--

:x: **1.** It returns the Absolute URI (including the scheme and hostname), eg:

    http://test.dev/test?foo=1&bar=2

RFC2616 § 5.1.2 states that the Absolute URI should only be used for requests to proxies.

For requests to normal (origin) servers, the scheme and hostname must be omitted:

    /test?foo=1&bar=2

In PHP, this is available in [`$_SERVER['REQUEST_URI']`](http://php.net/reserved.variables.server).

(Also note that the hostname, `test.dev`, is already being sent in [the 5th signature parameter](http://oauth2.thephpleague.com/token-types/#mac-tokens).)

--

:x: **2.** It uses [`getQueryString()`](https://github.com/symfony/HttpFoundation/blob/v2.7.3/Request.php#L1220), which:

> builds a normalized query string, where keys/value pairs are alphabetized and have consistent escaping.

I don't think the query string should be normalised. There is no requirement for the client to normalise the query string before sending the request.

As an example of the problem, consider a client sending this request:

    http://test.dev/test?foo=1&bar=2

`getUri()` returns:

    http://test.dev/test?bar=2&foo=1

`foo` and `bar` have been rearranged into alphabetical order by `getQueryString()` within `getUri()`, and this breaks the signature.

--

:white_check_mark: The solution is to use [`getRequestUri()`](https://github.com/symfony/HttpFoundation/blob/v2.7.3/Request.php#L1101), which returns "the raw URI" (without the scheme and hostname, and without any normalisation):

    /test?foo=1&bar=2
