### PR TITLE
Fix hints in PasswordGrant

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -77,12 +77,12 @@ class PasswordGrant extends AbstractGrant
     {
         $username = $this->getRequestParameter('username', $request);
         if (is_null($username)) {
-            throw OAuthServerException::invalidRequest('username', '`%s` parameter is missing');
+            throw OAuthServerException::invalidRequest('username', sprintf('`%s` parameter is missing', 'username'));
         }
 
         $password = $this->getRequestParameter('password', $request);
         if (is_null($password)) {
-            throw OAuthServerException::invalidRequest('password', '`%s` parameter is missing');
+            throw OAuthServerException::invalidRequest('password', sprintf('`%s` parameter is missing', 'password'));
         }
 
         $user = $this->userRepository->getUserEntityByUserCredentials(


### PR DESCRIPTION
When omitting `username` or `password` you get wrong hint `` `%s` is missing ``, with this PR you will get `` `username` is missing`` or `` `password` is missing``