### PR TITLE
Better www-authenticate headers inclusion

### DIFF
--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -60,7 +60,7 @@ class InvalidTokenException extends OAuthException
 
         switch ($authScheme) {
             case 'Bearer':
-                $headers[] = 'WWW-Authenticate: ' . $authScheme . 
+                $headers[] = 'WWW-Authenticate: ' . $authScheme . ' ' .
                     'error = "invalid_token", ' . 
                     'error_description="There is no access token present."';
             break;

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * OAuth 2.0 Base Exception
+ *
+ * @package     league/oauth2-server
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Exception;
+
+/**
+ * Exception class
+ */
+class InvalidTokenException extends OAuthException
+{
+    /**
+     * The HTTP status code for this exception that should be sent in the response
+     */
+    public $httpStatusCode = 401;
+
+    /**
+     * The exception type
+     */
+    public $errorType = 'invalid_token';
+
+    /**
+     * Throw a new exception
+     *
+     * @param string $msg Exception Message
+     */
+    public function __construct($msg = 'Invalid access token')
+    {
+        parent::__construct($msg);
+    }
+
+    /**
+     * Get all headers that have to be send with the error response
+     *
+     * @return array Array with header values
+     */
+
+    public function getHttpHeaders()
+    {
+        $headers = parent::getHttpHeaders();
+
+        // Add "WWW-Authenticate" header
+        //
+        // RFC 6749, section 5.2.:
+        // "If the client attempted to authenticate via the 'Authorization'
+        // request header field, the authorization server MUST
+        // respond with an HTTP 401 (Unauthorized) status code and
+        // include the "WWW-Authenticate" response header field
+        // matching the authentication scheme used by the client.
+        // @codeCoverageIgnoreStart
+
+        $authScheme = $this->determineAuthScheme();    
+
+        switch ($authScheme) {
+            case 'Bearer':
+                $headers[] = 'WWW-Authenticate: ' . $authScheme . 
+                    'error = "invalid_token", ' . 
+                    'error_description="There is no access token present."';
+            break;
+        }
+
+        // @codeCoverageIgnoreEnd
+        
+        return $headers;
+    }
+
+}

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -62,7 +62,7 @@ class InvalidTokenException extends OAuthException
             case 'Bearer':
                 $headers[] = 'WWW-Authenticate: ' . $authScheme . ' ' .
                     'error = "invalid_token", ' . 
-                    'error_description="There is no access token present."';
+                    'error_description="Token is expired, invalid, malformed, or just bad."';
             break;
         }
 

--- a/src/Exception/NoTokenException.php
+++ b/src/Exception/NoTokenException.php
@@ -19,7 +19,7 @@ class NoTokenException extends OAuthException
     /**
      * The HTTP status code for this exception that should be sent in the response
      */
-    public $httpStatusCode = 400;
+    public $httpStatusCode = 401;
 
     /**
      * The exception type

--- a/src/Exception/NoTokenException.php
+++ b/src/Exception/NoTokenException.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * OAuth 2.0 Base Exception
+ *
+ * @package     league/oauth2-server
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Exception;
+
+/**
+ * Exception class
+ */
+class NoTokenException extends OAuthException
+{
+    /**
+     * The HTTP status code for this exception that should be sent in the response
+     */
+    public $httpStatusCode = 400;
+
+    /**
+     * The exception type
+     */
+    public $errorType = 'invalid_request';
+
+    /**
+     * Throw a new exception
+     *
+     * @param string $msg Exception Message
+     */
+    public function __construct($msg = 'No access token present')
+    {
+        parent::__construct($msg);
+    }
+
+    /**
+     * Get all headers that have to be send with the error response
+     *
+     * @return array Array with header values
+     */
+
+    public function getHttpHeaders()
+    {
+        $headers = parent::getHttpHeaders();
+
+        // Add "WWW-Authenticate" header
+        //
+        // RFC 6749, section 5.2.:
+        // "If the client attempted to authenticate via the 'Authorization'
+        // request header field, the authorization server MUST
+        // respond with an HTTP 401 (Unauthorized) status code and
+        // include the "WWW-Authenticate" response header field
+        // matching the authentication scheme used by the client.
+        // @codeCoverageIgnoreStart
+
+        $authScheme = $this->determineAuthScheme();    
+
+        switch ($authScheme) {
+            case 'Bearer':
+                $headers[] = 'WWW-Authenticate: ' . $authScheme;
+            break;
+        }
+        
+        // @codeCoverageIgnoreEnd
+        
+        return $headers;
+    }
+
+}

--- a/src/Exception/NoTokenException.php
+++ b/src/Exception/NoTokenException.php
@@ -27,13 +27,20 @@ class NoTokenException extends OAuthException
     public $errorType = 'invalid_request';
 
     /**
+     * The token type
+     * @var string
+     */
+    private $typeName;
+
+    /**
      * Throw a new exception
      *
      * @param string $msg Exception Message
      */
-    public function __construct($msg = 'No access token present')
+    public function __construct($typeName)
     {
-        parent::__construct($msg);
+        parent::__construct('No ' . $typeName . ' token present in request.');
+        $this->typeName = $typeName;
     }
 
     /**
@@ -56,13 +63,7 @@ class NoTokenException extends OAuthException
         // matching the authentication scheme used by the client.
         // @codeCoverageIgnoreStart
 
-        $authScheme = $this->determineAuthScheme();    
-
-        switch ($authScheme) {
-            case 'Bearer':
-                $headers[] = 'WWW-Authenticate: ' . $authScheme;
-            break;
-        }
+        $headers[] = 'WWW-Authenticate: ' . $this->typeName;
         
         // @codeCoverageIgnoreEnd
         

--- a/src/Exception/NoTokenException.php
+++ b/src/Exception/NoTokenException.php
@@ -35,7 +35,7 @@ class NoTokenException extends OAuthException
     /**
      * Throw a new exception
      *
-     * @param string $msg Exception Message
+     * @param string $typeName The token type that should be used
      */
     public function __construct($typeName)
     {

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -12,8 +12,8 @@
 namespace League\OAuth2\Server;
 
 use League\OAuth2\Server\Entity\AccessTokenEntity;
-use League\OAuth2\Server\Exception\AccessDeniedException;
-use League\OAuth2\Server\Exception\InvalidRequestException;
+use League\OAuth2\Server\Exception\NoTokenException;
+use League\OAuth2\Server\Exception\InvalidTokenException;
 use League\OAuth2\Server\Storage\AccessTokenInterface;
 use League\OAuth2\Server\Storage\ClientInterface;
 use League\OAuth2\Server\Storage\ScopeInterface;
@@ -99,8 +99,8 @@ class ResourceServer extends AbstractServer
      * @param bool                                                $headerOnly Limit Access Token to Authorization header
      * @param \League\OAuth2\Server\Entity\AccessTokenEntity|null $accessToken Access Token
      *
-     * @throws \League\OAuth2\Server\Exception\AccessDeniedException
-     * @throws \League\OAuth2\Server\Exception\InvalidRequestException
+     * @throws \League\OAuth2\Server\Exception\NoTokenException
+     * @throws \League\OAuth2\Server\Exception\InvalidTokenException
      *
      * @return bool
      */
@@ -110,18 +110,25 @@ class ResourceServer extends AbstractServer
                                 ? $accessToken
                                 : $this->determineAccessToken($headerOnly);
 
+        if (empty($accessTokenString)) {
+            //invalid_request
+            throw new NoTokenException();
+        }
+
         // Set the access token
         $this->accessToken = $this->getAccessTokenStorage()->get($accessTokenString);
 
         // Ensure the access token exists
         if (!$this->accessToken instanceof AccessTokenEntity) {
-            throw new AccessDeniedException();
+            //invalid_token
+            throw new InvalidTokenException();
         }
 
         // Check the access token hasn't expired
         // Ensure the auth code hasn't expired
         if ($this->accessToken->isExpired() === true) {
-            throw new AccessDeniedException();
+            //invalid_token
+            throw new InvalidTokenException();
         }
 
         return true;
@@ -147,7 +154,7 @@ class ResourceServer extends AbstractServer
         }
 
         if (empty($accessToken)) {
-            throw new InvalidRequestException('access token');
+            throw new NoTokenException('access token');
         }
 
         return $accessToken;

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -139,7 +139,7 @@ class ResourceServer extends AbstractServer
      *
      * @param bool $headerOnly Limit Access Token to Authorization header
      *
-     * @throws \League\OAuth2\Server\Exception\InvalidRequestException Thrown if there is no access token presented
+     * @throws \League\OAuth2\Server\Exception\NoTokenException Thrown if there is no access token presented
      *
      * @return string
      */
@@ -154,7 +154,7 @@ class ResourceServer extends AbstractServer
         }
 
         if (empty($accessToken)) {
-            throw new NoTokenException('access token');
+            throw new NoTokenException($this->getTokenType()->getTypeName());
         }
 
         return $accessToken;

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -110,11 +110,6 @@ class ResourceServer extends AbstractServer
                                 ? $accessToken
                                 : $this->determineAccessToken($headerOnly);
 
-        if (empty($accessTokenString)) {
-            //invalid_request
-            throw new NoTokenException();
-        }
-
         // Set the access token
         $this->accessToken = $this->getAccessTokenStorage()->get($accessTokenString);
 

--- a/src/TokenType/Bearer.php
+++ b/src/TokenType/Bearer.php
@@ -15,6 +15,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 class Bearer extends AbstractTokenType implements TokenTypeInterface
 {
+
+    /**
+     * {$inheritdoc}
+     */
+    public function getTypeName()
+    {
+        return 'Bearer';
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/TokenType/MAC.php
+++ b/src/TokenType/MAC.php
@@ -20,6 +20,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class MAC extends AbstractTokenType implements TokenTypeInterface
 {
+
+    /**
+     * {$inheritdoc}
+     */
+    public function getTypeName()
+    {
+        return 'MAC';
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/TokenType/TokenTypeInterface.php
+++ b/src/TokenType/TokenTypeInterface.php
@@ -18,6 +18,13 @@ use Symfony\Component\HttpFoundation\Request;
 interface TokenTypeInterface
 {
     /**
+     * The name of the token type
+     * 
+     * @return string
+     */
+    public function getTypeName();
+
+    /**
      * Generate a response
      *
      * @return array

--- a/tests/unit/ResourceServerTest.php
+++ b/tests/unit/ResourceServerTest.php
@@ -53,7 +53,7 @@ class ResourceServerTest extends \PHPUnit_Framework_TestCase
 
     public function testDetermineAccessTokenMissingToken()
     {
-        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRequestException');
+        $this->setExpectedException('League\OAuth2\Server\Exception\NoTokenException');
 
         $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
         $sessionStorage->shouldReceive('setServer');
@@ -110,7 +110,7 @@ class ResourceServerTest extends \PHPUnit_Framework_TestCase
             $scopeStorage
         );
 
-        $this->setExpectedException('League\OAuth2\Server\Exception\AccessDeniedException');
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidTokenException');
         $server->isValidRequest(false, 'foobar');
     }
 
@@ -169,7 +169,7 @@ class ResourceServerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException League\OAuth2\Server\Exception\AccessDeniedException
+     * @expectedException League\OAuth2\Server\Exception\InvalidTokenException
      */
     public function testIsValidExpiredToken()
     {


### PR DESCRIPTION
Usage of the Bearer token specifies that a `www-authenticate` header should be returned when there is a token problem when accessing resources.

The changes I made here include:

1. Adding two new exceptions
    1. `NoTokenException`
    2. `InvalidTokenException`
2. Altering the `getHttpHeaders` function in the OAuthException class to not include anything related to the www-authenticate header
3. Using `Request::createFromGlobals()` when creating the request object in the exception to properly fetch the `Authorization` header from the request. Before the request was created using `$request = new Request();` and it resulted in the `$request` object not being populated with anything.
4. Changing the resource server to use these two exceptions when validating the token.
5. Edited EXISTING tests that expected `InvalidRequestException`s to expect one of the two new exceptions.
6. Added new `getTypeName` method to `TokenTypeInterface` so we have a way of getting the type of token being used. This is used with the `NoTokenException`.

What I DIDN'T do

1. Add new unit tests for the new exception classes.

These changes aren't "complete" by any means but they help conform a bit more to the recommended usage of the Bearer token.

Any suggestions are welcome.