### PR TITLE
Removed chmod from CryptKey and add toggle to disable checking

### DIFF
--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -29,8 +29,9 @@ class CryptKey
     /**
      * @param string      $keyPath
      * @param null|string $passPhrase
+     * @param bool        $keyPermissionsCheck
      */
-    public function __construct($keyPath, $passPhrase = null)
+    public function __construct($keyPath, $passPhrase = null, $keyPermissionsCheck = true)
     {
         if (preg_match(self::RSA_KEY_PATTERN, $keyPath)) {
             $keyPath = $this->saveKeyToFile($keyPath);
@@ -44,21 +45,15 @@ class CryptKey
             throw new \LogicException(sprintf('Key path "%s" does not exist or is not readable', $keyPath));
         }
 
-        // Verify the permissions of the key
-        $keyPathPerms = decoct(fileperms($keyPath) & 0777);
-        if ($keyPathPerms !== '600') {
-            // Attempt to correct the permissions
-            if (chmod($keyPath, 0600) === false) {
-                // @codeCoverageIgnoreStart
-                trigger_error(
-                    sprintf(
-                        'Key file "%s" permissions are not correct, should be 600 instead of %s, unable to automatically resolve the issue',
-                        $keyPath,
-                        $keyPathPerms
-                    ),
-                    E_USER_NOTICE
-                );
-                // @codeCoverageIgnoreEnd
+        if ($keyPermissionsCheck === true) {
+            // Verify the permissions of the key
+            $keyPathPerms = decoct(fileperms($keyPath) & 0777);
+            if (in_array($keyPathPerms, ['600', '660'], true) === false) {
+                trigger_error(sprintf(
+                    'Key file "%s" permissions are not correct, should be 600 or 660 instead of %s',
+                    $keyPath,
+                    $keyPathPerms
+                ), E_USER_NOTICE);
             }
         }
 

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -26,6 +26,13 @@ use Zend\Diactoros\ServerRequestFactory;
 
 class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        // Make sure the keys have the correct permissions.
+        chmod(__DIR__ . '/Stubs/private.key', 0600);
+        chmod(__DIR__ . '/Stubs/public.key', 0600);
+    }
+
     public function testRespondToRequestInvalidGrantType()
     {
         $server = new AuthorizationServer(


### PR DESCRIPTION
First of all, please do not touch my files... I do not think it's the responsibility of a package to set file permissions. It is the responsibility of your deployment pipeline or developers themselves.

While I appreciate the intent that was done in 2f8de3d2302beb490abb9475cf426148801c25c4. This is breaking for us in both our development and our production environments. And according to #760 for more people.

With this PR I would like to propose two things:
- First and foremost, remove any code that modifies files. However, do trigger a `USER_NOTICE` when not set to `600`.
- Option to skip the check. This can be useful for DEV environments.

A bit of context for our case:

Our PROD setup is as follows:
We have 4 users: `deploy`, `worker`, `scheduler` and `apache`. All four are part of the `deployment` group. So our code is chowned as `deploy:deployment`. So while `600` might seems like a good assumption, it will prevent our `apache` user from reading the key, thus breaking the web requests.

Our DEV setup is a bit different:
We have our own users, `yannickl88` in my case, and `www-data` for the web user. Files are chmodded `666` so both users can read everything. (we have a umask 0000 everywhere). While not the best setup, it's just development. In this case `660` is even not enough, but a warning would be justified. However, we would like to silence this in our DEV environment since Symfony converts the `USER_NOTICE` to an exception, making the lib unusable.