### PR TITLE
incompatability with PHP 5.4

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -138,7 +138,9 @@ class ResourceServer extends AbstractServer
      */
     public function determineAccessToken($headerOnly = false)
     {
-        if (!empty($this->getRequest()->headers->get('Authorization'))) {
+        $authorization = $this->getRequest()->headers->get('Authorization');
+        
+        if (!empty($authorization)) {
             $accessToken = $this->getTokenType()->determineAccessTokenInHeader($this->getRequest());
         } elseif ($headerOnly === false && (! $this->getTokenType() instanceof MAC)) {
             $accessToken = ($this->getRequest()->server->get('REQUEST_METHOD') === 'GET')


### PR DESCRIPTION
Fixed PHP 5.4 erroring with "Can't use method return value in write context".

empty() needs to access the value by reference (in order to check whether that reference points to something that exists), and PHP before 5.5 didn't support references to temporary values returned from functions as outlined in this post http://stackoverflow.com/a/4328049

The authorization has been moved into a variable and this is now checked as to whether it's empty.