### PR TITLE
Remove redundant parameters in getNewToken()

### DIFF
--- a/examples/src/Repositories/AccessTokenRepository.php
+++ b/examples/src/Repositories/AccessTokenRepository.php
@@ -43,15 +43,8 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
+    public function getNewToken()
     {
-        $accessToken = new AccessTokenEntity();
-        $accessToken->setClient($clientEntity);
-        foreach ($scopes as $scope) {
-            $accessToken->addScope($scope);
-        }
-        $accessToken->setUserIdentifier($userIdentifier);
-
-        return $accessToken;
+        return new AccessTokenEntity();
     }
 }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -300,7 +300,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         $userIdentifier,
         array $scopes = []
     ) {
-        $accessToken = $this->accessTokenRepository->getNewToken($client, $scopes, $userIdentifier);
+        $accessToken = $this->accessTokenRepository->getNewToken();
         $accessToken->setClient($client);
         $accessToken->setUserIdentifier($userIdentifier);
         $accessToken->setIdentifier($this->generateUniqueIdentifier());

--- a/src/Repositories/AccessTokenRepositoryInterface.php
+++ b/src/Repositories/AccessTokenRepositoryInterface.php
@@ -10,7 +10,6 @@
 namespace League\OAuth2\Server\Repositories;
 
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
-use League\OAuth2\Server\Entities\ClientEntityInterface;
 
 /**
  * Access token interface.
@@ -20,13 +19,9 @@ interface AccessTokenRepositoryInterface extends RepositoryInterface
     /**
      * Create a new access token
      *
-     * @param \League\OAuth2\Server\Entities\ClientEntityInterface  $clientEntity
-     * @param \League\OAuth2\Server\Entities\ScopeEntityInterface[] $scopes
-     * @param mixed                                                 $userIdentifier
-     *
      * @return AccessTokenEntityInterface
      */
-    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null);
+    public function getNewToken();
 
     /**
      * Persists a new access token to permanent storage.


### PR DESCRIPTION
It seems unnecessary to include the `$client`, `$scopes`, and `$userIdentifier` parameters in `AccessTokenRepositoryInterface::getNewToken()`, as these are set in `AbstractGrant::issueAccessToken()` anyway. My apologies if I've misunderstood something though.