### PR TITLE
AuthorizationServer: set private key only for BearerTokenResponse

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -204,9 +204,8 @@ class AuthorizationServer implements EmitterAwareInterface
     {
         if ($this->responseType instanceof ResponseTypeInterface === false) {
             $this->responseType = new BearerTokenResponse();
+            $this->responseType->setPrivateKey($this->privateKey);
         }
-
-        $this->responseType->setPrivateKey($this->privateKey);
 
         return $this->responseType;
     }

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -17,6 +17,7 @@ use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
 use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\AuthCodeEntity;
 use LeagueTests\Stubs\ClientEntity;
+use LeagueTests\Stubs\StubCustomResponseType;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
 use Psr\Http\Message\ResponseInterface;
@@ -93,6 +94,26 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
 
         $this->assertTrue($method->invoke($server) instanceof BearerTokenResponse);
+    }
+
+    /**
+     * @group wip
+     */
+    public function testGetResponseTypeCustom()
+    {
+        $server = new AuthorizationServer(
+            $this->getMockBuilder(ClientRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/private.key',
+            'file://' . __DIR__ . '/Stubs/public.key',
+            new StubCustomResponseType()
+        );
+
+        $method = new \ReflectionMethod($server, 'getResponseType');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($server) instanceof StubCustomResponseType);
     }
 
     public function testCompleteAuthorizationRequest()

--- a/tests/Stubs/StubCustomResponseType.php
+++ b/tests/Stubs/StubCustomResponseType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LeagueTests\Stubs;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class StubCustomResponseType implements ResponseTypeInterface
+{
+    /**
+     * @param \League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken
+     */
+    public function setAccessToken(AccessTokenEntityInterface $accessToken)
+    {
+    }
+
+    /**
+     * @param \League\OAuth2\Server\Entities\RefreshTokenEntityInterface $refreshToken
+     */
+    public function setRefreshToken(RefreshTokenEntityInterface $refreshToken)
+    {
+    }
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return ResponseInterface
+     */
+    public function generateHttpResponse(ResponseInterface $response)
+    {
+        return $response;
+    }
+}


### PR DESCRIPTION
`ResponseTypeInterface` does not contain `setPrivateKey()` method.
