### PR TITLE
Docblock stated that "," is the default scope delimiter but it is " ".

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -207,7 +207,7 @@ class AuthorizationServer extends AbstractServer
     /**
      * Get the scope delimiter
      *
-     * @return string The scope delimiter (default: ",")
+     * @return string The scope delimiter (default: " ")
      */
     public function getScopeDelimiter()
     {


### PR DESCRIPTION
Found inconsistency in the docblock comment for the default scope delimiter and fixed it.