### PR TITLE
V5 - Throw exception instead of return Response

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -128,7 +128,8 @@ class Server implements EmitterAwareInterface
         }
 
         $tokenResponse = null;
-        foreach ($this->enabledGrantTypes as $grantType) {
+        while ($tokenResponse === null && $grantType = array_shift($this->enabledGrantTypes)) {
+            /** @var \League\OAuth2\Server\Grant\GrantTypeInterface $grantType */
             if ($grantType->canRespondToRequest($request)) {
                 $tokenResponse = $grantType->respondToRequest(
                     $request,
@@ -142,11 +143,11 @@ class Server implements EmitterAwareInterface
             return $tokenResponse;
         }
 
-        if ($tokenResponse instanceof ResponseTypeInterface === false) {
-            return OAuthServerException::unsupportedGrantType()->generateHttpResponse($response);
+        if ($tokenResponse instanceof ResponseTypeInterface) {
+            return $tokenResponse->generateHttpResponse($response);
         }
 
-        return $tokenResponse->generateHttpResponse($response);
+        throw OAuthServerException::unsupportedGrantType();
     }
 
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -33,9 +33,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
 
         $server->enableGrantType(new ClientCredentialsGrant(), new \DateInterval('PT1M'));
 
-        $response = $server->respondToRequest();
-        $this->assertTrue($response instanceof ResponseInterface);
-        $this->assertEquals(400, $response->getStatusCode());
+        try {
+            $server->respondToRequest();
+        } catch (OAuthServerException $e) {
+            $this->assertEquals('unsupported_grant_type', $e->getErrorType());
+            $this->assertEquals(400, $e->getHttpStatusCode());
+        }
     }
 
     public function testRespondToRequest()


### PR DESCRIPTION
AuthenticationMiddleware (https://github.com/thephpleague/oauth2-server/blob/V5-WIP/src/Middleware/AuthenticationServerMiddleware.php#L38) expects an exception to be thrown in case token could not be generated (the token generation examples as well). 

Anyway `Server::respondToRequest` doesn't throw an exception for unsupported grants but compose a Response object.

Extra, exit soon on the grantType loop as only the first grant that matches `canRespondToRequest` should generate the token: https://github.com/juliangut/oauth2-server/blob/a0402f1994608f261a76dacc3b578e8443a70e95/src/Server.php#L131