### PR TITLE
Client identifier passed where user identifier is expected

### DIFF
--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -34,7 +34,7 @@ class ClientCredentialsGrant extends AbstractGrant
         $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);
 
         // Issue and persist access token
-        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $client->getIdentifier(), $scopes);
+        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, null, $scopes);
 
         // Inject access token into response type
         $responseType->setAccessToken($accessToken);


### PR DESCRIPTION
With client credentials grant, the wrong identifier is passed into the `issueAccessToken` method.