### PR TITLE
Allow different template engines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
         }
     },
     "suggest": {
-        "league/plates": "Required for parsing authorization code templates"
+        "league/plates": "Used for parsing authorization code templates",
+        "twig/twig": "Used for parsing authorization code templates",
+        "smarty/smarty": "Used for parsing authorization code templates",
+        "mustache/mustache": "Used for parsing authorization code templates"
     }
 }

--- a/src/Grant/AbstractAuthorizeGrant.php
+++ b/src/Grant/AbstractAuthorizeGrant.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Abstract authorization grant.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Grant;
+
+use League\OAuth2\Server\TemplateRenderer\PlatesRenderer;
+use League\OAuth2\Server\TemplateRenderer\RendererInterface;
+use League\Plates\Engine;
+
+abstract class AbstractAuthorizeGrant extends AbstractGrant
+{
+    /**
+     * @var null|\League\OAuth2\Server\TemplateRenderer\RendererInterface
+     */
+    protected $templateRenderer;
+
+    /**
+     * @var null|string
+     */
+    protected $loginTemplate;
+
+    /**
+     * @var null|string
+     */
+    protected $authorizeTemplate;
+
+    /**
+     * @param array $data
+     *
+     * @return string
+     */
+    protected function renderLoginTemplate(array $data = [])
+    {
+        return $this->getTemplateRenderer()->render($this->getLoginTemplate(), $data);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return string
+     */
+    protected function renderAuthorizeTemplate(array $data = [])
+    {
+        return $this->getTemplateRenderer()->render($this->getAuthorizeTemplate(), $data);
+    }
+
+    /**
+     * @return \League\OAuth2\Server\TemplateRenderer\RendererInterface
+     */
+    protected function getTemplateRenderer()
+    {
+        if (!$this->templateRenderer instanceof RendererInterface) {
+            $this->templateRenderer = new PlatesRenderer(new Engine(__DIR__ . '/../ResponseTypes/DefaultTemplates'));
+        }
+
+        return $this->templateRenderer;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getLoginTemplate()
+    {
+        if (empty($this->loginTemplate)) {
+            $this->loginTemplate = 'login_user';
+        }
+
+        return $this->loginTemplate;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getAuthorizeTemplate()
+    {
+        if (empty($this->authorizeTemplate)) {
+            $this->authorizeTemplate = 'authorize_client';
+        }
+
+        return $this->authorizeTemplate;
+    }
+}

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -11,13 +11,13 @@ use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use League\OAuth2\Server\TemplateRenderer\RendererInterface;
 use League\OAuth2\Server\Utils\KeyCrypt;
-use League\Plates\Engine;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Uri;
 
-class AuthCodeGrant extends AbstractGrant
+class AuthCodeGrant extends AbstractAuthorizeGrant
 {
     /**
      * @var \DateInterval
@@ -30,50 +30,31 @@ class AuthCodeGrant extends AbstractGrant
     private $userRepository;
 
     /**
-     * @var null|string
-     */
-    private $pathToLoginTemplate;
-
-    /**
-     * @var null|string
-     */
-    private $pathToAuthorizeTemplate;
-
-    /**
      * @param \League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface     $authCodeRepository
      * @param \League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface $refreshTokenRepository
      * @param \League\OAuth2\Server\Repositories\UserRepositoryInterface         $userRepository
      * @param \DateInterval                                                      $authCodeTTL
-     * @param string|null                                                        $pathToLoginTemplate
-     * @param string|null                                                        $pathToAuthorizeTemplate
+     * @param string|null                                                        $loginTemplate
+     * @param string|null                                                        $authorizeTemplate
+     * @param \League\OAuth2\Server\TemplateRenderer\RendererInterface|null      $templateRenderer
      */
     public function __construct(
         AuthCodeRepositoryInterface $authCodeRepository,
         RefreshTokenRepositoryInterface $refreshTokenRepository,
         UserRepositoryInterface $userRepository,
         \DateInterval $authCodeTTL,
-        $pathToLoginTemplate = null,
-        $pathToAuthorizeTemplate = null
+        $loginTemplate = null,
+        $authorizeTemplate = null,
+        RendererInterface $templateRenderer = null
     ) {
         $this->setAuthCodeRepository($authCodeRepository);
         $this->setRefreshTokenRepository($refreshTokenRepository);
         $this->userRepository = $userRepository;
         $this->authCodeTTL = $authCodeTTL;
         $this->refreshTokenTTL = new \DateInterval('P1M');
-
-        $this->pathToLoginTemplate = __DIR__ . '/../ResponseTypes/DefaultTemplates/login_user';
-        if ($pathToLoginTemplate !== null) {
-            $this->pathToLoginTemplate = (substr($pathToLoginTemplate, -4) === '.php')
-                ? substr($pathToLoginTemplate, 0, -4)
-                : $pathToLoginTemplate;
-        }
-
-        $this->pathToAuthorizeTemplate = __DIR__ . '/../ResponseTypes/DefaultTemplates/authorize_client';
-        if ($pathToAuthorizeTemplate !== null) {
-            $this->pathToAuthorizeTemplate = (substr($pathToAuthorizeTemplate, -4) === '.php')
-                ? substr($pathToAuthorizeTemplate, 0, -4)
-                : $pathToAuthorizeTemplate;
-        }
+        $this->loginTemplate = $loginTemplate;
+        $this->authorizeTemplate = $authorizeTemplate;
+        $this->templateRenderer = $templateRenderer;
     }
 
     /**
@@ -164,31 +145,21 @@ class AuthCodeGrant extends AbstractGrant
 
         // The user hasn't logged in yet so show a login form
         if ($userId === null) {
-            $engine = new Engine(dirname($this->pathToLoginTemplate));
-            $pathParts = explode(DIRECTORY_SEPARATOR, $this->pathToLoginTemplate);
-            $html = $engine->render(
-                end($pathParts),
-                [
-                    'error'        => $loginError,
-                    'postback_uri' => (string) $postbackUri->withQuery($queryString),
-                ]
-            );
+            $html = $this->renderLoginTemplate([
+                'error'        => $loginError,
+                'postback_uri' => (string) $postbackUri->withQuery($queryString),
+            ]);
 
             return new Response\HtmlResponse($html);
         }
 
         // The user hasn't approved the client yet so show an authorize form
         if ($userId !== null && $userHasApprovedClient === null) {
-            $engine = new Engine(dirname($this->pathToAuthorizeTemplate));
-            $pathParts = explode(DIRECTORY_SEPARATOR, $this->pathToAuthorizeTemplate);
-            $html = $engine->render(
-                end($pathParts),
-                [
-                    'client'       => $client,
-                    'scopes'       => $scopes,
-                    'postback_uri' => (string) $postbackUri->withQuery($queryString),
-                ]
-            );
+            $html = $this->renderAuthorizeTemplate([
+                'client'       => $client,
+                'scopes'       => $scopes,
+                'postback_uri' => (string) $postbackUri->withQuery($queryString),
+            ]);
 
             return new Response\HtmlResponse(
                 $html,

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -7,14 +7,14 @@ use League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\UserEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
+use League\OAuth2\Server\TemplateRenderer\RendererInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use League\OAuth2\Server\Utils\KeyCrypt;
-use League\Plates\Engine;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Uri;
 
-class ImplicitGrant extends AbstractGrant
+class ImplicitGrant extends AbstractAuthorizeGrant
 {
     /**
      * @var \League\OAuth2\Server\Repositories\UserRepositoryInterface
@@ -22,41 +22,22 @@ class ImplicitGrant extends AbstractGrant
     private $userRepository;
 
     /**
-     * @var null|string
-     */
-    private $pathToLoginTemplate;
-
-    /**
-     * @var null|string
-     */
-    private $pathToAuthorizeTemplate;
-
-    /**
-     * @param \League\OAuth2\Server\Repositories\UserRepositoryInterface $userRepository
-     * @param string|null                                                $pathToLoginTemplate
-     * @param string|null                                                $pathToAuthorizeTemplate
+     * @param \League\OAuth2\Server\Repositories\UserRepositoryInterface    $userRepository
+     * @param string|null                                                   $loginTemplate
+     * @param string|null                                                   $authorizeTemplate
+     * @param \League\OAuth2\Server\TemplateRenderer\RendererInterface|null $templateRenderer
      */
     public function __construct(
         UserRepositoryInterface $userRepository,
-        $pathToLoginTemplate = null,
-        $pathToAuthorizeTemplate = null
+        $loginTemplate = null,
+        $authorizeTemplate = null,
+        RendererInterface $templateRenderer = null
     ) {
         $this->userRepository = $userRepository;
         $this->refreshTokenTTL = new \DateInterval('P1M');
-
-        $this->pathToLoginTemplate = __DIR__ . '/../ResponseTypes/DefaultTemplates/login_user';
-        if ($pathToLoginTemplate !== null) {
-            $this->pathToLoginTemplate = (substr($pathToLoginTemplate, -4) === '.php')
-                ? substr($pathToLoginTemplate, 0, -4)
-                : $pathToLoginTemplate;
-        }
-
-        $this->pathToAuthorizeTemplate = __DIR__ . '/../ResponseTypes/DefaultTemplates/authorize_client';
-        if ($pathToAuthorizeTemplate !== null) {
-            $this->pathToAuthorizeTemplate = (substr($pathToAuthorizeTemplate, -4) === '.php')
-                ? substr($pathToAuthorizeTemplate, 0, -4)
-                : $pathToAuthorizeTemplate;
-        }
+        $this->loginTemplate = $loginTemplate;
+        $this->authorizeTemplate = $authorizeTemplate;
+        $this->templateRenderer = $templateRenderer;
     }
 
     /**
@@ -164,31 +145,21 @@ class ImplicitGrant extends AbstractGrant
 
         // The user hasn't logged in yet so show a login form
         if ($userId === null) {
-            $engine = new Engine(dirname($this->pathToLoginTemplate));
-            $pathParts = explode(DIRECTORY_SEPARATOR, $this->pathToLoginTemplate);
-            $html = $engine->render(
-                end($pathParts),
-                [
-                    'error'        => $loginError,
-                    'postback_uri' => (string) $postbackUri->withQuery($queryString),
-                ]
-            );
+            $html = $this->renderLoginTemplate([
+                'error'        => $loginError,
+                'postback_uri' => (string) $postbackUri->withQuery($queryString),
+            ]);
 
             return new Response\HtmlResponse($html);
         }
 
         // The user hasn't approved the client yet so show an authorize form
         if ($userId !== null && $userHasApprovedClient === null) {
-            $engine = new Engine(dirname($this->pathToAuthorizeTemplate));
-            $pathParts = explode(DIRECTORY_SEPARATOR, $this->pathToAuthorizeTemplate);
-            $html = $engine->render(
-                end($pathParts),
-                [
-                    'client'       => $client,
-                    'scopes'       => $scopes,
-                    'postback_uri' => (string) $postbackUri->withQuery($queryString),
-                ]
-            );
+            $html = $this->renderAuthorizeTemplate([
+                'client'       => $client,
+                'scopes'       => $scopes,
+                'postback_uri' => (string) $postbackUri->withQuery($queryString),
+            ]);
 
             return new Response\HtmlResponse(
                 $html,

--- a/src/TemplateRenderer/MustacheRenderer.php
+++ b/src/TemplateRenderer/MustacheRenderer.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Mustache template renderer bridge.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+namespace League\OAuth2\Server\TemplateRenderer;
+
+use Mustache_Engine;
+
+class MustacheRenderer implements RendererInterface
+{
+    /**
+     * @var \Mustache_Engine
+     */
+    private $engine;
+
+    /**
+     * TwigRenderer constructor.
+     *
+     * @param \Mustache_Engine $engine
+     */
+    public function __construct(Mustache_Engine $engine)
+    {
+        $this->engine = $engine;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($template, array $data = [])
+    {
+        return $this->engine->render($template, $data);
+    }
+}

--- a/src/TemplateRenderer/PlatesRenderer.php
+++ b/src/TemplateRenderer/PlatesRenderer.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plates template renderer bridge.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+namespace League\OAuth2\Server\TemplateRenderer;
+
+use League\Plates\Engine;
+
+class PlatesRenderer implements RendererInterface
+{
+    /**
+     * @var \League\Plates\Engine
+     */
+    private $engine;
+
+    /**
+     * PlatesRenderer constructor.
+     *
+     * @param \League\Plates\Engine $engine
+     */
+    public function __construct(Engine $engine)
+    {
+        $this->engine = $engine;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($template, array $data = [])
+    {
+        if ($this->engine->getFileExtension()) {
+            $template = preg_replace(sprintf('/\.%s$/', $this->engine->getFileExtension()), '', $template);
+        }
+
+        return $this->engine->render($template, $data);
+    }
+}

--- a/src/TemplateRenderer/RendererInterface.php
+++ b/src/TemplateRenderer/RendererInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Template renderer Interface.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+namespace League\OAuth2\Server\TemplateRenderer;
+
+interface RendererInterface
+{
+    /**
+     * @param string $template
+     * @param array  $data
+     *
+     * @return string
+     */
+    public function render($template, array $data = []);
+}

--- a/src/TemplateRenderer/SmartyRenderer.php
+++ b/src/TemplateRenderer/SmartyRenderer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Smarty template renderer bridge.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+namespace League\OAuth2\Server\TemplateRenderer;
+
+use Smarty;
+
+class SmartyRenderer implements RendererInterface
+{
+    /**
+     * Smarty class.
+     *
+     * @var \Smarty
+     */
+    private $smarty;
+
+    /**
+     * @param \Smarty $smarty
+     */
+    public function __construct(Smarty $smarty)
+    {
+        $this->smarty = $smarty;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($template, array $data = [])
+    {
+        $this->smarty->assign($data);
+
+        $output = $this->smarty->fetch($template);
+
+        $this->smarty->clear_assign(array_keys($data));
+
+        return $output;
+    }
+}

--- a/src/TemplateRenderer/TwigRenderer.php
+++ b/src/TemplateRenderer/TwigRenderer.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Twig template renderer bridge.
+ *
+ * @author      Julián Gutiérrez <juliangut@gmail.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+namespace League\OAuth2\Server\TemplateRenderer;
+
+use Twig_Environment;
+
+class PlatesRenderer implements RendererInterface
+{
+    /**
+     * @var \Twig_Environment
+     */
+    private $environment;
+
+    /**
+     * TwigRenderer constructor.
+     *
+     * @param \Twig_Environment $environment
+     */
+    public function __construct(Twig_Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($template, array $data = [])
+    {
+        return $this->environment->loadTemplate($template)->render($data);
+    }
+}


### PR DESCRIPTION
I've nothing against Plates as template engine but only allowing one template engine for authorization/login templates is kind of limiting.

Through `\League\OAuth2\Server\TemplateRenderer\RendererInterface` any template engine can be added, bridges for Twig, Smarty, Mustache and Plates (default) have been added.

`AbstractAuthorizeGrant` has been introduced to abstract commonalities between AuthCodeGrant and ImplicitGrant