### PR TITLE
Fix WWW-Authenticate entry in $headers array

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -267,7 +267,7 @@ class OAuthServerException extends \Exception
             ) {
                 $authScheme = 'Bearer';
             }
-            $headers[] = 'WWW-Authenticate: ' . $authScheme . ' realm="OAuth"';
+            $headers['WWW-Authenticate'] = $authScheme . ' realm="OAuth"';
         }
         // @codeCoverageIgnoreEnd
         return $headers;


### PR DESCRIPTION
In this context the header name should be the array key and the header value the array value. Left as-is, the `WWW-Authenticate` header looks like this:

```
HTTP/1.1 401 Unauthorized
0: WWW-Authenticate: Basic realm="OAuth"
```

After the fix, the header looks like this:

```
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Basic realm="OAuth"
```

I would have updated a test except there is no test coverage for the `OAuthServerException`. In fact, the portion of the code I touched is ignored by code coverage. I decided to leave it as-is for now.