### PR TITLE
remove unnecessary methods from interfaces

### DIFF
--- a/src/Entities/Interfaces/ClientEntityInterface.php
+++ b/src/Entities/Interfaces/ClientEntityInterface.php
@@ -12,13 +12,6 @@ interface ClientEntityInterface
     public function getIdentifier();
 
     /**
-     * Set the client's identifier.
-     *
-     * @param $identifier
-     */
-    public function setIdentifier($identifier);
-
-    /**
      * Get the client's name.
      *
      * @return string
@@ -26,18 +19,11 @@ interface ClientEntityInterface
     public function getName();
 
     /**
-     * Set the client's name.
+     * Get the hashed client secret
      *
-     * @param string $name
+     * @return string
      */
-    public function setName($name);
-
-    /**
-     * Set the client's redirect uri.
-     *
-     * @param string $redirectUri
-     */
-    public function setRedirectUri($redirectUri);
+    public function getSecret();
 
     /**
      * Returns the registered redirect URI.

--- a/src/Entities/Interfaces/ScopeEntityInterface.php
+++ b/src/Entities/Interfaces/ScopeEntityInterface.php
@@ -11,10 +11,4 @@ interface ScopeEntityInterface extends \JsonSerializable
      */
     public function getIdentifier();
 
-    /**
-     * Set the scope's identifier.
-     *
-     * @param $identifier
-     */
-    public function setIdentifier($identifier);
 }

--- a/src/Entities/Interfaces/ScopeEntityInterface.php
+++ b/src/Entities/Interfaces/ScopeEntityInterface.php
@@ -10,5 +10,4 @@ interface ScopeEntityInterface extends \JsonSerializable
      * @return string
      */
     public function getIdentifier();
-
 }


### PR DESCRIPTION
The interfaces should only contain methods that are required because the server consumes those methods. A few of them were not used, and could therefore be removed,