### PR TITLE
AuthCodeGrant and RefreshTokenGrant don't require client_secret

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -61,6 +61,14 @@ class AuthCodeGrant extends AbstractGrant
     protected $authTokenTTL = 600;
 
     /**
+     * Whether to require the client secret when
+     * completing the flow.
+     *
+     * @var boolean
+     */
+    protected $requireClientSecret = true;
+
+    /**
      * Override the default access token expire time
      *
      * @param int $authTokenTTL
@@ -70,6 +78,27 @@ class AuthCodeGrant extends AbstractGrant
     public function setAuthTokenTTL($authTokenTTL)
     {
         $this->authTokenTTL = $authTokenTTL;
+    }
+
+    /**
+     *
+     * @param bool $required True to require client secret during access
+     *                       token request. False if not. Default = true
+     */
+    public function setRequireClientSecret($required)
+    {
+        $this->requireClientSecret = $required;
+    }
+
+    /**
+     * True if client secret is required during
+     * access token request. False if it isn't.
+     *
+     * @return bool
+     */
+    public function shouldRequireClientSecret()
+    {
+        return $this->requireClientSecret;
     }
 
     /**
@@ -184,7 +213,7 @@ class AuthCodeGrant extends AbstractGrant
 
         $clientSecret = $this->server->getRequest()->request->get('client_secret',
             $this->server->getRequest()->getPassword());
-        if (is_null($clientSecret)) {
+        if ($this->shouldRequireClientSecret() && is_null($clientSecret)) {
             throw new Exception\InvalidRequestException('client_secret');
         }
 

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -43,6 +43,14 @@ class RefreshTokenGrant extends AbstractGrant
     protected $refreshTokenRotate = true;
 
     /**
+     * Whether to require the client secret when
+     * completing the flow.
+     *
+     * @var boolean
+     */
+    protected $requireClientSecret = true;
+
+    /**
      * Set the TTL of the refresh token
      *
      * @param int $refreshTokenTTL
@@ -84,6 +92,28 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
+     *
+     * @param bool $required True to require client secret during access
+     *                       token request. False if not. Default = true
+     */
+    public function setRequireClientSecret($required)
+    {
+        $this->requireClientSecret = $required;
+    }
+
+    /**
+     * True if client secret is required during
+     * access token request. False if it isn't.
+     *
+     * @return bool
+     */
+    public function shouldRequireClientSecret()
+    {
+        return $this->requireClientSecret;
+    }
+
+
+    /**
      * {@inheritdoc}
      */
     public function completeFlow()
@@ -95,7 +125,7 @@ class RefreshTokenGrant extends AbstractGrant
 
         $clientSecret = $this->server->getRequest()->request->get('client_secret',
             $this->server->getRequest()->getPassword());
-        if (is_null($clientSecret)) {
+        if ($this->shouldRequireClientSecret() && is_null($clientSecret)) {
             throw new Exception\InvalidRequestException('client_secret');
         }
 

--- a/tests/unit/Grant/RefreshTokenGrantTest.php
+++ b/tests/unit/Grant/RefreshTokenGrantTest.php
@@ -498,4 +498,73 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('expires_in', $response));
         $this->assertEquals($response['refresh_token'], $_POST['refresh_token']);
     }
+
+    public function testCompleteFlowShouldRequireClientSecret()
+    {
+        $_POST = [
+            'grant_type'    => 'refresh_token',
+            'client_id'     =>  'testapp',
+            'refresh_token' =>  'refresh_token',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new RefreshTokenGrant();
+        $grant->setRequireClientSecret(false);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+
+        $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
+        $sessionStorage->shouldReceive('setServer');
+        $sessionStorage->shouldReceive('getScopes')->shouldReceive('getScopes')->andReturn([]);
+        $sessionStorage->shouldReceive('associateScope');
+        $sessionStorage->shouldReceive('getByAccessToken')->andReturn(
+            (new SessionEntity($server))
+        );
+
+        $accessTokenStorage = M::mock('League\OAuth2\Server\Storage\AccessTokenInterface');
+        $accessTokenStorage->shouldReceive('setServer');
+        $accessTokenStorage->shouldReceive('get')->andReturn(
+            (new AccessTokenEntity($server))
+        );
+        $accessTokenStorage->shouldReceive('delete');
+        $accessTokenStorage->shouldReceive('create');
+        $accessTokenStorage->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $accessTokenStorage->shouldReceive('associateScope');
+
+        $refreshTokenStorage = M::mock('League\OAuth2\Server\Storage\RefreshTokenInterface');
+        $refreshTokenStorage->shouldReceive('setServer');
+        $refreshTokenStorage->shouldReceive('associateScope');
+        $refreshTokenStorage->shouldReceive('delete');
+        $refreshTokenStorage->shouldReceive('create');
+        $refreshTokenStorage->shouldReceive('get')->andReturn(
+            (new RefreshTokenEntity($server))->setId('refresh_token')->setExpireTime(time() + 86400)
+        );
+
+        $scopeStorage = M::mock('League\OAuth2\Server\Storage\ScopeInterface');
+        $scopeStorage->shouldReceive('setServer');
+        $scopeStorage->shouldReceive('get')->andReturn(
+            (new ScopeEntity($server))->hydrate(['id' => 'foo'])
+        );
+
+        $server->setClientStorage($clientStorage);
+        $server->setScopeStorage($scopeStorage);
+        $server->setSessionStorage($sessionStorage);
+        $server->setAccessTokenStorage($accessTokenStorage);
+        $server->setRefreshTokenStorage($refreshTokenStorage);
+
+        $server->addGrantType($grant);
+
+        $response = $server->issueAccessToken();
+        $this->assertTrue(array_key_exists('access_token', $response));
+        $this->assertTrue(array_key_exists('refresh_token', $response));
+        $this->assertTrue(array_key_exists('token_type', $response));
+        $this->assertTrue(array_key_exists('expires_in', $response));
+
+    }
 }


### PR DESCRIPTION
Hey,

I started to implement OAuth2 in my workplace using this library. We have a requirement to NOT store client secrets in native applications. The RFC suggests as much in section https://tools.ietf.org/html/rfc6749#section-2.1 where it says public clients are incapable of keeping their credentials secure. 

From my understanding, the spec allows client_ids to be created with no client_secret, which is our use case at the moment. 

I added a flag to the authcode grant and the refreshtoken grants to reflect this. It was a quick hack so why not?

This leads to maybe some confusion with `ClientInterface->get` because even if the passed in client_secret is null, the implementation should return null if the client_id does have a client_secret associated with it.

Well, let me know what you think. I plan on using this since this is my use case right now. I like that your library is flexible in some areas and actually has a MAC implementation. 