### PR TITLE
Documentation: fix typo in terminology.md

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -6,10 +6,10 @@ permalink: /terminology/
 
 # Terminology
 
-* `Access token` - A token used to access protected resources
+* `Access token` - A token used to access protected resources.
 * `Authorization code` - An intermediary token generated when a user authorizes a client to access protected resources on their behalf. The client receives this token and exchanges it for an access token.
 * `Authorization server` - A server which issues access tokens after successfully authenticating a client and resource owner, and authorizing the request.
-* `Client` - An application which accesses protected resources on behalf of the resource owner (such as a user).  The client could hosted on a server, desktop, mobile or other device.
+* `Client` - An application which accesses protected resources on behalf of the resource owner (such as a user).  The client could be hosted on a server, desktop, mobile or other device.
 * `Grant` - A grant is a method of acquiring an access token.
 * `Resource server` - A server which sits in front of protected resources (for example "tweets", users' photos, or personal data) and is capable of accepting and responsing to protected resource requests using access tokens.
-* `Scope` - A permission
+* `Scope` - A permission.


### PR DESCRIPTION
* missing word
* missing dots (for uniformity)