### PR TITLE
ClientStorage returns invalid ClientEntity

### DIFF
--- a/examples/relational/Storage/ClientStorage.php
+++ b/examples/relational/Storage/ClientStorage.php
@@ -26,7 +26,6 @@ class ClientStorage extends AbstractStorage implements ClientInterface
 
         if ($redirectUri) {
             $query->join('oauth_client_redirect_uris', 'oauth_clients.id', '=', 'oauth_client_redirect_uris.client_id')
-                  ->select(['oauth_clients.*', 'oauth_client_redirect_uris.*'])
                   ->where('oauth_client_redirect_uris.redirect_uri', $redirectUri);
         }
 


### PR DESCRIPTION
ClientStorage returns invalid ClientEntity in certain cases (if client is requested with redirect_uri)
Not necessary to load table-data of oauth_client_redirect_uris. This causes ClientEntity to return primary key of oauth_client_redirect_uris table instead of client alphanumeric id. Creating a client sessions fails, because of invalid client id.