### PR TITLE
V5 - Allow refresh token TTL assign

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -81,6 +81,11 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected $pathToPublicKey;
 
     /**
+     * @var \DateInterval
+     */
+    protected $refreshTokenTTL;
+
+    /**
      * @param ClientRepositoryInterface $clientRepository
      */
     public function setClientRepository(ClientRepositoryInterface $clientRepository)
@@ -126,6 +131,14 @@ abstract class AbstractGrant implements GrantTypeInterface
     public function setEmitter(EmitterInterface $emitter)
     {
         $this->emitter = $emitter;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setRefreshTokenTTL(\DateInterval $refreshTokenTTL)
+    {
+        $this->refreshTokenTTL = $refreshTokenTTL;
     }
 
     /**
@@ -283,16 +296,15 @@ abstract class AbstractGrant implements GrantTypeInterface
     }
 
     /**
-     * @param \DateInterval                                    $tokenTTL
      * @param \League\OAuth2\Server\Entities\AccessTokenEntity $accessToken
      *
      * @return \League\OAuth2\Server\Entities\RefreshTokenEntity
      */
-    protected function issueRefreshToken(\DateInterval $tokenTTL, AccessTokenEntity $accessToken)
+    protected function issueRefreshToken(AccessTokenEntity $accessToken)
     {
         $refreshToken = new RefreshTokenEntity();
         $refreshToken->setIdentifier(SecureKey::generate());
-        $refreshToken->setExpiryDateTime((new \DateTime())->add($tokenTTL));
+        $refreshToken->setExpiryDateTime((new \DateTime())->add($this->refreshTokenTTL));
         $refreshToken->setAccessToken($accessToken);
 
         return $refreshToken;

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -283,15 +283,16 @@ abstract class AbstractGrant implements GrantTypeInterface
     }
 
     /**
+     * @param \DateInterval                                    $tokenTTL
      * @param \League\OAuth2\Server\Entities\AccessTokenEntity $accessToken
      *
      * @return \League\OAuth2\Server\Entities\RefreshTokenEntity
      */
-    protected function issueRefreshToken(AccessTokenEntity $accessToken)
+    protected function issueRefreshToken(\DateInterval $tokenTTL, AccessTokenEntity $accessToken)
     {
         $refreshToken = new RefreshTokenEntity();
         $refreshToken->setIdentifier(SecureKey::generate());
-        $refreshToken->setExpiryDateTime((new \DateTime())->add(new \DateInterval('P1M')));
+        $refreshToken->setExpiryDateTime((new \DateTime())->add($tokenTTL));
         $refreshToken->setAccessToken($accessToken);
 
         return $refreshToken;

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -32,14 +32,15 @@ class ClientCredentialsGrant extends AbstractGrant
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $tokenTTL
+        \DateInterval $accessTokenTTL,
+        \DateInterval $refreshTokenTTL
     ) {
         // Validate request
         $client = $this->validateClient($request);
         $scopes = $this->validateScopes($request, $client);
 
         // Issue and persist access token
-        $accessToken = $this->issueAccessToken($tokenTTL, $client, $client->getIdentifier(), $scopes);
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $client->getIdentifier(), $scopes);
         $this->accessTokenRepository->persistNewAccessToken($accessToken);
 
         // Inject access token into response type

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -32,8 +32,7 @@ class ClientCredentialsGrant extends AbstractGrant
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $accessTokenTTL,
-        \DateInterval $refreshTokenTTL
+        \DateInterval $accessTokenTTL
     ) {
         // Validate request
         $client = $this->validateClient($request);

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -11,7 +11,6 @@
 
 namespace League\OAuth2\Server\Grant;
 
-use DateInterval;
 use League\Event\EmitterInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
@@ -43,14 +42,16 @@ interface GrantTypeInterface
      *
      * @param \Psr\Http\Message\ServerRequestInterface                  $request
      * @param \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface $responseType
-     * @param \DateInterval                                             $tokenTTL
+     * @param \DateInterval                                             $accessTokenTTL
+     * @param \DateInterval                                             $refreshTokenTTL
      *
      * @return \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface
      */
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        DateInterval $tokenTTL
+        \DateInterval $accessTokenTTL,
+        \DateInterval $refreshTokenTTL
     );
 
     /**

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -24,6 +24,13 @@ use Psr\Http\Message\ServerRequestInterface;
 interface GrantTypeInterface
 {
     /**
+     * Set refresh token TTL
+     *
+     * @param \DateInterval $refreshTokenTTL
+     */
+    public function setRefreshTokenTTL(\DateInterval $refreshTokenTTL);
+
+    /**
      * Return the identifier
      *
      * @return string
@@ -43,15 +50,13 @@ interface GrantTypeInterface
      * @param \Psr\Http\Message\ServerRequestInterface                  $request
      * @param \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface $responseType
      * @param \DateInterval                                             $accessTokenTTL
-     * @param \DateInterval                                             $refreshTokenTTL
      *
      * @return \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface
      */
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $accessTokenTTL,
-        \DateInterval $refreshTokenTTL
+        \DateInterval $accessTokenTTL
     );
 
     /**

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -51,6 +51,8 @@ class PasswordGrant extends AbstractGrant
     ) {
         $this->userRepository = $userRepository;
         $this->refreshTokenRepository = $refreshTokenRepository;
+
+        $this->refreshTokenTTL = new \DateInterval('P1M');
     }
 
     /**
@@ -59,8 +61,7 @@ class PasswordGrant extends AbstractGrant
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $accessTokenTTL,
-        \DateInterval $refreshTokenTTL
+        \DateInterval $accessTokenTTL
     ) {
         // Validate request
         $client = $this->validateClient($request);
@@ -69,7 +70,7 @@ class PasswordGrant extends AbstractGrant
 
         // Issue and persist new tokens
         $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $user->getIdentifier(), $scopes);
-        $refreshToken = $this->issueRefreshToken($refreshTokenTTL, $accessToken);
+        $refreshToken = $this->issueRefreshToken($accessToken);
         $this->accessTokenRepository->persistNewAccessToken($accessToken);
         $this->refreshTokenRepository->persistNewRefreshToken($refreshToken);
 

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -59,7 +59,8 @@ class PasswordGrant extends AbstractGrant
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $tokenTTL
+        \DateInterval $accessTokenTTL,
+        \DateInterval $refreshTokenTTL
     ) {
         // Validate request
         $client = $this->validateClient($request);
@@ -67,8 +68,8 @@ class PasswordGrant extends AbstractGrant
         $scopes = $this->validateScopes($request, $client);
 
         // Issue and persist new tokens
-        $accessToken = $this->issueAccessToken($tokenTTL, $client, $user->getIdentifier(), $scopes);
-        $refreshToken = $this->issueRefreshToken($accessToken);
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $user->getIdentifier(), $scopes);
+        $refreshToken = $this->issueRefreshToken($refreshTokenTTL, $accessToken);
         $this->accessTokenRepository->persistNewAccessToken($accessToken);
         $this->refreshTokenRepository->persistNewRefreshToken($refreshToken);
 

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -50,8 +50,10 @@ class RefreshTokenGrant extends AbstractGrant
     public function respondToRequest(
         ServerRequestInterface $request,
         ResponseTypeInterface $responseType,
-        \DateInterval $tokenTTL
+        \DateInterval $accessTokenTTL,
+        \DateInterval $refreshTokenTTL
     ) {
+        // Validate request
         $client          = $this->validateClient($request);
         $oldRefreshToken = $this->validateOldRefreshToken($request, $client->getIdentifier());
         $scopes          = $this->validateScopes($request, $client);
@@ -75,8 +77,8 @@ class RefreshTokenGrant extends AbstractGrant
         $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
         $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
 
-        $accessToken = $this->issueAccessToken($tokenTTL, $client, $oldRefreshToken['user_id'], $scopes);
-        $refreshToken = $this->issueRefreshToken($accessToken);
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $oldRefreshToken['user_id'], $scopes);
+        $refreshToken = $this->issueRefreshToken($refreshTokenTTL, $accessToken);
 
         $this->accessTokenRepository->persistNewAccessToken($accessToken);
         $this->refreshTokenRepository->persistNewRefreshToken($refreshToken);

--- a/src/Server.php
+++ b/src/Server.php
@@ -27,14 +27,9 @@ class Server implements EmitterAwareInterface
     protected $enabledGrantTypes = [];
 
     /**
-     * @var ResponseTypeInterface[]
-     */
-    protected $grantResponseTypes = [];
-
-    /**
      * @var DateInterval[]
      */
-    protected $grantTypeAccessTokenTTL = [];
+    protected $grantTypeTokensTTL = [];
 
     /**
      * @var string
@@ -93,47 +88,30 @@ class Server implements EmitterAwareInterface
     }
 
     /**
-     * Get the token type that grants will return in the HTTP response
-     *
-     * @return ResponseTypeInterface
-     */
-    public function getResponseType()
-    {
-        if (!$this->responseType instanceof ResponseTypeInterface) {
-            $this->responseType = new BearerTokenResponse(
-                $this->privateKeyPath,
-                $this->publicKeyPath,
-                $this->accessTokenRepository
-            );
-        }
-
-        return $this->responseType;
-    }
-
-    /**
      * Enable a grant type on the server
      *
      * @param \League\OAuth2\Server\Grant\GrantTypeInterface $grantType
-     * @param DateInterval                                   $accessTokenTTL
+     * @param DateInterval|null                              $accessTokenTTL
+     * @param DateInterval|null                              $refreshTokenTTL
      */
     public function enableGrantType(
         GrantTypeInterface $grantType,
-        \DateInterval $accessTokenTTL
+        \DateInterval $accessTokenTTL,
+        \DateInterval $refreshTokenTTL = null
     ) {
         $grantType->setAccessTokenRepository($this->accessTokenRepository);
         $grantType->setClientRepository($this->clientRepository);
         $grantType->setScopeRepository($this->scopeRepository);
         $grantType->setPathToPrivateKey($this->privateKeyPath);
         $grantType->setPathToPublicKey($this->publicKeyPath);
-
         $grantType->setEmitter($this->getEmitter());
+
         $this->enabledGrantTypes[$grantType->getIdentifier()] = $grantType;
 
-        // Set grant response type
-        $this->grantResponseTypes[$grantType->getIdentifier()] = $this->getResponseType();
-
-        // Set grant access token TTL
-        $this->grantTypeAccessTokenTTL[$grantType->getIdentifier()] = $accessTokenTTL;
+        $this->grantTypeTokensTTL[$grantType->getIdentifier()] = [
+            'access'  => $accessTokenTTL,
+            'refresh' => $refreshTokenTTL !== null ? $refreshTokenTTL : new \DateInterval('P1M'),
+        ];
     }
 
     /**
@@ -160,8 +138,9 @@ class Server implements EmitterAwareInterface
             if ($grantType->canRespondToRequest($request)) {
                 $tokenResponse = $grantType->respondToRequest(
                     $request,
-                    $this->grantResponseTypes[$grantType->getIdentifier()],
-                    $this->grantTypeAccessTokenTTL[$grantType->getIdentifier()]
+                    $this->getResponseType(),
+                    $this->grantTypeTokensTTL[$grantType->getIdentifier()]['access'],
+                    $this->grantTypeTokensTTL[$grantType->getIdentifier()]['refresh']
                 );
             }
         }
@@ -171,5 +150,23 @@ class Server implements EmitterAwareInterface
         }
 
         return $tokenResponse->generateHttpResponse($response);
+    }
+
+    /**
+     * Get the token type that grants will return in the HTTP response
+     *
+     * @return ResponseTypeInterface
+     */
+    public function getResponseType()
+    {
+        if (!$this->responseType instanceof ResponseTypeInterface) {
+            $this->responseType = new BearerTokenResponse(
+                $this->privateKeyPath,
+                $this->publicKeyPath,
+                $this->accessTokenRepository
+            );
+        }
+
+        return $this->responseType;
     }
 }


### PR DESCRIPTION
Allow assign of refresh token TLL along with access token TTL

ResponseType is globally unique (defined in Server), no need to keep an array of references to the same object.