### PR TITLE
Fix Segfaults: treat rsa candidate as one string

### DIFF
--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -14,7 +14,7 @@ namespace League\OAuth2\Server;
 class CryptKey
 {
     const RSA_KEY_PATTERN =
-        '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----\n)(.|\n)+(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)$/';
+        '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----\n).+(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)$/s';
 
     /**
      * @var string


### PR DESCRIPTION
- save pcre backtracking work
- prevent segfaults with long private keys

(though contributing guidelines state to open PR to dev, I was unable to find that branch)