### PR TITLE
Adding missing variable

### DIFF
--- a/auth-server-implicit.md
+++ b/auth-server-implicit.md
@@ -60,7 +60,6 @@ $server = new \League\OAuth2\Server\AuthorizationServer(
 );
 
 // Enable the implicit grant on the server
-
 $server->enableGrantType(
     new ImplicitGrant(new \DateInterval('PT1H')),
     new \DateInterval('PT1H') // access tokens will expire after 1 hour

--- a/auth-server-implicit.md
+++ b/auth-server-implicit.md
@@ -60,8 +60,9 @@ $server = new \League\OAuth2\Server\AuthorizationServer(
 );
 
 // Enable the implicit grant on the server
+
 $server->enableGrantType(
-    new ImplicitGrant(),
+    new ImplicitGrant(new \DateInterval('PT1H')),
     new \DateInterval('PT1H') // access tokens will expire after 1 hour
 );
 {% endhighlight %}


### PR DESCRIPTION
ImplicitGrant's constructor requires \DateInterval object