### PR TITLE
ResourceServer: set public key only for BearerTokenValidator

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -57,9 +57,8 @@ class ResourceServer
     {
         if (!$this->authorizationValidator instanceof AuthorizationValidatorInterface) {
             $this->authorizationValidator = new BearerTokenValidator($this->accessTokenRepository);
+            $this->authorizationValidator->setPublicKey($this->publicKey);
         }
-
-        $this->authorizationValidator->setPublicKey($this->publicKey);
 
         return $this->authorizationValidator;
     }

--- a/tests/ResourceServerTest.php
+++ b/tests/ResourceServerTest.php
@@ -6,6 +6,8 @@ namespace LeagueTests;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
+use LeagueTests\Stubs\StubValidator;
+use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\ServerRequestFactory;
 
 class ResourceServerTest extends \PHPUnit_Framework_TestCase
@@ -22,5 +24,17 @@ class ResourceServerTest extends \PHPUnit_Framework_TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals('Missing "Authorization" header', $e->getHint());
         }
+    }
+
+    public function testValidateAuthenticatedRequestCustomValidator()
+    {
+        $server = new ResourceServer(
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/public.key',
+            new StubValidator()
+        );
+
+        $result = $server->validateAuthenticatedRequest(new ServerRequest());
+        $this->assertTrue($result->getAttribute('validated'));
     }
 }

--- a/tests/Stubs/StubValidator.php
+++ b/tests/Stubs/StubValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LeagueTests\Stubs;
+
+use League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class StubValidator implements AuthorizationValidatorInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     *
+     * @return ServerRequestInterface
+     */
+    public function validateAuthorization(ServerRequestInterface $request)
+    {
+        return $request->withAttribute('validated', true);
+    }
+}


### PR DESCRIPTION
`AuthorizationValidatorInterface` does not contain `setPublicKey()` method.
