### PR TITLE
Fixed code_challenge_method in Auth Code Payload

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -319,7 +319,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                                     'user_id'                 => $authCode->getUserIdentifier(),
                                     'expire_time'             => (new \DateTime())->add($this->authCodeTTL)->format('U'),
                                     'code_challenge'          => $authorizationRequest->getCodeChallenge(),
-                                    'code_challenge_method  ' => $authorizationRequest->getCodeChallengeMethod(),
+                                    'code_challenge_method'   => $authorizationRequest->getCodeChallengeMethod(),
                                 ]
                             )
                         ),


### PR DESCRIPTION
Removed extra spaces in the code_challenge_method property of the encrypted Auth Code Payload as this was preventing the PKCE verification from working properly.