### PR TITLE
Added support for Symfony HttpFoundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "zendframework/zend-diactoros": "^1.0",
-        "indigophp/hash-compat": "^1.1"
+        "zendframework/zend-diactoros": "^1.3",
+        "indigophp/hash-compat": "^1.1",
+        "symfony/psr-http-message-bridge": "^0.2.0"
     },
     "repositories": [
         {
@@ -66,6 +67,8 @@
         }
     },
     "suggest": {
-        "indigophp/hash-compat": "Polyfill for hash_equals function for PHP 5.5"
+        "indigophp/hash-compat": "Polyfill for hash_equals function for PHP 5.5",
+        "symfony/psr-http-message-bridge": "Required for Symfony HTTP request and response comparability",
+        "zendframework/zend-diactoros": "Required for Symfony HTTP request and response comparability"
     }
 }

--- a/examples/public/api.php
+++ b/examples/public/api.php
@@ -31,21 +31,20 @@ $app->add(
 $app->get(
     '/users',
     function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
-
         $users = [
             [
-                'id'    => 123,
-                'name'  => 'Alex',
+                'id' => 123,
+                'name' => 'Alex',
                 'email' => 'alex@thephpleague.com',
             ],
             [
-                'id'    => 124,
-                'name'  => 'Frank',
+                'id' => 124,
+                'name' => 'Frank',
                 'email' => 'frank@thephpleague.com',
             ],
             [
-                'id'    => 125,
-                'name'  => 'Phil',
+                'id' => 125,
+                'name' => 'Phil',
                 'email' => 'phil@thephpleague.com',
             ],
         ];

--- a/examples/public/auth_code.php
+++ b/examples/public/auth_code.php
@@ -24,7 +24,7 @@ use Zend\Diactoros\Stream;
 include __DIR__ . '/../vendor/autoload.php';
 
 $app = new App([
-    'settings'    => [
+    'settings' => [
         'displayErrorDetails' => true,
     ],
     AuthorizationServer::class => function () {

--- a/examples/public/client_credentials.php
+++ b/examples/public/client_credentials.php
@@ -20,7 +20,7 @@ use Zend\Diactoros\Stream;
 include __DIR__ . '/../vendor/autoload.php';
 
 $app = new App([
-    'settings'                 => [
+    'settings' => [
         'displayErrorDetails' => true,
     ],
     AuthorizationServer::class => function () {
@@ -30,9 +30,9 @@ $app = new App([
         $accessTokenRepository = new AccessTokenRepository(); // instance of AccessTokenRepositoryInterface
 
         // Path to public and private keys
-        $privateKey = 'file://'.__DIR__.'/../private.key';
+        $privateKey = 'file://' . __DIR__ . '/../private.key';
         //$privateKey = new CryptKey('file://path/to/private.key', 'passphrase'); // if private key has a pass phrase
-        $publicKey = 'file://'.__DIR__.'/../public.key';
+        $publicKey = 'file://' . __DIR__ . '/../public.key';
 
         // Setup the authorization server
         $server = new AuthorizationServer(

--- a/examples/public/implicit.php
+++ b/examples/public/implicit.php
@@ -22,7 +22,7 @@ use Zend\Diactoros\Stream;
 include __DIR__ . '/../vendor/autoload.php';
 
 $app = new App([
-    'settings'    => [
+    'settings' => [
         'displayErrorDetails' => true,
     ],
     AuthorizationServer::class => function () {

--- a/examples/public/middleware_use.php
+++ b/examples/public/middleware_use.php
@@ -10,8 +10,8 @@
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
-use League\OAuth2\Server\Middleware\AuthorizationServerMiddleware;
-use League\OAuth2\Server\Middleware\ResourceServerMiddleware;
+use League\OAuth2\Server\Middleware\Psr7AuthorizationServerMiddleware;
+use League\OAuth2\Server\Middleware\Psr7ResourceServerMiddleware;
 use OAuth2ServerExamples\Repositories\AccessTokenRepository;
 use OAuth2ServerExamples\Repositories\AuthCodeRepository;
 use OAuth2ServerExamples\Repositories\ClientRepository;
@@ -70,7 +70,7 @@ $app = new App([
 
 // Access token issuer
 $app->post('/access_token', function () {
-})->add(new AuthorizationServerMiddleware($app->getContainer()->get(AuthorizationServer::class)));
+})->add(new Psr7AuthorizationServerMiddleware($app->getContainer()->get(AuthorizationServer::class)));
 
 // Secured API
 $app->group('/api', function () {
@@ -94,6 +94,6 @@ $app->group('/api', function () {
 
         return $response->withBody($body);
     });
-})->add(new ResourceServerMiddleware($app->getContainer()->get(AuthorizationServer::class)));
+})->add(new Psr7ResourceServerMiddleware($app->getContainer()->get(AuthorizationServer::class)));
 
 $app->run();

--- a/examples/public/middleware_use.php
+++ b/examples/public/middleware_use.php
@@ -25,7 +25,7 @@ use Zend\Diactoros\Stream;
 include __DIR__ . '/../vendor/autoload.php';
 
 $app = new App([
-    'settings'                 => [
+    'settings' => [
         'displayErrorDetails' => true,
     ],
     AuthorizationServer::class => function () {
@@ -79,7 +79,7 @@ $app->group('/api', function () {
 
         if (in_array('basic', $request->getAttribute('oauth_scopes', []))) {
             $params = [
-                'id'   => 1,
+                'id' => 1,
                 'name' => 'Alex',
                 'city' => 'London',
             ];

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -23,8 +23,8 @@ $app = new App([
             new ClientRepository(),                 // instance of ClientRepositoryInterface
             new AccessTokenRepository(),            // instance of AccessTokenRepositoryInterface
             new ScopeRepository(),                  // instance of ScopeRepositoryInterface
-            'file://'.__DIR__.'/../private.key',    // path to private key
-            'file://'.__DIR__.'/../public.key'      // path to public key
+            'file://' . __DIR__ . '/../private.key',    // path to private key
+            'file://' . __DIR__ . '/../public.key'      // path to public key
         );
 
         $grant = new PasswordGrant(
@@ -54,19 +54,17 @@ $app->post(
 
             // Try to respond to the access token request
             return $server->respondToAccessTokenRequest($request, $response);
-
         } catch (OAuthServerException $exception) {
 
             // All instances of OAuthServerException can be converted to a PSR-7 response
             return $exception->generateHttpResponse($response);
-
         } catch (\Exception $exception) {
 
             // Catch unexpected exceptions
             $body = $response->getBody();
             $body->write($exception->getMessage());
-            return $response->withStatus(500)->withBody($body);
 
+            return $response->withStatus(500)->withBody($body);
         }
     }
 );

--- a/examples/public/refresh_token.php
+++ b/examples/public/refresh_token.php
@@ -22,7 +22,7 @@ use Zend\Diactoros\Stream;
 include __DIR__ . '/../vendor/autoload.php';
 
 $app = new App([
-    'settings'    => [
+    'settings' => [
         'displayErrorDetails' => true,
     ],
     AuthorizationServer::class => function () {

--- a/examples/src/Repositories/ClientRepository.php
+++ b/examples/src/Repositories/ClientRepository.php
@@ -21,9 +21,9 @@ class ClientRepository implements ClientRepositoryInterface
     {
         $clients = [
             'myawesomeapp' => [
-                'secret'          => password_hash('abc123', PASSWORD_BCRYPT),
-                'name'            => 'My Awesome App',
-                'redirect_uri'    => 'http://foo/bar',
+                'secret' => password_hash('abc123', PASSWORD_BCRYPT),
+                'name' => 'My Awesome App',
+                'redirect_uri' => 'http://foo/bar',
                 'is_confidential' => true,
             ],
         ];

--- a/examples/src/Repositories/ScopeRepository.php
+++ b/examples/src/Repositories/ScopeRepository.php
@@ -54,7 +54,7 @@ class ScopeRepository implements ScopeRepositoryInterface
             $scope->setIdentifier('email');
             $scopes[] = $scope;
         }
-        
+
         return $scopes;
     }
 }

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -75,7 +75,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
         } catch (\InvalidArgumentException $exception) {
             // JWT couldn't be parsed so return the request as is
             throw OAuthServerException::accessDenied($exception->getMessage());
-        } catch(\RuntimeException $exception){
+        } catch (\RuntimeException $exception) {
             //JWR couldn't be parsed so return the request as is
             throw OAuthServerException::accessDenied('Error while decoding to JSON');
         }

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -213,7 +213,7 @@ class OAuthServerException extends \Exception
         $headers = $this->getHttpHeaders();
 
         $payload = [
-            'error'   => $this->getErrorType(),
+            'error' => $this->getErrorType(),
             'message' => $this->getMessage(),
         ];
 

--- a/src/Exception/UniqueTokenIdentifierConstraintViolationException.php
+++ b/src/Exception/UniqueTokenIdentifierConstraintViolationException.php
@@ -9,7 +9,6 @@
 
 namespace League\OAuth2\Server\Exception;
 
-
 class UniqueTokenIdentifierConstraintViolationException extends OAuthServerException
 {
     public static function create()

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -345,6 +345,7 @@ abstract class AbstractGrant implements GrantTypeInterface
             $accessToken->setIdentifier($this->generateUniqueIdentifier());
             try {
                 $this->accessTokenRepository->persistNewAccessToken($accessToken);
+
                 return $accessToken;
             } catch (UniqueTokenIdentifierConstraintViolationException $e) {
                 if ($maxGenerationAttempts === 0) {
@@ -391,6 +392,7 @@ abstract class AbstractGrant implements GrantTypeInterface
             $authCode->setIdentifier($this->generateUniqueIdentifier());
             try {
                 $this->authCodeRepository->persistNewAuthCode($authCode);
+
                 return $authCode;
             } catch (UniqueTokenIdentifierConstraintViolationException $e) {
                 if ($maxGenerationAttempts === 0) {
@@ -420,6 +422,7 @@ abstract class AbstractGrant implements GrantTypeInterface
             $refreshToken->setIdentifier($this->generateUniqueIdentifier());
             try {
                 $this->refreshTokenRepository->persistNewRefreshToken($refreshToken);
+
                 return $refreshToken;
             } catch (UniqueTokenIdentifierConstraintViolationException $e) {
                 if ($maxGenerationAttempts === 0) {

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -309,16 +309,16 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 $this->makeRedirectUri(
                     $finalRedirectUri,
                     [
-                        'code'  => $this->encrypt(
+                        'code' => $this->encrypt(
                             json_encode(
                                 [
-                                    'client_id'               => $authCode->getClient()->getIdentifier(),
-                                    'redirect_uri'            => $authCode->getRedirectUri(),
-                                    'auth_code_id'            => $authCode->getIdentifier(),
-                                    'scopes'                  => $authCode->getScopes(),
-                                    'user_id'                 => $authCode->getUserIdentifier(),
-                                    'expire_time'             => (new \DateTime())->add($this->authCodeTTL)->format('U'),
-                                    'code_challenge'          => $authorizationRequest->getCodeChallenge(),
+                                    'client_id' => $authCode->getClient()->getIdentifier(),
+                                    'redirect_uri' => $authCode->getRedirectUri(),
+                                    'auth_code_id' => $authCode->getIdentifier(),
+                                    'scopes' => $authCode->getScopes(),
+                                    'user_id' => $authCode->getUserIdentifier(),
+                                    'expire_time' => (new \DateTime())->add($this->authCodeTTL)->format('U'),
+                                    'code_challenge' => $authorizationRequest->getCodeChallenge(),
                                     'code_challenge_method  ' => $authorizationRequest->getCodeChallengeMethod(),
                                 ]
                             )

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -193,9 +193,9 @@ class ImplicitGrant extends AbstractAuthorizeGrant
                     $finalRedirectUri,
                     [
                         'access_token' => (string) $accessToken->convertToJWT($this->privateKey),
-                        'token_type'   => 'bearer',
-                        'expires_in'   => $accessToken->getExpiryDateTime()->getTimestamp() - (new \DateTime())->getTimestamp(),
-                        'state'        => $authorizationRequest->getState(),
+                        'token_type' => 'bearer',
+                        'expires_in' => $accessToken->getExpiryDateTime()->getTimestamp() - (new \DateTime())->getTimestamp(),
+                        'state' => $authorizationRequest->getState(),
                     ],
                     '#'
                 )

--- a/src/HttpMessageConverter.php
+++ b/src/HttpMessageConverter.php
@@ -2,9 +2,9 @@
 
 namespace League\OAuth2\Server;
 
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -18,7 +18,7 @@ class HttpMessageConverter
      *
      * @return \Psr\Http\Message\ServerRequestInterface
      */
-    static public function convertSymfonyRequestToPsr7(SymfonyRequest $request)
+    public static function convertSymfonyRequestToPsr7(SymfonyRequest $request)
     {
         $psr7Factory = new DiactorosFactory();
 
@@ -32,7 +32,7 @@ class HttpMessageConverter
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    static public function convertSymfonyResponseToPsr7(SymfonyResponse $response)
+    public static function convertSymfonyResponseToPsr7(SymfonyResponse $response)
     {
         $psr7Factory = new DiactorosFactory();
 
@@ -46,7 +46,7 @@ class HttpMessageConverter
      *
      * @return \Symfony\Component\HttpFoundation\Request
      */
-    static public function convertPsr7RequestToSymfony(ServerRequestInterface $request)
+    public static function convertPsr7RequestToSymfony(ServerRequestInterface $request)
     {
         $httpFoundationFactory = new HttpFoundationFactory();
 
@@ -60,7 +60,7 @@ class HttpMessageConverter
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    static public function convertPsr7ResponseToSymfony(ResponseInterface $response)
+    public static function convertPsr7ResponseToSymfony(ResponseInterface $response)
     {
         $httpFoundationFactory = new HttpFoundationFactory();
 

--- a/src/HttpMessageConverter.php
+++ b/src/HttpMessageConverter.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace League\OAuth2\Server;
+
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class HttpMessageConverter
+{
+    /**
+     * Convert a Symfony HTTP Request to a Psr7 Response
+     *
+     * @param SymfonyRequest $request
+     *
+     * @return \Psr\Http\Message\ServerRequestInterface
+     */
+    static public function convertSymfonyRequestToPsr7(SymfonyRequest $request)
+    {
+        $psr7Factory = new DiactorosFactory();
+
+        return $psr7Factory->createRequest($request);
+    }
+
+    /**
+     * Convert a Symfony HTTP Response to a Psr7 Response
+     *
+     * @param SymfonyResponse $response
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    static public function convertSymfonyResponseToPsr7(SymfonyResponse $response)
+    {
+        $psr7Factory = new DiactorosFactory();
+
+        return $psr7Factory->createResponse($response);
+    }
+
+    /**
+     * Convert a Symfony HTTP Request to a Psr7 Response
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     *
+     * @return \Symfony\Component\HttpFoundation\Request
+     */
+    static public function convertPsr7RequestToSymfony(ServerRequestInterface $request)
+    {
+        $httpFoundationFactory = new HttpFoundationFactory();
+
+        return $httpFoundationFactory->createRequest($request);
+    }
+
+    /**
+     * Convert a Symfony HTTP Response to a Psr7 Response
+     *
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    static public function convertPsr7ResponseToSymfony(ResponseInterface $response)
+    {
+        $httpFoundationFactory = new HttpFoundationFactory();
+
+        return $httpFoundationFactory->createResponse($response);
+    }
+}

--- a/src/Middleware/AuthorizationServerMiddleware.php
+++ b/src/Middleware/AuthorizationServerMiddleware.php
@@ -9,47 +9,9 @@
 
 namespace League\OAuth2\Server\Middleware;
 
-use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\Exception\OAuthServerException;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-
-class AuthorizationServerMiddleware
+/**
+ * @deprecated Use the Psr7AuthorizationServerMiddleware or SymfonyAuthorizationServerMiddleware
+ */
+class AuthorizationServerMiddleware extends PSR7AuthorizationServerMiddleware
 {
-    /**
-     * @var AuthorizationServer
-     */
-    private $server;
-
-    /**
-     * @param AuthorizationServer $server
-     */
-    public function __construct(AuthorizationServer $server)
-    {
-        $this->server = $server;
-    }
-
-    /**
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
-     * @param callable               $next
-     *
-     * @return ResponseInterface
-     */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
-        try {
-            $response = $this->server->respondToAccessTokenRequest($request, $response);
-        } catch (OAuthServerException $exception) {
-            return $exception->generateHttpResponse($response);
-            // @codeCoverageIgnoreStart
-        } catch (\Exception $exception) {
-            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
-                ->generateHttpResponse($response);
-            // @codeCoverageIgnoreEnd
-        }
-
-        // Pass the request and response on to the next responder in the chain
-        return $next($request, $response);
-    }
 }

--- a/src/Middleware/AuthorizationServerMiddleware.php
+++ b/src/Middleware/AuthorizationServerMiddleware.php
@@ -12,6 +12,6 @@ namespace League\OAuth2\Server\Middleware;
 /**
  * @deprecated Use the Psr7AuthorizationServerMiddleware or SymfonyAuthorizationServerMiddleware
  */
-class AuthorizationServerMiddleware extends PSR7AuthorizationServerMiddleware
+class AuthorizationServerMiddleware extends Psr7AuthorizationServerMiddleware
 {
 }

--- a/src/Middleware/Psr7AuthorizationServerMiddleware.php
+++ b/src/Middleware/Psr7AuthorizationServerMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Middleware;
+
+use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class Psr7AuthorizationServerMiddleware
+{
+    /**
+     * @var AuthorizationServer
+     */
+    private $server;
+
+    /**
+     * @param AuthorizationServer $server
+     */
+    public function __construct(AuthorizationServer $server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     * @param callable               $next
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        try {
+            $response = $this->server->respondToAccessTokenRequest($request, $response);
+        } catch (OAuthServerException $exception) {
+            return $exception->generateHttpResponse($response);
+            // @codeCoverageIgnoreStart
+        } catch (\Exception $exception) {
+            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
+                ->generateHttpResponse($response);
+            // @codeCoverageIgnoreEnd
+        }
+
+        // Pass the request and response on to the next responder in the chain
+        return $next($request, $response);
+    }
+}

--- a/src/Middleware/Psr7ResourceServerMiddleware.php
+++ b/src/Middleware/Psr7ResourceServerMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Middleware;
+
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\ResourceServer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class Psr7ResourceServerMiddleware
+{
+    /**
+     * @var ResourceServer
+     */
+    private $server;
+
+    /**
+     * @param ResourceServer $server
+     */
+    public function __construct(ResourceServer $server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     * @param callable               $next
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        try {
+            $request = $this->server->validateAuthenticatedRequest($request);
+        } catch (OAuthServerException $exception) {
+            return $exception->generateHttpResponse($response);
+            // @codeCoverageIgnoreStart
+        } catch (\Exception $exception) {
+            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
+                ->generateHttpResponse($response);
+            // @codeCoverageIgnoreEnd
+        }
+
+        // Pass the request and response on to the next responder in the chain
+        return $next($request, $response);
+    }
+}

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -9,47 +9,9 @@
 
 namespace League\OAuth2\Server\Middleware;
 
-use League\OAuth2\Server\Exception\OAuthServerException;
-use League\OAuth2\Server\ResourceServer;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-
-class ResourceServerMiddleware
+/**
+ * @deprecated Use the Psr7ResourceServerMiddleware or SymfonyResourceServerMiddleware
+ */
+class ResourceServerMiddleware extends Psr7ResourceServerMiddleware
 {
-    /**
-     * @var ResourceServer
-     */
-    private $server;
-
-    /**
-     * @param ResourceServer $server
-     */
-    public function __construct(ResourceServer $server)
-    {
-        $this->server = $server;
-    }
-
-    /**
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
-     * @param callable               $next
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
-        try {
-            $request = $this->server->validateAuthenticatedRequest($request);
-        } catch (OAuthServerException $exception) {
-            return $exception->generateHttpResponse($response);
-            // @codeCoverageIgnoreStart
-        } catch (\Exception $exception) {
-            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
-                ->generateHttpResponse($response);
-            // @codeCoverageIgnoreEnd
-        }
-
-        // Pass the request and response on to the next responder in the chain
-        return $next($request, $response);
-    }
 }

--- a/src/Middleware/SmyfonyAuthorizationServerMiddleware.php
+++ b/src/Middleware/SmyfonyAuthorizationServerMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Middleware;
+
+use League\OAuth2\Server\HttpMessageConverter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Zend\Diactoros\Response;
+
+class SymfonyAuthorizationServerMiddleware extends Psr7AuthorizationServerMiddleware
+{
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param callable                                  $next
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function handle(Request $request, callable $next)
+    {
+        return $this->__invoke($request, $next);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param callable                                  $next
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function __invoke(Request $request, callable $next)
+    {
+        $psr7request = HttpMessageConverter::convertSymfonyRequestToPsr7($request);
+        $psr7response = new Response();
+
+        return parent::__invoke(
+            $psr7request,
+            $psr7response,
+            function (ServerRequestInterface $psr7request, ResponseInterface $psr7response) use ($next) {
+                return $next(
+                    HttpMessageConverter::convertPsr7RequestToSymfony($psr7request),
+                    HttpMessageConverter::convertPsr7ResponseToSymfony($psr7response)
+                );
+            }
+        );
+    }
+}

--- a/src/Middleware/SmyfonyAuthorizationServerMiddleware.php
+++ b/src/Middleware/SmyfonyAuthorizationServerMiddleware.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Zend\Diactoros\Response;
 
-class SymfonyAuthorizationServerMiddleware extends Psr7AuthorizationServerMiddleware
+class SmyfonyAuthorizationServerMiddleware extends Psr7AuthorizationServerMiddleware
 {
     /**
      * @param \Symfony\Component\HttpFoundation\Request $request

--- a/src/Middleware/SymfonyResourceServerMiddleware.php
+++ b/src/Middleware/SymfonyResourceServerMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Middleware;
+
+use League\OAuth2\Server\HttpMessageConverter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Zend\Diactoros\Response;
+
+class SymfonyResourceServerMiddleware extends Psr7ResourceServerMiddleware
+{
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param callable                                  $next
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function handle(Request $request, callable $next)
+    {
+        return $this->__invoke($request, $next);
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param callable                                  $next
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function __invoke(Request $request, callable $next)
+    {
+        $psr7request = HttpMessageConverter::convertSymfonyRequestToPsr7($request);
+        $psr7response = new Response();
+
+        return parent::__invoke(
+            $psr7request,
+            $psr7response,
+            function (ServerRequestInterface $psr7request, ResponseInterface $psr7response) use ($next) {
+                return $next(
+                    HttpMessageConverter::convertPsr7RequestToSymfony($psr7request),
+                    HttpMessageConverter::convertPsr7ResponseToSymfony($psr7response)
+                );
+            }
+        );
+    }
+}

--- a/src/RequestTypes/AuthorizationRequest.php
+++ b/src/RequestTypes/AuthorizationRequest.php
@@ -66,12 +66,14 @@ class AuthorizationRequest
 
     /**
      * The code challenge (if provided)
+     *
      * @var string
      */
     protected $codeChallenge;
 
     /**
      * The code challenge method (if provided)
+     *
      * @var string
      */
     protected $codeChallengeMethod;

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -27,8 +27,8 @@ class BearerTokenResponse extends AbstractResponseType
         $jwtAccessToken = $this->accessToken->convertToJWT($this->privateKey);
 
         $responseParams = [
-            'token_type'   => 'Bearer',
-            'expires_in'   => $expireDateTime - (new \DateTime())->getTimestamp(),
+            'token_type' => 'Bearer',
+            'expires_in' => $expireDateTime - (new \DateTime())->getTimestamp(),
             'access_token' => (string) $jwtAccessToken,
         ];
 
@@ -36,12 +36,12 @@ class BearerTokenResponse extends AbstractResponseType
             $refreshToken = $this->encrypt(
                 json_encode(
                     [
-                        'client_id'        => $this->accessToken->getClient()->getIdentifier(),
+                        'client_id' => $this->accessToken->getClient()->getIdentifier(),
                         'refresh_token_id' => $this->refreshToken->getIdentifier(),
-                        'access_token_id'  => $this->accessToken->getIdentifier(),
-                        'scopes'           => $this->accessToken->getScopes(),
-                        'user_id'          => $this->accessToken->getUserIdentifier(),
-                        'expire_time'      => $this->refreshToken->getExpiryDateTime()->getTimestamp(),
+                        'access_token_id' => $this->accessToken->getIdentifier(),
+                        'scopes' => $this->accessToken->getScopes(),
+                        'user_id' => $this->accessToken->getUserIdentifier(),
+                        'expire_time' => $this->refreshToken->getExpiryDateTime()->getTimestamp(),
                     ]
                 )
             );
@@ -68,6 +68,7 @@ class BearerTokenResponse extends AbstractResponseType
      * this class rather than the default.
      *
      * @param AccessTokenEntityInterface $accessToken
+     *
      * @return array
      */
     protected function getExtraParams(AccessTokenEntityInterface $accessToken)

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -164,7 +164,7 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 
@@ -195,7 +195,7 @@ class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -144,9 +144,9 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
         $validateClientMethod = $abstractGrantReflection->getMethod('validateClient');
@@ -219,7 +219,7 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody([
-            'client_id'     => 'foo',
+            'client_id' => 'foo',
             'client_secret' => 'foo',
         ]);
 
@@ -247,7 +247,7 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody([
-            'client_id'    => 'foo',
+            'client_id' => 'foo',
             'redirect_uri' => 'http://bar/foo',
         ]);
 
@@ -275,7 +275,7 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody([
-            'client_id'    => 'foo',
+            'client_id' => 'foo',
             'redirect_uri' => 'http://bar/foo',
         ]);
 
@@ -301,7 +301,7 @@ class AbstractGrantTest extends \PHPUnit_Framework_TestCase
 
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody([
-            'client_id'     => 'foo',
+            'client_id' => 'foo',
             'client_secret' => 'bar',
         ]);
 

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -66,7 +66,7 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 
@@ -97,8 +97,8 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
@@ -129,14 +129,13 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
         $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
     }
-
 
     public function testValidateAuthorizationRequestCodeChallenge()
     {
@@ -162,9 +161,9 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'response_type'  => 'code',
-                'client_id'      => 'foo',
-                'redirect_uri'   => 'http://foo/bar',
+                'response_type' => 'code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
                 'code_challenge' => 'FOOBAR',
             ]
         );
@@ -229,7 +228,7 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 
@@ -264,8 +263,8 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://bar',
             ]
         );
 
@@ -300,8 +299,8 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://bar',
             ]
         );
 
@@ -337,8 +336,8 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
@@ -373,10 +372,10 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'response_type'         => 'code',
-                'client_id'             => 'foo',
-                'redirect_uri'          => 'http://foo/bar',
-                'code_challenge'        => 'foobar',
+                'response_type' => 'code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
+                'code_challenge' => 'foobar',
                 'code_challenge_method' => 'foo',
             ]
         );
@@ -477,17 +476,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -546,20 +545,20 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
                 'code_verifier' => 'foobar',
-                'code'          => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'user_id'               => 123,
-                            'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => 'foobar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
+                            'redirect_uri' => 'http://foo/bar',
+                            'code_challenge' => 'foobar',
                             'code_challenge_method' => 'plain',
                         ]
                     )
@@ -618,20 +617,20 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
                 'code_verifier' => 'foobar',
-                'code'          => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'user_id'               => 123,
-                            'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => urlencode(base64_encode(hash('sha256', 'foobar'))),
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
+                            'redirect_uri' => 'http://foo/bar',
+                            'code_challenge' => urlencode(base64_encode(hash('sha256', 'foobar'))),
                             'code_challenge_method' => 'S256',
                         ]
                     )
@@ -675,15 +674,15 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'client_id'  => 'foo',
+                'client_id' => 'foo',
                 'grant_type' => 'authorization_code',
-                'code'       => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'redirect_uri'          => 'http://foo/bar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'redirect_uri' => 'http://foo/bar',
                         ]
                     )
                 ),
@@ -722,16 +721,16 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'client_id'  => 'foo',
+                'client_id' => 'foo',
                 'grant_type' => 'authorization_code',
                 'redirect_uri' => 'http://bar/foo',
-                'code'       => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'redirect_uri'          => 'http://foo/bar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'redirect_uri' => 'http://foo/bar',
                         ]
                     )
                 ),
@@ -776,10 +775,10 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
@@ -822,17 +821,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() - 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() - 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -886,17 +885,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -947,17 +946,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'bar',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'bar',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -1008,10 +1007,10 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => 'sdfsfsd',
+                'code' => 'sdfsfsd',
             ]
         );
 
@@ -1067,20 +1066,20 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
                 'code_verifier' => 'nope',
-                'code'          => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'user_id'               => 123,
-                            'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => 'foobar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
+                            'redirect_uri' => 'http://foo/bar',
+                            'code_challenge' => 'foobar',
                             'code_challenge_method' => 'plain',
                         ]
                     )
@@ -1140,20 +1139,20 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
                 'code_verifier' => 'nope',
-                'code'          => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'user_id'               => 123,
-                            'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => 'foobar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
+                            'redirect_uri' => 'http://foo/bar',
+                            'code_challenge' => 'foobar',
                             'code_challenge_method' => 'S256',
                         ]
                     )
@@ -1213,19 +1212,19 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
-                            'auth_code_id'          => uniqid(),
-                            'expire_time'           => time() + 3600,
-                            'client_id'             => 'foo',
-                            'user_id'               => 123,
-                            'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => 'foobar',
+                            'auth_code_id' => uniqid(),
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
+                            'redirect_uri' => 'http://foo/bar',
+                            'code_challenge' => 'foobar',
                             'code_challenge_method' => 'plain',
                         ]
                     )
@@ -1367,17 +1366,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -1439,17 +1438,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )
@@ -1511,17 +1510,17 @@ class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
             [],
             [],
             [
-                'grant_type'   => 'authorization_code',
-                'client_id'    => 'foo',
+                'grant_type' => 'authorization_code',
+                'client_id' => 'foo',
                 'redirect_uri' => 'http://foo/bar',
-                'code'         => $this->cryptStub->doEncrypt(
+                'code' => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
                             'auth_code_id' => uniqid(),
-                            'expire_time'  => time() + 3600,
-                            'client_id'    => 'foo',
-                            'user_id'      => 123,
-                            'scopes'       => ['foo'],
+                            'expire_time' => time() + 3600,
+                            'client_id' => 'foo',
+                            'user_id' => 123,
+                            'scopes' => ['foo'],
                             'redirect_uri' => 'http://foo/bar',
                         ]
                     )

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -41,7 +41,7 @@ class ClientCredentialsGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
             ]
         );

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -72,7 +72,7 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'token',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 
@@ -99,8 +99,8 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
@@ -127,8 +127,8 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://foo/bar',
             ]
         );
 
@@ -184,7 +184,7 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
             ]
         );
 
@@ -215,8 +215,8 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://bar',
             ]
         );
 
@@ -247,8 +247,8 @@ class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
             $cookies = [],
             $queryParams = [
                 'response_type' => 'code',
-                'client_id'     => 'foo',
-                'redirect_uri'  => 'http://bar',
+                'client_id' => 'foo',
+                'redirect_uri' => 'http://bar',
             ]
         );
 

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -57,10 +57,10 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
-                'username'      => 'foo',
-                'password'      => 'bar',
+                'username' => 'foo',
+                'password' => 'bar',
             ]
         );
 
@@ -93,7 +93,7 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
             ]
         );
@@ -124,9 +124,9 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
-                'username'      => 'alex',
+                'username' => 'alex',
             ]
         );
 
@@ -157,10 +157,10 @@ class PasswordGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
-                'username'      => 'alex',
-                'password'      => 'whisky',
+                'username' => 'alex',
+                'password' => 'whisky',
             ]
         );
 

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -71,12 +71,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'foo',
+                    'client_id' => 'foo',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() + 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo'],
+                    'user_id' => 123,
+                    'expire_time' => time() + 3600,
                 ]
             )
         );
@@ -84,7 +84,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
             ]
@@ -127,12 +127,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'foo',
+                    'client_id' => 'foo',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo', 'bar'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() + 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo', 'bar'],
+                    'user_id' => 123,
+                    'expire_time' => time() + 3600,
                 ]
             )
         );
@@ -140,10 +140,10 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
-                'scope'         => 'foo',
+                'scope' => 'foo',
             ]
         );
 
@@ -186,12 +186,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'foo',
+                    'client_id' => 'foo',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo', 'bar'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() + 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo', 'bar'],
+                    'user_id' => 123,
+                    'expire_time' => time() + 3600,
                 ]
             )
         );
@@ -199,10 +199,10 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
-                'scope'         => 'foobar',
+                'scope' => 'foobar',
             ]
         );
 
@@ -233,7 +233,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
             ]
         );
@@ -267,7 +267,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
             ]
@@ -304,12 +304,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'bar',
+                    'client_id' => 'bar',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() + 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo'],
+                    'user_id' => 123,
+                    'expire_time' => time() + 3600,
                 ]
             )
         );
@@ -317,7 +317,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
             ]
@@ -350,12 +350,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'foo',
+                    'client_id' => 'foo',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() - 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo'],
+                    'user_id' => 123,
+                    'expire_time' => time() - 3600,
                 ]
             )
         );
@@ -363,7 +363,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
             ]
@@ -397,12 +397,12 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             json_encode(
                 [
-                    'client_id'        => 'foo',
+                    'client_id' => 'foo',
                     'refresh_token_id' => 'zyxwvu',
-                    'access_token_id'  => 'abcdef',
-                    'scopes'           => ['foo'],
-                    'user_id'          => 123,
-                    'expire_time'      => time() + 3600,
+                    'access_token_id' => 'abcdef',
+                    'scopes' => ['foo'],
+                    'user_id' => 123,
+                    'expire_time' => time() + 3600,
                 ]
             )
         );
@@ -410,7 +410,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $serverRequest = new ServerRequest();
         $serverRequest = $serverRequest->withParsedBody(
             [
-                'client_id'     => 'foo',
+                'client_id' => 'foo',
                 'client_secret' => 'bar',
                 'refresh_token' => $oldRefreshToken,
             ]


### PR DESCRIPTION
* `AuthorizationServerMiddleware` renamed to `Psr7AuthorizationServerMiddleware`
* `ResourceServerMiddleware` renamed to `Psr7ResourceServerMiddleware`
* Added deprecation warning on `AuthorizationServerMiddleware`
* Added deprecation warning on `ResourceServerMiddleware `
* Added new `HttpMessageConverter` class
* Added `SymfonyAuthorizationServerMiddleware`
* Added `SymfonyResourceServerMiddleware`