### PR TITLE
allow data to be appended to jwt

### DIFF
--- a/src/BearerWasValidated.php
+++ b/src/BearerWasValidated.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace League\OAuth2\Server;
+
+use Lcobucci\JWT\Token;
+use League\Event\Event;
+
+class BearerWasValidated extends Event
+{
+    /**
+     * @var Token
+     */
+    private $token;
+
+    /**
+     * JwtWasValidated constructor.
+     *
+     * @param Token $token
+     */
+    public function __construct(Token $token)
+    {
+        parent::__construct('validated');
+        $this->token = $token;
+    }
+
+    /**
+     * @return Token
+     */
+    public function getToken()
+    {
+        return $this->token;
+    }
+}

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -12,7 +12,6 @@ namespace League\OAuth2\Server\Grant;
 
 use League\Event\EmitterAwareTrait;
 use League\OAuth2\Server\CryptTrait;
-use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\AuthCodeEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface;
@@ -291,11 +290,11 @@ abstract class AbstractGrant implements GrantTypeInterface
         $userIdentifier,
         array $scopes = []
     ) {
-        $accessToken = new AccessTokenEntity();
-        $accessToken->setIdentifier($this->generateUniqueIdentifier());
-        $accessToken->setExpiryDateTime((new \DateTime())->add($accessTokenTTL));
+        $accessToken = $this->accessTokenRepository->createNewToken($client, $scopes, $userIdentifier);
         $accessToken->setClient($client);
         $accessToken->setUserIdentifier($userIdentifier);
+        $accessToken->setIdentifier($this->generateUniqueIdentifier());
+        $accessToken->setExpiryDateTime((new \DateTime())->add($accessTokenTTL));
 
         foreach ($scopes as $scope) {
             $accessToken->addScope($scope);

--- a/src/Repositories/AbstractAccessTokenRepository.php
+++ b/src/Repositories/AbstractAccessTokenRepository.php
@@ -1,22 +1,11 @@
 <?php
-/**
- * OAuth 2.0 Access token storage interface.
- *
- * @author      Alex Bilbie <hello@alexbilbie.com>
- * @copyright   Copyright (c) Alex Bilbie
- * @license     http://mit-license.org/
- *
- * @link        https://github.com/thephpleague/oauth2-server
- */
 namespace League\OAuth2\Server\Repositories;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface;
 
-/**
- * Access token interface.
- */
-interface AccessTokenRepositoryInterface extends RepositoryInterface
+abstract class AbstractAccessTokenRepository implements AccessTokenRepositoryInterface
 {
     /**
      * Create a new access token
@@ -25,23 +14,26 @@ interface AccessTokenRepositoryInterface extends RepositoryInterface
      * @param \League\OAuth2\Server\Entities\Interfaces\ScopeEntityInterface[] $scopes
      * @param mixed                                                            $userIdentifier
      *
-     * @return AccessTokenEntityInterface
+     * @return \League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface
      */
-    public function createNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null);
+    public function createNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
+    {
+        return new AccessTokenEntity();
+    }
 
     /**
      * Persists a new access token to permanent storage.
      *
      * @param \League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface $accessTokenEntity
      */
-    public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity);
+    abstract public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity);
 
     /**
      * Revoke an access token.
      *
      * @param string $tokenId
      */
-    public function revokeAccessToken($tokenId);
+    abstract public function revokeAccessToken($tokenId);
 
     /**
      * Check if the access token has been revoked.
@@ -50,5 +42,5 @@ interface AccessTokenRepositoryInterface extends RepositoryInterface
      *
      * @return bool Return true if this token has been revoked
      */
-    public function isAccessTokenRevoked($tokenId);
+    abstract public function isAccessTokenRevoked($tokenId);
 }

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -248,6 +248,7 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
     public function testIssueAccessToken()
     {
         $accessTokenRepoMock = $this->getMock(AccessTokenRepositoryInterface::class);
+        $accessTokenRepoMock->method('createNewToken')->willReturn(new AccessTokenEntity());
 
         /** @var AbstractGrant $grantMock */
         $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -592,6 +593,7 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
         $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -27,6 +28,7 @@ class ClientCredentialsGrantTest extends \PHPUnit_Framework_TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -68,6 +69,7 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
         $userRepositoryMock->method('getUserEntityByUserCredentials')->willReturn($userEntity);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Grant\PasswordGrant;
@@ -34,6 +35,7 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $userRepositoryMock = $this->getMockBuilder(UserRepositoryInterface::class)->getMock();

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\Interfaces\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\Interfaces\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
@@ -48,6 +49,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock
             ->expects($this->once())
             ->method('persistNewAccessToken')->willReturnSelf();
@@ -102,6 +104,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();

--- a/tests/Middleware/AuthenticationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthenticationServerMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests\Middleware;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use League\OAuth2\Server\Middleware\AuthenticationServerMiddleware;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -23,9 +24,12 @@ class AuthenticationServerMiddlewareTest extends \PHPUnit_Framework_TestCase
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
 
+        $accessRepositoryMock = $this->getMock(AccessTokenRepositoryInterface::class);
+        $accessRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
+
         $server = new Server(
             $clientRepository,
-            $this->getMock(AccessTokenRepositoryInterface::class),
+            $accessRepositoryMock,
             $scopeRepositoryMock,
             '',
             '',

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -3,6 +3,7 @@
 namespace LeagueTests\ResponseTypes;
 
 use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
+use League\OAuth2\Server\BearerWasValidated;
 use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Entities\RefreshTokenEntity;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -90,6 +91,13 @@ class BearerResponseTypeTest extends \PHPUnit_Framework_TestCase
         $json = json_decode((string) $response->getBody());
 
         $authorizationValidator = new BearerTokenValidator($accessTokenRepositoryMock);
+        $authorizationValidator->addListener(
+            'validated',
+            function (BearerWasValidated $event) use ($accessToken) {
+                $this->assertEquals($accessToken->getIdentifier(), $event->getToken()->getClaim('jti'));
+            }
+        );
+
         $authorizationValidator->setPrivateKeyPath('file://' . __DIR__ . '/../Stubs/private.key');
         $authorizationValidator->setPublicKeyPath('file://' . __DIR__ . '/../Stubs/public.key');
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2,6 +2,7 @@
 
 namespace LeagueTests;
 
+use League\OAuth2\Server\Entities\AccessTokenEntity;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -51,9 +52,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
 
+        $accessTokenRepositoryMock = $this->getMock(AccessTokenRepositoryInterface::class);
+        $accessTokenRepositoryMock->method('createNewToken')->willReturn(new AccessTokenEntity());
+
         $server = new Server(
             $clientRepository,
-            $this->getMock(AccessTokenRepositoryInterface::class),
+            $accessTokenRepositoryMock,
             $scopeRepositoryMock,
             '',
             '',


### PR DESCRIPTION
At the moment the content of the JWT is defined from inside the library. It is not possible to append data. But an access token entity already has an interface. So it was not hard to implement the feature.

There must be a location that creates the access token, which can be implemented by the developer. So I added another method to the `AccessTokenRepositoryInterface` called `createNewToken`.

```php
public function createNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
{
    return new MyAccessTokenEntity();
}
```

Now the developer can create his own his own implementation of `AccessTokenEntityInterface` which in turn implements for `convertToJWT`.

Secondly, after the access token is validated it must be possible to read contents from the jwt. I created an additional event for this `BearerWasValidated`. From the outside, this might look like this.

```php
$validator = new BearerTokenValidator();
$validator->addListener('validated', function (BearerWasValidated $event) { $jwt = $event->getToken(); });
$server = new Server(.. $validator);
```

When the access token is validated, the content from the jwt can be read.