### PR TITLE
Allow Symfony 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=5.4.0",
-		"symfony/http-foundation": "~2.4",
+		"symfony/http-foundation": "~2.4|~3.0",
 		"league/event": "~2.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Symfony 3.0 has been released and I'd like to migrate my Symfony projects to that new release. Your library is currently blocking the migration because its composer.json file defines a dependency against Symfony HTTP Foundation 2.

As far as I can tell, the code should work just fine with Symfony HTTP Foundation 3, so I've marked the 3.x series as compatible in this PR.