### PR TITLE
pass ResponseInterface to be handled

### DIFF
--- a/examples/public/client_credentials.php
+++ b/examples/public/client_credentials.php
@@ -13,8 +13,8 @@ use OAuth2ServerExamples\Repositories\ClientRepository;
 use OAuth2ServerExamples\Repositories\ScopeRepository;
 
 use Slim\App;
-use Slim\Http\Request;
-use Slim\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 include(__DIR__ . '/../vendor/autoload.php');
 
@@ -31,7 +31,7 @@ $server->enableGrantType(new ClientCredentialsGrant(
 // App
 $app = new App([Server::class => $server]);
 
-$app->post('/access_token', function (Request $request, Response $response) {
+$app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) {
     /** @var Server $server */
     $server = $this->getContainer()->get(Server::class);
     try {

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace OAuth2ServerExamples;
+
+use Exception;
+
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Server;
@@ -18,18 +22,12 @@ include(__DIR__ . '/../vendor/autoload.php');
 // Setup the authorization server
 $server = new Server();
 
-// Init our repositories
-$clientRepository = new ClientRepository();
-$scopeRepository = new ScopeRepository();
-$accessTokenRepository = new AccessTokenRepository();
-$userRepository = new UserRepository();
-
 // Enable the client credentials grant on the server
 $server->enableGrantType(new PasswordGrant(
-    $userRepository,
-    $clientRepository,
-    $scopeRepository,
-    $accessTokenRepository
+    new UserRepository(),
+    new ClientRepository(),
+    new ScopeRepository(),
+    new AccessTokenRepository()
 ));
 
 // App
@@ -39,10 +37,10 @@ $app->post('/access_token', function (Request $request, Response $response) {
     /** @var Server $server */
     $server = $this->getContainer()->get(Server::class);
     try {
-        return $server->respondToRequest($request);
+        return $server->handleTokenRequest($request, $response);
     } catch (OAuthServerException $e) {
-        return $e->generateHttpResponse();
-    } catch (\Exception $e) {
+        return $e->getResponse($response);
+    } catch (Exception $e) {
         return $response->withStatus(500)->write($e->getMessage());
     }
 });

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -14,8 +14,8 @@ use OAuth2ServerExamples\Repositories\ScopeRepository;
 use OAuth2ServerExamples\Repositories\UserRepository;
 
 use Slim\App;
-use Slim\Http\Request;
-use Slim\Http\Response;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 include(__DIR__ . '/../vendor/autoload.php');
 
@@ -33,7 +33,7 @@ $server->enableGrantType(new PasswordGrant(
 // App
 $app = new App([Server::class => $server]);
 
-$app->post('/access_token', function (Request $request, Response $response) {
+$app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) {
     /** @var Server $server */
     $server = $this->getContainer()->get(Server::class);
     try {

--- a/examples/src/Repositories/ClientRepository.php
+++ b/examples/src/Repositories/ClientRepository.php
@@ -9,7 +9,7 @@ class ClientRepository implements ClientRepositoryInterface
     /**
      * @inheritdoc
      */
-    public function getClientEntity($clientIdentifier, $clientSecret = null, $redirectUri = null, $grantType = null)
+    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $redirectUri = null)
     {
         $clients = [
             'myawesomeapp' => [

--- a/src/Repositories/ClientRepositoryInterface.php
+++ b/src/Repositories/ClientRepositoryInterface.php
@@ -26,5 +26,5 @@ interface ClientRepositoryInterface extends RepositoryInterface
      *
      * @return \League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface
      */
-    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $redirectUri = null);
+    public function getClientEntity($clientIdentifier, $clientSecret = null, $redirectUri = null, $grantType = null);
 }

--- a/src/Repositories/ClientRepositoryInterface.php
+++ b/src/Repositories/ClientRepositoryInterface.php
@@ -20,11 +20,11 @@ interface ClientRepositoryInterface extends RepositoryInterface
      * Get a client
      *
      * @param string      $clientIdentifier The client's identifier
+     * @param string      $grantType        The grant type used
      * @param string|null $clientSecret     The client's secret
      * @param string|null $redirectUri      The client's redirect URI
-     * @param string|null $grantType        The grant type used
      *
      * @return \League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface
      */
-    public function getClientEntity($clientIdentifier, $clientSecret = null, $redirectUri = null, $grantType = null);
+    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $redirectUri = null);
 }

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -12,6 +12,7 @@
 namespace League\OAuth2\Server\ResponseTypes;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response;
 
 class BearerTokenResponse extends AbstractResponseType
@@ -19,8 +20,12 @@ class BearerTokenResponse extends AbstractResponseType
     /**
      * {@inheritdoc}
      */
-    public function generateHttpResponse()
+    public function getResponse(ResponseInterface $response = null)
     {
+        if ($response === null) {
+            $response = new Response('php://memory');
+        }
+
         $values = [
             'access_token' => $this->accessToken->getIdentifier(),
             'token_type'   => 'Bearer',
@@ -31,18 +36,11 @@ class BearerTokenResponse extends AbstractResponseType
             $values['refresh_token'] = $this->getParam('refresh_token');
         }
 
-        $response = new Response(
-            'php://memory',
-            200,
-            [
-                'pragma'        => 'no-cache',
-                'cache-control' => 'no-store',
-                'content-type'  => 'application/json;charset=UTF-8'
-            ]
-        );
-        $response->getBody()->write(json_encode($values));
-
-        return $response;
+        return $response->withStatus(200)
+            ->withHeader('pragma', 'no-cache')
+            ->withHeader('cache-control', 'no-store')
+            ->withHeader('content-type', 'application/json;charset=UTF-8')
+            ->write(json_encode($values));
     }
 
     /**

--- a/src/ResponseTypes/JsonWebTokenType.php
+++ b/src/ResponseTypes/JsonWebTokenType.php
@@ -94,21 +94,20 @@ class JsonWebTokenType extends AbstractTokenType
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Response
+     * {@inheritdoc}
      */
-    public function generateHttpResponse()
+    public function getResponse(ResponseInterface $response = null)
     {
-        return new Response(
-            json_encode([
-                $this->generateResponse()
-            ]),
-            200,
-            [
-                'Content-type'  => 'application/json',
-                'Cache-Control' => 'no-store',
-                'Pragma'        => 'no-cache'
-            ]
-        );
+        if ($response === null) {
+            $response = new Response('php://memory');
+        }
+
+        return $response
+            ->withStatus(200)
+            ->withHeader('pragma', 'no-cache')
+            ->withHeader('cache-control', 'no-store')
+            ->withHeader('content-type', 'application/json;charset=UTF-8')
+            ->write(json_encode($this->generateResponse()));
     }
 
     /**

--- a/src/ResponseTypes/ResponseTypeInterface.php
+++ b/src/ResponseTypes/ResponseTypeInterface.php
@@ -49,7 +49,9 @@ interface ResponseTypeInterface
     public function determineAccessTokenInHeader(ServerRequestInterface $request);
 
     /**
+     * @param ResponseInterface|null $response
+     *
      * @return ResponseInterface
      */
-    public function generateHttpResponse();
+    public function getResponse(ResponseInterface $response = null);
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -10,6 +10,7 @@ use League\OAuth2\Server\Grant\GrantTypeInterface;
 use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\ServerRequestFactory;
 
 class Server implements EmitterAwareInterface
@@ -123,10 +124,14 @@ class Server implements EmitterAwareInterface
      * @return \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface
      * @throws \League\OAuth2\Server\Exception\OAuthServerException
      */
-    public function respondToRequest(ServerRequestInterface $request = null)
+    public function handleTokenRequest(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
         if ($request === null) {
             $request = ServerRequestFactory::fromGlobals();
+        }
+
+        if ($response === null) {
+            $response = new Response('php://memory');
         }
 
         $tokenResponse = null;
@@ -142,11 +147,9 @@ class Server implements EmitterAwareInterface
         }
 
         if ($tokenResponse instanceof ResponseTypeInterface) {
-            return $tokenResponse->generateHttpResponse();
-        } else {
-            $response = OAuthServerException::unsupportedGrantType()->generateHttpResponse();
+            return $tokenResponse->getResponse($response);
         }
 
-        return $response;
+        return OAuthServerException::unsupportedGrantType()->getResponse($response);
     }
 }


### PR DESCRIPTION
Apart from allowing the library to create Zend\Diactoros\Response when needed, passing an already PSR7 response object allows oauth2-server to be leveraged at the end of the middleware chain, it might even use `__invoke` instead of `handleTokenResponse`

With this `generateHttpResponse` doesn't really has a meaning so I've changed it to `getResponse($response)`

There is a question I have, why using `League\OAuth2\Server\Exception\OAuthServerException` as a factory instead of a collection of Exceptions?