### PR TITLE
Look at Authorization header directly for HTTP Basic auth checks

### DIFF
--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -32,6 +32,76 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
         $grantMock->setEmitter(new Emitter());
     }
 
+    public function testHttpBasicWithPassword()
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withHeader('Authorization', 'Basic ' . base64_encode('Open:Sesame'));
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        $this->assertSame(['Open', 'Sesame'], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
+    public function testHttpBasicNoPassword()
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withHeader('Authorization', 'Basic ' . base64_encode('Open:'));
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        $this->assertSame(['Open', ''], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
+    public function testHttpBasicNotBasic()
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withHeader('Authorization', 'Foo ' . base64_encode('Open:Sesame'));
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        $this->assertSame([null, null], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
+    public function testHttpBasicNotBase64()
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withHeader('Authorization', 'Basic ||');
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        $this->assertSame([null, null], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
+    public function testHttpBasicNoColon()
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withHeader('Authorization', 'Basic ' . base64_encode('OpenSesame'));
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        $this->assertSame([null, null], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
     public function testValidateClientPublic()
     {
         $client = new ClientEntity();


### PR DESCRIPTION
Should allow for better compatibility with server implementations that aren't sitting on top of a standard SAPI (e.g. persistent web servers building a PSR-7 compatible request from a socket-received message).

One catch here is that I've seen Apache hijack the HTTP Authorization header in the past, though that would probably impact the other aspects of the server just as much as it would this, so I think that risk is manageable.

Added tests to cover all paths through the new code, so the AbstractGrant type still has 100% coverage :)

Noticed that, as of the latest versions of PHPUnit, the mock creation method is deprecated. Maybe that needs to be updated? Haven't checked to see whether the replacements are PHPUnit 4.8 compatible though, so maybe they need to stay in order to test on older PHP versions?

Finally, I didn't see a develop branch, so PRing this against master. I'll re-PR if that's not the right place at this point.