### PR TITLE
two small fixes for auth code grant

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -98,6 +98,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
                 $scopes[] = $scope;
             }
+
+            // Finalize the requested scopes
+            $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client, $authCodePayload->user_id);
         } catch (\LogicException  $e) {
             throw OAuthServerException::invalidRequest('code', 'Cannot decrypt the authorization code');
         }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -109,6 +109,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         // Inject tokens into response type
         $responseType->setAccessToken($accessToken);
         $responseType->setRefreshToken($refreshToken);
+        
+        // Revoke used auth code
+        $this->authCodeRepository->revokeAuthCode($authCodePayload->auth_code_id);
 
         return $responseType;
     }


### PR DESCRIPTION
The used auth code was not revoked, so that you could use the same code multiple times and get a new access token all the time.
Also, the call to finalize scopes was missing (used to if the app & user really have the permission for all requested scopes)