### PR TITLE
Update Slim example in auth-code docs

### DIFF
--- a/auth-server-auth-code.md
+++ b/auth-server-auth-code.md
@@ -95,11 +95,8 @@ _Please note: These examples here demonstrate usage with the Slim Framework; Sli
 The client will redirect the user to an authorization endpoint.
 
 {% highlight php %}
-$app->get('/authorize', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
+$app->get('/authorize', function (ServerRequestInterface $request, ResponseInterface $response) use ($server) {
    
-    /* @var \League\OAuth2\Server\AuthorizationServer $server */
-    $server = $app->getContainer()->get(AuthorizationServer::class);
-    
     try {
     
         // Validate the HTTP request and return an AuthorizationRequest object.
@@ -140,10 +137,7 @@ $app->get('/authorize', function (ServerRequestInterface $request, ResponseInter
 The client will request an access token using an authorization code so create an `/access_token` endpoint.
 
 {% highlight php %}
-$app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
-
-    /* @var \League\OAuth2\Server\AuthorizationServer $server */
-    $server = $app->getContainer()->get(AuthorizationServer::class);
+$app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($server) {
 
     try {
     


### PR DESCRIPTION
As it stands, if a user isn't familiar with Slim and they put both
the Setup code and the Implementation example into a file, the request
errors in Slim.

The implementation code assumes the user has put the setup code into a Slim
container - which they won't have done if they've simply followed this page.

This doc update tweaks the example code to provide direct access to the oauth2 `$server` that is configured in the Setup code example above it.