### PR TITLE
Missing Zend library

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -6,6 +6,7 @@
         "league/event": "^2.1",
         "lcobucci/jwt": "^3.1",
         "paragonie/random_compat": "^1.1",
+        "zendframework/zend-diactoros": "1.3.*",
         "psr/http-message": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Missing Zend library that causes an error below:

::1:37754 [500]: /client_credentials.php/access_token - Class 'Zend\Diactoros\Stream' not found in /data/www/html/sites/oauth2-server/examples/public/client_credentials.php on line 72