### PR TITLE
unify middleware exception responses

### DIFF
--- a/src/Middleware/AuthorizationServerMiddleware.php
+++ b/src/Middleware/AuthorizationServerMiddleware.php
@@ -46,9 +46,8 @@ class AuthorizationServerMiddleware
             return $exception->generateHttpResponse($response);
             // @codeCoverageIgnoreStart
         } catch (\Exception $exception) {
-            $response->getBody()->write($exception->getMessage());
-
-            return $response->withStatus(500);
+            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
+                ->generateHttpResponse($response);
             // @codeCoverageIgnoreEnd
         }
 

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -46,9 +46,8 @@ class ResourceServerMiddleware
             return $exception->generateHttpResponse($response);
             // @codeCoverageIgnoreStart
         } catch (\Exception $exception) {
-            $response->getBody()->write($exception->getMessage());
-
-            return $response->withStatus(500);
+            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
+                ->generateHttpResponse($response);
             // @codeCoverageIgnoreEnd
         }
 


### PR DESCRIPTION
If it isn't an OAuthServerException, result still needs to be properly formatted (json) and not just a string error message