### PR TITLE
rename validateRequest

### DIFF
--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -35,7 +35,7 @@ class ResourceServerMiddleware
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
         try {
-            $request = $this->server->validateRequest($request);
+            $request = $this->server->validateAuthenticatedRequest($request);
         } catch (OAuthServerException $exception) {
             return $exception->generateHttpResponse($response);
         } catch (\Exception $exception) {

--- a/src/ResponseTypes/AbstractResponseType.php
+++ b/src/ResponseTypes/AbstractResponseType.php
@@ -78,7 +78,7 @@ abstract class AbstractResponseType implements ResponseTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function determineAccessTokenInHeader(ServerRequestInterface $request)
+    public function validateAccessToken(ServerRequestInterface $request)
     {
         if ($request->hasHeader('authorization') === false) {
             throw OAuthServerException::accessDenied('Missing "Authorization" header');

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -79,9 +79,9 @@ class BearerTokenResponse extends AbstractResponseType
     /**
      * {@inheritdoc}
      */
-    public function determineAccessTokenInHeader(ServerRequestInterface $request)
+    public function validateAccessToken(ServerRequestInterface $request)
     {
-        $request = parent::determineAccessTokenInHeader($request);
+        $request = parent::validateAccessToken($request);
 
         $header = $request->getHeader('authorization');
         $jwt = trim(preg_replace('/^(?:\s+)?Bearer\s/', '', $header[0]));

--- a/src/ResponseTypes/MAC.php
+++ b/src/ResponseTypes/MAC.php
@@ -42,7 +42,7 @@ class MAC extends AbstractTokenType implements TokenTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function determineAccessTokenInHeader(Request $request)
+    public function validateAccessToken(Request $request)
     {
         if ($request->headers->has('Authorization') === false) {
             return;

--- a/src/ResponseTypes/ResponseTypeInterface.php
+++ b/src/ResponseTypes/ResponseTypeInterface.php
@@ -36,7 +36,7 @@ interface ResponseTypeInterface
      *
      * @return ServerRequestInterface
      */
-    public function determineAccessTokenInHeader(ServerRequestInterface $request);
+    public function validateAccessToken(ServerRequestInterface $request);
 
     /**
      * @param ResponseInterface $response

--- a/src/Server.php
+++ b/src/Server.php
@@ -157,9 +157,9 @@ class Server implements EmitterAwareInterface
      *
      * @throws \League\OAuth2\Server\Exception\OAuthServerException
      */
-    public function validateRequest(ServerRequestInterface $request)
+    public function validateAuthenticatedRequest(ServerRequestInterface $request)
     {
-        return $this->getResponseType()->determineAccessTokenInHeader($request);
+        return $this->getResponseType()->validateAccessToken($request);
     }
 
     /**


### PR DESCRIPTION
As @alexbilbie commented on a previous PR...

`determineAccessTokenInHeader` also seems a candidate for renaming to `validaeAccessToken`