### PR TITLE
Change case for implict grant token_type

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -200,7 +200,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
                     $finalRedirectUri,
                     [
                         'access_token' => (string) $accessToken->convertToJWT($this->privateKey),
-                        'token_type'   => 'bearer',
+                        'token_type'   => 'Bearer',
                         'expires_in'   => $accessToken->getExpiryDateTime()->getTimestamp() - (new \DateTime())->getTimestamp(),
                         'state'        => $authorizationRequest->getState(),
                     ],


### PR DESCRIPTION
My understanding of the specs

- value for `token_type` is case insensitive - https://tools.ietf.org/html/rfc6749#section-4.2.2
- However, the auth scheme in the `Authorization` header to be exactly "Bearer", without mention of case insensitivity, so should be taken as case sensitive. - https://tools.ietf.org/html/rfc6750#section-2.1

As per the spec, the Resource Server portion of leage/oauth2-server requires a case sensitive `Bearer`. I'm using Swagger UI, which uses the `token_type` value directly when trying to send authenticated requests, so the header looks something like `Authorization: bearer <token>` and rightly so the server denies the request.


This change would also make it consistent with [BearerTokenResponse](https://github.com/davedevelopment/oauth2-server/blob/master/src/ResponseTypes/BearerTokenResponse.php#L30)