### PR TITLE
Added Zend diactoros library dependency to the examples

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -6,7 +6,8 @@
         "league/event": "^2.1",
         "lcobucci/jwt": "^3.1",
         "paragonie/random_compat": "^1.1",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "zendframework/zend-diactoros": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I was trying the examples an got a Fatal error: "Class 'Zend\Diactoros\Stream' not found in oauth2-server/examples/public/client_credentials.php on line 72.
Adding this explicit dependency and running composer update fixes it.