### PR TITLE
less verbose exceptions for RefreshTokenGrant

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -101,17 +101,13 @@ class RefreshTokenGrant extends AbstractGrant
         try {
             $refreshToken = $this->decrypt($encryptedRefreshToken);
         } catch (\LogicException $e) {
-            throw OAuthServerException::invalidRefreshToken('Cannot parse refresh token: ' . $e->getMessage());
+            throw OAuthServerException::invalidRefreshToken('Cannot decrypt the refresh token');
         }
 
         $refreshTokenData = json_decode($refreshToken, true);
         if ($refreshTokenData['client_id'] !== $clientId) {
             $this->getEmitter()->emit(new RequestEvent('refresh_token.client.failed', $request));
-            throw OAuthServerException::invalidRefreshToken(
-                'Token is not linked to client,' .
-                ' got: ' . $clientId .
-                ' expected: ' . $refreshTokenData['client_id']
-            );
+            throw OAuthServerException::invalidRefreshToken('Token is not linked to client');
         }
 
         if ($refreshTokenData['expire_time'] < time()) {


### PR DESCRIPTION
For the LogicException you could also use `throw OAuthServerException::invalidRequest('refresh_token', 'Cannot decrypt the authorization code');`, to get the exact same error [AuthCodeGrant.php throws](https://github.com/thephpleague/oauth2-server/blob/V5-WIP/src/Grant/RefreshTokenGrant.php#L104) if decryption of `code` fails there.
The second error hint provides information which doesn't help users of the API, although it is next to impossible to trigger this error due to the encryption.