### PR TITLE
Add meaning of `Resource owner` to terminology.md

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -12,5 +12,6 @@ permalink: /terminology/
 * `Client` - An application which accesses protected resources on behalf of the resource owner (such as a user).  The client could be hosted on a server, desktop, mobile or other device.
 * `Grant` - A grant is a method of acquiring an access token.
 * `Resource server` - A server which sits in front of protected resources (for example "tweets", users' photos, or personal data) and is capable of accepting and responsing to protected resource requests using access tokens.
+* `Resource owner` - The user who authorizes an application to access their account. The application's access to the user's account is limited to the "scope" of the authorization granted (e.g. read or write access).
 * `Scope` - A permission.
 * `JWT` - A JSON Web Token is a method for representing claims securely between two parties as defined in [RFC 7519](https://tools.ietf.org/html/rfc7519). 


### PR DESCRIPTION
I saw the section `Roles` of the [OAuth2 specification](https://tools.ietf.org/html/rfc6749#section-1.1) and could not find the meaning of `Resource owner` while all other roles where defined. To complete the list, I've added the missing role.