### PR TITLE
Fixed problem with empty Authorization header

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -140,7 +140,9 @@ class ResourceServer extends AbstractServer
     {
         if ($this->getRequest()->headers->get('Authorization') !== null) {
             $accessToken = $this->getTokenType()->determineAccessTokenInHeader($this->getRequest());
-        } elseif ($headerOnly === false && (! $this->getTokenType() instanceof MAC)) {
+        }
+
+        if (empty($accessToken) && $headerOnly === false && (! $this->getTokenType() instanceof MAC)) {
             $accessToken = ($this->getRequest()->server->get('REQUEST_METHOD') === 'GET')
                                 ? $this->getRequest()->query->get($this->tokenKey)
                                 : $this->getRequest()->request->get($this->tokenKey);


### PR DESCRIPTION
On my machine the variable `$_SERVER['HTTP_AUTHORIZATION']` is set to an empty string when no Authorization header is present. As a result the detection of access token does not work properly.

I don't really know why the `$_SERVER['HTTP_AUTHORIZATION']` is set to an empty string. I'm using Mac OS X with Apache 2.2 and PHP 5.6 installed using homebrew.