### PR TITLE
Allow phpunit 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.0",
         "zendframework/zend-diactoros": "^1.0"
     },
     "repositories": [


### PR DESCRIPTION
We can allow phpunit 5.0 when testing against newer versions of PHP.