### PR TITLE
Key file auto-generation from string

### DIFF
--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -13,6 +13,9 @@ namespace League\OAuth2\Server;
 
 class CryptKey
 {
+    const RSA_KEY_PATTERN =
+        '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----\n)(.|\n)+(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)$/';
+
     /**
      * @var string
      */
@@ -29,6 +32,10 @@ class CryptKey
      */
     public function __construct($keyPath, $passPhrase = null)
     {
+        if (preg_match(self::RSA_KEY_PATTERN, $keyPath)) {
+            $keyPath = $this->saveKeyToFile($keyPath);
+        }
+
         if (strpos($keyPath, 'file://') !== 0) {
             $keyPath = 'file://' . $keyPath;
         }
@@ -39,6 +46,24 @@ class CryptKey
 
         $this->keyPath = $keyPath;
         $this->passPhrase = $passPhrase;
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string
+     */
+    private function saveKeyToFile($key)
+    {
+        $keyPath = sys_get_temp_dir() . '/' . sha1($key) . '.key';
+
+        if (!file_exists($keyPath) && !mkdir($keyPath)) {
+            throw new \RuntimeException('"%s" key file could not be created', $keyPath);
+        }
+
+        file_put_contents($keyPath, $key);
+
+        return 'file://' . $keyPath;
     }
 
     /**

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -51,6 +51,8 @@ class CryptKey
     /**
      * @param string $key
      *
+     * @throws \RuntimeException
+     *
      * @return string
      */
     private function saveKeyToFile($key)
@@ -58,7 +60,9 @@ class CryptKey
         $keyPath = sys_get_temp_dir() . '/' . sha1($key) . '.key';
 
         if (!file_exists($keyPath) && !touch($keyPath)) {
+            // @codeCoverageIgnoreStart
             throw new \RuntimeException('"%s" key file could not be created', $keyPath);
+            // @codeCoverageIgnoreEnd
         }
 
         file_put_contents($keyPath, $key);

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -57,7 +57,7 @@ class CryptKey
     {
         $keyPath = sys_get_temp_dir() . '/' . sha1($key) . '.key';
 
-        if (!file_exists($keyPath) && !mkdir($keyPath)) {
+        if (!file_exists($keyPath) && !touch($keyPath)) {
             throw new \RuntimeException('"%s" key file could not be created', $keyPath);
         }
 

--- a/tests/CryptKeyTest.php
+++ b/tests/CryptKeyTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace LeagueTests\Utils;
+
+use League\OAuth2\Server\CryptKey;
+
+class CryptKeyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testNoFile()
+    {
+        new CryptKey('undefined file');
+    }
+
+    public function testKeyCreation()
+    {
+        $keyFile = __DIR__ . '/Stubs/public.key';
+        $key = new CryptKey($keyFile, 'secret');
+
+        $this->assertEquals('file://' . $keyFile, $key->getKeyPath());
+        $this->assertEquals('secret', $key->getPassPhrase());
+    }
+
+    public function testKeyFileCreation()
+    {
+        $keyContent = file_get_contents(__DIR__ . '/Stubs/public.key');
+        $key = new CryptKey($keyContent);
+
+        $this->assertEquals(
+            'file://' . sys_get_temp_dir() . '/' . sha1($keyContent) . '.key',
+            $key->getKeyPath()
+        );
+    }
+}


### PR DESCRIPTION
Allow storing keys in database instead of plain files.

RSA key format is detected and a file is automatically generated on sys_get_temp_dir() and used instead