### PR TITLE
Getting parameters from request

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -231,7 +231,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      */
     protected function getRequestParameter($parameter, ServerRequestInterface $request, $default = null)
     {
-        $requestParameters = (array) $request->getParsedBody();
+        $requestParameters = (array) ($request->getParsedBody()) ? $request->getParsedBody() : $request->getQueryParams();
 
         return isset($requestParameters[$parameter]) ? $requestParameters[$parameter] : $default;
     }


### PR DESCRIPTION
I'm using PHP 5.6.16 with Laravel 5.3 and I received some exceptions after trying to generate access tokens via GET.

The issue is in getRequestParameter(), where the property 'parsedBody' comes as an empty array.

This little change worked for me, I expect to get your opinion.