### PR TITLE
Make ClientRepositoryInterface more flexible

### DIFF
--- a/src/Repositories/ClientRepositoryInterface.php
+++ b/src/Repositories/ClientRepositoryInterface.php
@@ -17,12 +17,12 @@ interface ClientRepositoryInterface extends RepositoryInterface
      * Get a client.
      *
      * @param string      $clientIdentifier   The client's identifier
-     * @param string      $grantType          The grant type used
+     * @param null|string $grantType          The grant type used (if sent)
      * @param null|string $clientSecret       The client's secret (if sent)
      * @param bool        $mustValidateSecret If true the client must attempt to validate the secret unless the client
      *                                        is confidential
      *
      * @return \League\OAuth2\Server\Entities\ClientEntityInterface
      */
-    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $mustValidateSecret = true);
+    public function getClientEntity($clientIdentifier, $grantType = null, $clientSecret = null, $mustValidateSecret = false);
 }


### PR DESCRIPTION
This small change will allow the use of the `ClientRepositoryInterface` for more use cases than simply validating clients when authorizing them. There might be some places where this change will affect the behavior. I also think the `$mustValidateSecret` is redundant since in an implementation a check could be done wether `$clientSecret` is null or not.
