### PR TITLE
Remove client secret check for PasswordGrant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "saga64/oauth2-server",
+	"name": "league/oauth2-server",
 	"description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
 	"homepage": "http://oauth2.thephpleague.com/",
 	"license": "MIT",
@@ -12,6 +12,12 @@
 		"phpunit/phpunit": "4.3.*",
 		"mockery/mockery": "0.9.*"
 	},
+	"repositories": [
+		{
+			"type": "git",
+			"url": "https://github.com/thephpleague/oauth2-server.git"
+		}
+	],
 	"keywords": [
 		"oauth",
 		"oauth2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "league/oauth2-server",
+	"name": "saga64/oauth2-server",
 	"description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
 	"homepage": "http://oauth2.thephpleague.com/",
 	"license": "MIT",
@@ -12,12 +12,6 @@
 		"phpunit/phpunit": "4.3.*",
 		"mockery/mockery": "0.9.*"
 	},
-	"repositories": [
-		{
-			"type": "git",
-			"url": "https://github.com/thephpleague/oauth2-server.git"
-		}
-	],
 	"keywords": [
 		"oauth",
 		"oauth2",

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -95,16 +95,10 @@ class PasswordGrant extends AbstractGrant
             throw new Exception\InvalidRequestException('client_id');
         }
 
-        $clientSecret = $this->server->getRequest()->request->get('client_secret',
-            $this->server->getRequest()->getPassword());
-        if (is_null($clientSecret)) {
-            throw new Exception\InvalidRequestException('client_secret');
-        }
-
         // Validate client ID and client secret
         $client = $this->server->getClientStorage()->get(
             $clientId,
-            $clientSecret,
+            null,
             null,
             $this->getIdentifier()
         );

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -48,7 +48,7 @@ class RefreshTokenGrant extends AbstractGrant
      *
      * @var boolean
      */
-    protected $requireClientSecret = true;
+    protected $requireClientSecret = false;
 
     /**
      * Set the TTL of the refresh token

--- a/tests/unit/Grant/PasswordGrantTest.php
+++ b/tests/unit/Grant/PasswordGrantTest.php
@@ -25,22 +25,6 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $server->issueAccessToken();
     }
 
-    public function testCompleteFlowMissingClientSecret()
-    {
-        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
-
-        $_POST = [
-            'grant_type' => 'password',
-            'client_id' =>  'testapp',
-        ];
-
-        $server = new AuthorizationServer();
-        $grant = new PasswordGrant();
-
-        $server->addGrantType($grant);
-        $server->issueAccessToken();
-    }
-
     public function testCompleteFlowInvalidClient()
     {
         $this->setExpectedException('League\OAuth2\Server\Exception\InvalidClientException');

--- a/tests/unit/Grant/RefreshTokenGrantTest.php
+++ b/tests/unit/Grant/RefreshTokenGrantTest.php
@@ -49,6 +49,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $server = new AuthorizationServer();
         $grant = new RefreshTokenGrant();
 
+        $grant->setRequireClientSecret(true);
         $server->addGrantType($grant);
         $server->issueAccessToken();
     }


### PR DESCRIPTION
In terms of https://tools.ietf.org/html/rfc6749, since v2-16,
PasswordGrant and RefreshGrant are no longer require client secret validation
by default. Pleaseread section 4.3.1 and section 6.

This commit will remove client secret validation and remove the
correspond test.