### PR TITLE
Update Laravel link

### DIFF
--- a/framework-integrations.md
+++ b/framework-integrations.md
@@ -6,7 +6,7 @@ permalink: /framework-integrations/
 
 # Framework Integrations
 
-* [Laravel + Lumen](https://github.com/lucadegasperi/oauth2-server-laravel)
+* [Laravel + Lumen](https://laravel.com/docs/passport)
 * Slim (or any PSR7-supporting framework) - See the examples in this repository
 * [Nette Framework](https://github.com/lookyman/nette-oauth2-server)
 

--- a/framework-integrations.md
+++ b/framework-integrations.md
@@ -6,7 +6,8 @@ permalink: /framework-integrations/
 
 # Framework Integrations
 
-* [Laravel + Lumen](https://laravel.com/docs/passport)
+* [Laravel + Lumen](https://github.com/lucadegasperi/oauth2-server-laravel)
+* [Laravel Passport (Official)](https://laravel.com/docs/passport)
 * Slim (or any PSR7-supporting framework) - See the examples in this repository
 * [Nette Framework](https://github.com/lookyman/nette-oauth2-server)
 


### PR DESCRIPTION
The passport package has replaced oauth2-server-laravel for future versions of Laravel.