### PR TITLE
Alternative approach to RFC 7636

### DIFF
--- a/src/CodeChallengeVerifiers/CodeChallengeVerifierInterface.php
+++ b/src/CodeChallengeVerifiers/CodeChallengeVerifierInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author      Lukáš Unger <lookymsc@gmail.com>
+ * @copyright   Copyright (c) Lukáš Unger
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\CodeChallengeVerifiers;
+
+interface CodeChallengeVerifierInterface
+{
+    /**
+     * Return code challenge method.
+     *
+     * @return string
+     */
+    public function getMethod();
+
+    /**
+     * Verify the code challenge.
+     *
+     * @param string $codeVerifier
+     * @param string $codeChallenge
+     *
+     * @return bool
+     */
+    public function verifyCodeChallenge($codeVerifier, $codeChallenge);
+}

--- a/src/CodeChallengeVerifiers/PlainVerifier.php
+++ b/src/CodeChallengeVerifiers/PlainVerifier.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author      Lukáš Unger <lookymsc@gmail.com>
+ * @copyright   Copyright (c) Lukáš Unger
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\CodeChallengeVerifiers;
+
+class PlainVerifier implements CodeChallengeVerifierInterface
+{
+    /**
+     * Return code challenge method.
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return 'plain';
+    }
+
+    /**
+     * Verify the code challenge.
+     *
+     * @param string $codeVerifier
+     * @param string $codeChallenge
+     *
+     * @return bool
+     */
+    public function verifyCodeChallenge($codeVerifier, $codeChallenge)
+    {
+        return hash_equals($codeVerifier, $codeChallenge);
+    }
+}

--- a/src/CodeChallengeVerifiers/S256Verifier.php
+++ b/src/CodeChallengeVerifiers/S256Verifier.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author      Lukáš Unger <lookymsc@gmail.com>
+ * @copyright   Copyright (c) Lukáš Unger
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\CodeChallengeVerifiers;
+
+class S256Verifier implements CodeChallengeVerifierInterface
+{
+    /**
+     * Return code challenge method.
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return 'S256';
+    }
+
+    /**
+     * Verify the code challenge.
+     *
+     * @param string $codeVerifier
+     * @param string $codeChallenge
+     *
+     * @return bool
+     */
+    public function verifyCodeChallenge($codeVerifier, $codeChallenge)
+    {
+        return hash_equals(
+            strtr(rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='), '+/', '-_'),
+            $codeChallenge
+        );
+    }
+}

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -9,6 +9,7 @@
 
 namespace League\OAuth2\Server\Grant;
 
+use League\OAuth2\Server\CodeChallengeVerifiers\CodeChallengeVerifierInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
@@ -29,9 +30,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     private $authCodeTTL;
 
     /**
-     * @var bool
+     * @var CodeChallengeVerifierInterface[]
      */
-    private $enableCodeExchangeProof = false;
+    private $codeChallengeVerifiers = [];
 
     /**
      * @param AuthCodeRepositoryInterface     $authCodeRepository
@@ -49,9 +50,14 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         $this->refreshTokenTTL = new \DateInterval('P1M');
     }
 
-    public function enableCodeExchangeProof()
+    /**
+     * Enable a code challenge verifier on the grant.
+     *
+     * @param CodeChallengeVerifierInterface $codeChallengeVerifier
+     */
+    public function enableCodeChallengeVerifier(CodeChallengeVerifierInterface $codeChallengeVerifier)
     {
-        $this->enableCodeExchangeProof = true;
+        $this->codeChallengeVerifiers[$codeChallengeVerifier->getMethod()] = $codeChallengeVerifier;
     }
 
     /**
@@ -127,38 +133,25 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             throw OAuthServerException::invalidRequest('code', 'Cannot decrypt the authorization code');
         }
 
-        // Validate code challenge
-        if ($this->enableCodeExchangeProof === true) {
+        // Verify code challenge
+        if (empty($this->codeChallengeVerifiers) === false) {
             $codeVerifier = $this->getRequestParameter('code_verifier', $request, null);
             if ($codeVerifier === null) {
                 throw OAuthServerException::invalidRequest('code_verifier');
             }
 
-            switch ($authCodePayload->code_challenge_method) {
-                case 'plain':
-                    if (hash_equals($codeVerifier, $authCodePayload->code_challenge) === false) {
-                        throw OAuthServerException::invalidGrant('Failed to verify `code_verifier`.');
-                    }
-
-                    break;
-                case 'S256':
-                    if (
-                        hash_equals(
-                            strtr(rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='), '+/', '-_'),
-                            $authCodePayload->code_challenge
-                        ) === false
-                    ) {
-                        throw OAuthServerException::invalidGrant('Failed to verify `code_verifier`.');
-                    }
-                    // @codeCoverageIgnoreStart
-                    break;
-                default:
-                    throw OAuthServerException::serverError(
-                        sprintf(
-                            'Unsupported code challenge method `%s`',
-                            $authCodePayload->code_challenge_method
-                        )
-                    );
+            if (isset($this->codeChallengeVerifiers[$authCodePayload->code_challenge_method])) {
+                if ($this->codeChallengeVerifiers[$authCodePayload->code_challenge_method]->verifyCodeChallenge($codeVerifier, $authCodePayload->code_challenge) === false) {
+                    throw OAuthServerException::invalidGrant('Failed to verify `code_verifier`.');
+                }
+            } else {
+                // @codeCoverageIgnoreStart
+                throw OAuthServerException::serverError(
+                    sprintf(
+                        'Unsupported code challenge method `%s`',
+                        $authCodePayload->code_challenge_method
+                    )
+                );
                 // @codeCoverageIgnoreEnd
             }
         }
@@ -263,7 +256,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         $authorizationRequest->setState($stateParameter);
         $authorizationRequest->setScopes($scopes);
 
-        if ($this->enableCodeExchangeProof === true) {
+        if (empty($this->codeChallengeVerifiers) === false) {
             $codeChallenge = $this->getQueryStringParameter('code_challenge', $request);
             if ($codeChallenge === null) {
                 throw OAuthServerException::invalidRequest('code_challenge');
@@ -277,10 +270,13 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             }
 
             $codeChallengeMethod = $this->getQueryStringParameter('code_challenge_method', $request, 'plain');
-            if (in_array($codeChallengeMethod, ['plain', 'S256']) === false) {
+            if (array_key_exists($codeChallengeMethod, $this->codeChallengeVerifiers) === false) {
                 throw OAuthServerException::invalidRequest(
                     'code_challenge_method',
-                    'Code challenge method must be `plain` or `S256`'
+                    'Code challenge method must be one of ' . implode(', ', array_map(
+                        function ($method) { return '`' . $method . '`'; },
+                        array_keys($this->codeChallengeVerifiers)
+                    ))
                 );
             }
 

--- a/tests/CodeChallengeVerifiers/PlainVerifierTest.php
+++ b/tests/CodeChallengeVerifiers/PlainVerifierTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LeagueTests\CodeChallengeVerifiers;
+
+use League\OAuth2\Server\CodeChallengeVerifiers\PlainVerifier;
+use PHPUnit\Framework\TestCase;
+
+class PlainVerifierTest extends TestCase
+{
+    public function testGetMethod()
+    {
+        $verifier = new PlainVerifier();
+        $this->assertEquals('plain', $verifier->getMethod());
+    }
+
+    public function testVerifyCodeChallenge()
+    {
+        $verifier = new PlainVerifier();
+        $this->assertTrue($verifier->verifyCodeChallenge('foo', 'foo'));
+        $this->assertFalse($verifier->verifyCodeChallenge('foo', 'bar'));
+    }
+}

--- a/tests/CodeChallengeVerifiers/S256VerifierTest.php
+++ b/tests/CodeChallengeVerifiers/S256VerifierTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LeagueTests\CodeChallengeVerifiers;
+
+use League\OAuth2\Server\CodeChallengeVerifiers\S256Verifier;
+use PHPUnit\Framework\TestCase;
+
+class S256VerifierTest extends TestCase
+{
+    public function testGetMethod()
+    {
+        $verifier = new S256Verifier();
+        $this->assertEquals('S256', $verifier->getMethod());
+    }
+
+    public function testVerifyCodeChallenge()
+    {
+        $verifier = new S256Verifier();
+
+        $this->assertTrue($verifier->verifyCodeChallenge('foo', strtr(rtrim(base64_encode(hash('sha256', 'foo', true)), '='), '+/', '-_')));
+        $this->assertFalse($verifier->verifyCodeChallenge('foo', strtr(rtrim(base64_encode(hash('sha256', 'bar', true)), '='), '+/', '-_')));
+    }
+}

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -2,6 +2,8 @@
 
 namespace LeagueTests\Grant;
 
+use League\OAuth2\Server\CodeChallengeVerifiers\PlainVerifier;
+use League\OAuth2\Server\CodeChallengeVerifiers\S256Verifier;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -168,7 +170,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setDefaultScope(self::DEFAULT_SCOPE);
@@ -207,7 +209,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
 
         $request = new ServerRequest(
@@ -244,7 +246,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+		$grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
 
         $request = new ServerRequest(
@@ -281,7 +283,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
 
         $request = new ServerRequest(
@@ -300,7 +302,9 @@ class AuthCodeGrantTest extends TestCase
             ]
         );
 
-        $grant->validateAuthorizationRequest($request);
+        self::assertInstanceOf(AuthorizationRequest::class, $authorizationRequest = $grant->validateAuthorizationRequest($request));
+        self::assertEquals('plain', $authorizationRequest->getCodeChallengeMethod());
+        self::assertEquals('FOOBAR', $authorizationRequest->getCodeChallenge());
     }
 
     /**
@@ -459,7 +463,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setDefaultScope(self::DEFAULT_SCOPE);
@@ -502,7 +506,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setDefaultScope(self::DEFAULT_SCOPE);
@@ -666,7 +670,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
@@ -737,7 +741,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new S256Verifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
@@ -1184,7 +1188,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
@@ -1256,7 +1260,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new S256Verifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
@@ -1328,7 +1332,7 @@ class AuthCodeGrantTest extends TestCase
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new \DateInterval('PT10M')
         );
-        $grant->enableCodeExchangeProof();
+        $grant->enableCodeChallengeVerifier(new PlainVerifier());
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);


### PR DESCRIPTION
Basically just trying to see what you think. It does break BC, but could be more useful in the long run. Plus it fixes some issues, mainly that according to the RFC, new projects should not support plain method unless absolutely necessary, while the original implementation has that baked in.
