### PR TITLE
V5 - allow middleware use

### DIFF
--- a/examples/public/client_credentials.php
+++ b/examples/public/client_credentials.php
@@ -32,9 +32,9 @@ $app->post('/access_token', function (Request $request, Response $response) {
     /** @var Server $server */
     $server = $this->get(Server::class);
     try {
-        return $server->respondToRequest($request);
+        return $server->respondToRequest($request, $response);
     } catch (OAuthServerException $e) {
-        return $e->generateHttpResponse();
+        return $e->generateHttpResponse($response);
     } catch (\Exception $e) {
         return $response->withStatus(500)->write($e->getMessage());
     }

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -43,9 +43,9 @@ $app->post('/access_token', function (Request $request, Response $response) {
     /** @var Server $server */
     $server = $this->get(Server::class);
     try {
-        return $server->respondToRequest($request);
+        return $server->respondToRequest($request, $response);
     } catch (OAuthServerException $e) {
-        return $e->generateHttpResponse();
+        return $e->generateHttpResponse($response);
     } catch (\Exception $e) {
         return $response->withStatus(500)->write($e->getMessage());
     }

--- a/examples/public/refresh_token.php
+++ b/examples/public/refresh_token.php
@@ -43,9 +43,9 @@ $app->post('/access_token', function (Request $request, Response $response) {
     /** @var Server $server */
     $server = $this->get(Server::class);
     try {
-        return $server->respondToRequest($request);
+        return $server->respondToRequest($request, $response);
     } catch (OAuthServerException $e) {
-        return $e->generateHttpResponse();
+        return $e->generateHttpResponse($response);
     } catch (\Exception $e) {
         return $response->withStatus(500)->write(
             sprintf('<h1>%s</h1><p>%s</p>', get_class($e), $e->getMessage())

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -16,6 +16,7 @@ use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Utils\KeyCrypt;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response;
 
@@ -24,7 +25,7 @@ class BearerTokenResponse extends AbstractResponseType
     /**
      * {@inheritdoc}
      */
-    public function generateHttpResponse()
+    public function generateHttpResponse(ResponseInterface $response)
     {
         $jwtAccessToken = (new Builder())
             ->setAudience($this->accessToken->getClient()->getIdentifier())
@@ -61,16 +62,12 @@ class BearerTokenResponse extends AbstractResponseType
             $responseParams['refresh_token'] = $refreshToken;
         }
 
-        $response = new Response(
-            'php://memory',
-            200,
-            [
-                'pragma'        => 'no-cache',
-                'cache-control' => 'no-store',
-                'content-type'  => 'application/json;charset=UTF-8'
-            ]
-        );
-        $response->getBody()->write(json_encode($responseParams));
+        $response
+            ->withStatus(200)
+            ->withHeader('pragma', 'no-cache')
+            ->withHeader('cache-control', 'no-store')
+            ->withHeader('content-type', 'application/json;charset=UTF-8')
+            ->getBody()->write(json_encode($responseParams));
 
         return $response;
     }

--- a/src/ResponseTypes/ResponseTypeInterface.php
+++ b/src/ResponseTypes/ResponseTypeInterface.php
@@ -38,7 +38,9 @@ interface ResponseTypeInterface
     public function determineAccessTokenInHeader(ServerRequestInterface $request);
 
     /**
+     * @param ResponseInterface $response
+     *
      * @return ResponseInterface
      */
-    public function generateHttpResponse();
+    public function generateHttpResponse(ResponseInterface $response);
 }


### PR DESCRIPTION
Pass Response object to `respondToRequest` to be composed with result of auth check instead of creating a new Response
`__invoke` method to allow to be used as middleware