### PR TITLE
Allow easy addition of custom fields to Bearer token response

### DIFF
--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -11,6 +11,7 @@
 
 namespace League\OAuth2\Server\ResponseTypes;
 
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -48,6 +49,8 @@ class BearerTokenResponse extends AbstractResponseType
             $responseParams['refresh_token'] = $refreshToken;
         }
 
+        $responseParams = array_merge($this->getExtraParams($this->accessToken), $responseParams);
+
         $response = $response
             ->withStatus(200)
             ->withHeader('pragma', 'no-cache')
@@ -57,5 +60,18 @@ class BearerTokenResponse extends AbstractResponseType
         $response->getBody()->write(json_encode($responseParams));
 
         return $response;
+    }
+
+    /**
+     * Add custom fields to your Bearer Token response here, then override
+     * AuthorizationServer::getResponseType() to pull in your version of
+     * this class rather than the default.
+     *
+     * @param AccessTokenEntityInterface $accessToken
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        return [];
     }
 }

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -61,6 +61,53 @@ class BearerResponseTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(isset($json->refresh_token));
     }
 
+    public function testGenerateHttpResponseWithExtraParams()
+    {
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+
+        $responseType = new BearerTokenResponseWithParams($accessTokenRepositoryMock);
+        $responseType->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+        $responseType->setPublicKey(new CryptKey('file://' . __DIR__ . '/../Stubs/public.key'));
+
+        $client = new ClientEntity();
+        $client->setIdentifier('clientName');
+
+        $scope = new ScopeEntity();
+        $scope->setIdentifier('basic');
+
+        $accessToken = new AccessTokenEntity();
+        $accessToken->setIdentifier('abcdef');
+        $accessToken->setExpiryDateTime((new \DateTime())->add(new \DateInterval('PT1H')));
+        $accessToken->setClient($client);
+        $accessToken->addScope($scope);
+
+        $refreshToken = new RefreshTokenEntity();
+        $refreshToken->setIdentifier('abcdef');
+        $refreshToken->setAccessToken($accessToken);
+        $refreshToken->setExpiryDateTime((new \DateTime())->add(new \DateInterval('PT1H')));
+
+        $responseType->setAccessToken($accessToken);
+        $responseType->setRefreshToken($refreshToken);
+
+        $response = $responseType->generateHttpResponse(new Response());
+
+        $this->assertTrue($response instanceof ResponseInterface);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('no-cache', $response->getHeader('pragma')[0]);
+        $this->assertEquals('no-store', $response->getHeader('cache-control')[0]);
+        $this->assertEquals('application/json; charset=UTF-8', $response->getHeader('content-type')[0]);
+
+        $response->getBody()->rewind();
+        $json = json_decode($response->getBody()->getContents());
+        $this->assertEquals('Bearer', $json->token_type);
+        $this->assertTrue(isset($json->expires_in));
+        $this->assertTrue(isset($json->access_token));
+        $this->assertTrue(isset($json->refresh_token));
+
+        $this->assertTrue(isset($json->foo));
+        $this->assertEquals('bar', $json->foo);
+    }
+
     public function testDetermineAccessTokenInHeaderValidToken()
     {
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
@@ -226,7 +273,7 @@ class BearerResponseTypeTest extends \PHPUnit_Framework_TestCase
             );
         }
     }
-    
+
     public function testDetermineMissingBearerInHeader()
     {
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();

--- a/tests/ResponseTypes/BearerTokenResponseWithParams.php
+++ b/tests/ResponseTypes/BearerTokenResponseWithParams.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LeagueTests\ResponseTypes;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+
+class BearerTokenResponseWithParams extends BearerTokenResponse
+{
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        return ['foo' => 'bar', 'token_type' => 'Should not overwrite'];
+    }
+}


### PR DESCRIPTION
Solves #623.

See tests/ResponseTypes/BearerTokenResponseWithParams.php for an example of how to add fields. Note that fields already defined in the response will not be overwritten.