### PR TITLE
V5 - Exception based access token check

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -243,9 +243,9 @@ class OAuthServerException extends \Exception
             $response = $response->withHeader($header, $content);
         }
 
-        $response = $response->withStatus($this->getHttpStatusCode());
         $response->getBody()->write(json_encode($payload));
-        return $response;
+
+        return $response->withStatus($this->getHttpStatusCode());
     }
 
     /**

--- a/src/Middleware/AuthenticationServerMiddleware.php
+++ b/src/Middleware/AuthenticationServerMiddleware.php
@@ -34,7 +34,7 @@ class AuthenticationServerMiddleware
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
         try {
-            $response = $server->respondToRequest($request, $response);
+            $response = $this->server->respondToRequest($request, $response);
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse($response);
         } catch (\Exception $exception) {

--- a/src/Middleware/AuthenticationServerMiddleware.php
+++ b/src/Middleware/AuthenticationServerMiddleware.php
@@ -38,7 +38,9 @@ class AuthenticationServerMiddleware
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse($response);
         } catch (\Exception $exception) {
-            return $response->withStatus(500)->write($exception->getMessage());
+            $response->getBody()->write($exception->getMessage());
+
+            return $response->withStatus(500);
         }
 
         if (in_array($response->getStatusCode(), [400, 401, 500])) {

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -38,7 +38,9 @@ class ResourceServerMiddleware
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse($response);
         } catch (\Exception $exception) {
-            return $response->withStatus(500)->write($exception->getMessage());
+            $response->getBody()->write($exception->getMessage());
+
+            return $response->withStatus(500);
         }
 
         // Pass the request and response on to the next responder in the chain

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -33,18 +33,12 @@ class ResourceServerMiddleware
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        if ($request->hasHeader('authorization') === false) {
-            $exception = OAuthServerException::accessDenied('Missing authorization header');
-
+        try {
+            $request = $this->server->getResponseType()->determineAccessTokenInHeader($request);
+        } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse($response);
-        }
-
-        $request = $this->server->getResponseType()->determineAccessTokenInHeader($request);
-
-        if ($request->getAttribute('oauth_access_token') === null) {
-            $exception = OAuthServerException::accessDenied($request->getAttribute('oauth_access_token_error'));
-
-            return $exception->generateHttpResponse($response);
+        } catch (\Exception $exception) {
+            return $response->withStatus(500)->write($exception->getMessage());
         }
 
         // Pass the request and response on to the next responder in the chain

--- a/src/ResponseTypes/AbstractResponseType.php
+++ b/src/ResponseTypes/AbstractResponseType.php
@@ -13,7 +13,9 @@ namespace League\OAuth2\Server\ResponseTypes;
 
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 abstract class AbstractResponseType implements ResponseTypeInterface
 {
@@ -66,10 +68,22 @@ abstract class AbstractResponseType implements ResponseTypeInterface
     }
 
     /**
-     * @param \League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface $refreshToken
+     * {@inheritdoc}
      */
     public function setRefreshToken(RefreshTokenEntityInterface $refreshToken)
     {
         $this->refreshToken = $refreshToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function determineAccessTokenInHeader(ServerRequestInterface $request)
+    {
+        if ($request->hasHeader('authorization') === false) {
+            throw OAuthServerException::accessDenied('Missing "Authorization" header');
+        }
+
+        return $request;
     }
 }


### PR DESCRIPTION
Access token check by exception handling

* Move `Authorization` header check into `AbstractResponseType`
* Pass exceptions when erroring on determining access token instead of passing request attributes
* Makes `ResourceServerMiddleware` more concise