### PR TITLE
Replaces array_key_exists by isset, which is faster, on ImplicitGrant.

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -96,7 +96,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
     {
         return (
             isset($request->getQueryParams()['response_type'])
-            && 'token' === $request->getQueryParams()['response_type']
+            && $request->getQueryParams()['response_type'] === 'token'
             && isset($request->getQueryParams()['client_id'])
         );
     }

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -95,8 +95,8 @@ class ImplicitGrant extends AbstractAuthorizeGrant
     public function canRespondToAuthorizationRequest(ServerRequestInterface $request)
     {
         return (
-            array_key_exists('response_type', $request->getQueryParams())
-            && $request->getQueryParams()['response_type'] === 'token'
+            isset($request->getQueryParams()['response_type'])
+            && 'token' === $request->getQueryParams()['response_type']
             && isset($request->getQueryParams()['client_id'])
         );
     }


### PR DESCRIPTION
Related to issue #748 .