### PR TITLE
Include redirect_uri check on authorization endpoint

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -30,9 +30,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     private $authCodeTTL;
 
     /**
-     * @param \League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface     $authCodeRepository
+     * @param \League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface $authCodeRepository
      * @param \League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface $refreshTokenRepository
-     * @param \DateInterval                                                      $authCodeTTL
+     * @param \DateInterval $authCodeTTL
      */
     public function __construct(
         AuthCodeRepositoryInterface $authCodeRepository,
@@ -48,9 +48,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     /**
      * Respond to an access token request.
      *
-     * @param \Psr\Http\Message\ServerRequestInterface                  $request
+     * @param \Psr\Http\Message\ServerRequestInterface $request
      * @param \League\OAuth2\Server\ResponseTypes\ResponseTypeInterface $responseType
-     * @param \DateInterval                                             $accessTokenTTL
+     * @param \DateInterval $accessTokenTTL
      *
      * @throws \League\OAuth2\Server\Exception\OAuthServerException
      *
@@ -195,6 +195,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
                 throw OAuthServerException::invalidClient();
             }
+        } elseif (is_array($client->getRedirectUri()) && count($client->getRedirectUri()) !== 1
+            || empty($client->getRedirectUri())
+        ) {
+            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient();
         }
 
         $scopes = $this->validateScopes(
@@ -246,15 +251,15 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 $this->makeRedirectUri(
                     $finalRedirectUri,
                     [
-                        'code'  => $this->encrypt(
+                        'code' => $this->encrypt(
                             json_encode(
                                 [
-                                    'client_id'    => $authCode->getClient()->getIdentifier(),
+                                    'client_id' => $authCode->getClient()->getIdentifier(),
                                     'redirect_uri' => $authCode->getRedirectUri(),
                                     'auth_code_id' => $authCode->getIdentifier(),
-                                    'scopes'       => $authCode->getScopes(),
-                                    'user_id'      => $authCode->getUserIdentifier(),
-                                    'expire_time'  => (new \DateTime())->add($this->authCodeTTL)->format('U'),
+                                    'scopes' => $authCode->getScopes(),
+                                    'user_id' => $authCode->getUserIdentifier(),
+                                    'expire_time' => (new \DateTime())->add($this->authCodeTTL)->format('U'),
                                 ]
                             )
                         ),

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -32,8 +32,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $this->getMock(ClientRepositoryInterface::class),
             $this->getMock(AccessTokenRepositoryInterface::class),
             $this->getMock(ScopeRepositoryInterface::class),
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key',
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key',
             new StubResponseType()
         );
 
@@ -62,8 +62,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $clientRepository,
             $accessTokenRepositoryMock,
             $scopeRepositoryMock,
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key',
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key',
             new StubResponseType()
         );
 
@@ -84,8 +84,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $clientRepository,
             $this->getMock(AccessTokenRepositoryInterface::class),
             $this->getMock(ScopeRepositoryInterface::class),
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key'
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key'
         );
 
         $abstractGrantReflection = new \ReflectionClass($server);
@@ -103,8 +103,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $clientRepository,
             $this->getMock(AccessTokenRepositoryInterface::class),
             $this->getMock(ScopeRepositoryInterface::class),
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key'
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key'
         );
 
         $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
@@ -116,8 +116,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             new \DateInterval('PT10M')
         );
 
-        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/Stubs/private.key'));
-        $grant->setPublicKey(new CryptKey('file://' . __DIR__ . '/Stubs/public.key'));
+        $grant->setPrivateKey(new CryptKey('file://'.__DIR__.'/Stubs/private.key'));
+        $grant->setPublicKey(new CryptKey('file://'.__DIR__.'/Stubs/public.key'));
 
         $server->enableGrantType($grant);
 
@@ -135,6 +135,7 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
     public function testValidateAuthorizationRequest()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -149,8 +150,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $clientRepositoryMock,
             $this->getMock(AccessTokenRepositoryInterface::class),
             $this->getMock(ScopeRepositoryInterface::class),
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key'
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key'
         );
         $server->enableGrantType($grant);
 
@@ -164,11 +165,55 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo'
             ]
         );
 
         $this->assertTrue($server->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+    }
+
+    public function testValidateAuthorizationRequestWithMissingRedirectUri()
+    {
+        $client = new ClientEntity();
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $grant = new AuthCodeGrant(
+            $this->getMock(AuthCodeRepositoryInterface::class),
+            $this->getMock(RefreshTokenRepositoryInterface::class),
+            new \DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+
+        $server = new AuthorizationServer(
+            $clientRepositoryMock,
+            $this->getMock(AccessTokenRepositoryInterface::class),
+            $this->getMock(ScopeRepositoryInterface::class),
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key'
+        );
+        $server->enableGrantType($grant);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            $headers = [],
+            $cookies = [],
+            $queryParams = [
+                'response_type' => 'code',
+                'client_id' => 'foo'
+            ]
+        );
+
+        try {
+            $server->validateAuthorizationRequest($request);
+        } catch (OAuthServerException $e) {
+            $this->assertEquals('invalid_client', $e->getErrorType());
+            $this->assertEquals(401, $e->getHttpStatusCode());
+        }
     }
 
     /**
@@ -181,8 +226,8 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $this->getMock(ClientRepositoryInterface::class),
             $this->getMock(AccessTokenRepositoryInterface::class),
             $this->getMock(ScopeRepositoryInterface::class),
-            'file://' . __DIR__ . '/Stubs/private.key',
-            'file://' . __DIR__ . '/Stubs/public.key'
+            'file://'.__DIR__.'/Stubs/private.key',
+            'file://'.__DIR__.'/Stubs/public.key'
         );
 
         $request = new ServerRequest(
@@ -195,7 +240,7 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 


### PR DESCRIPTION
If multiple redirection URIs have been registered, if only part of
the redirection URI has been registered, or if no redirection URI has
been registered, the client MUST include a redirection URI with the
authorization request using the "redirect_uri" request parameter.

https://tools.ietf.org/html/rfc6749#section-3.1.2.3