### PR TITLE
Include redirect_uri check on authorization endpoint

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -196,6 +196,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 throw OAuthServerException::invalidClient();
             }
         }
+        elseif(is_array($client->getRedirectUri()) && count($client->getRedirectUri()) !== 1
+            || empty($client->getRedirectUri())) {
+            $this->getEmitter()->emit(new RequestEvent(Events::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient();
+        }
 
         $scopes = $this->validateScopes(
             $this->getQueryStringParameter('scope', $request),


### PR DESCRIPTION
If multiple redirection URIs have been registered, if only part of
   the redirection URI has been registered, or if no redirection URI has
   been registered, the client MUST include a redirection URI with the
   authorization request using the "redirect_uri" request parameter.

https://tools.ietf.org/html/rfc6749#section-3.1.2.3