### PR TITLE
Add check on ivalid access token in Refresh Grant

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * OAuth 2.0 Refresh token grant
+ * OAuth 2.0 Refresh token grant.
  *
- * @package     league/oauth2-server
  * @author      Alex Bilbie <hello@alexbilbie.com>
  * @copyright   Copyright (c) Alex Bilbie
  * @license     http://mit-license.org/
+ *
  * @link        https://github.com/thephpleague/oauth2-server
  */
 
@@ -19,7 +19,7 @@ use League\OAuth2\Server\Exception;
 use League\OAuth2\Server\Util\SecureKey;
 
 /**
- * Refresh token grant
+ * Refresh token grant.
  */
 class RefreshTokenGrant extends AbstractGrant
 {
@@ -29,16 +29,16 @@ class RefreshTokenGrant extends AbstractGrant
     protected $identifier = 'refresh_token';
 
     /**
-     * Refresh token TTL (default = 604800 | 1 week)
+     * Refresh token TTL (default = 604800 | 1 week).
      *
-     * @var integer
+     * @var int
      */
     protected $refreshTokenTTL = 604800;
 
     /**
-     * Rotate token (default = true)
+     * Rotate token (default = true).
      *
-     * @var integer
+     * @var int
      */
     protected $refreshTokenRotate = true;
 
@@ -46,12 +46,12 @@ class RefreshTokenGrant extends AbstractGrant
      * Whether to require the client secret when
      * completing the flow.
      *
-     * @var boolean
+     * @var bool
      */
     protected $requireClientSecret = true;
 
     /**
-     * Set the TTL of the refresh token
+     * Set the TTL of the refresh token.
      *
      * @param int $refreshTokenTTL
      *
@@ -63,7 +63,7 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Get the TTL of the refresh token
+     * Get the TTL of the refresh token.
      *
      * @return int
      */
@@ -73,7 +73,8 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Set the rotation boolean of the refresh token
+     * Set the rotation boolean of the refresh token.
+     *
      * @param bool $refreshTokenRotate
      */
     public function setRefreshTokenRotation($refreshTokenRotate = true)
@@ -82,7 +83,7 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Get rotation boolean of the refresh token
+     * Get rotation boolean of the refresh token.
      *
      * @return bool
      */
@@ -92,7 +93,6 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     *
      * @param bool $required True to require client secret during access
      *                       token request. False if not. Default = true
      */
@@ -111,7 +111,6 @@ class RefreshTokenGrant extends AbstractGrant
     {
         return $this->requireClientSecret;
     }
-
 
     /**
      * {@inheritdoc}
@@ -139,6 +138,7 @@ class RefreshTokenGrant extends AbstractGrant
 
         if (($client instanceof ClientEntity) === false) {
             $this->server->getEventEmitter()->emit(new Event\ClientAuthenticationFailedEvent($this->server->getRequest()));
+
             throw new Exception\InvalidClientException();
         }
 
@@ -160,6 +160,10 @@ class RefreshTokenGrant extends AbstractGrant
         }
 
         $oldAccessToken = $oldRefreshToken->getAccessToken();
+
+        if (is_null($oldAccessToken)) {
+            throw new Exception\InvalidRefreshException();
+        }
 
         // Get the scopes for the original session
         $session = $oldAccessToken->getSession();

--- a/tests/unit/Grant/RefreshTokenGrantTest.php
+++ b/tests/unit/Grant/RefreshTokenGrantTest.php
@@ -43,7 +43,7 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
 
         $_POST = [
             'grant_type' => 'refresh_token',
-            'client_id'  =>  'testapp',
+            'client_id'  => 'testapp',
         ];
 
         $server = new AuthorizationServer();
@@ -58,9 +58,9 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('League\OAuth2\Server\Exception\InvalidClientException');
 
         $_POST = [
-            'grant_type' => 'refresh_token',
-            'client_id' =>  'testapp',
-            'client_secret' =>  'foobar',
+            'grant_type'    => 'refresh_token',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
         ];
 
         $server = new AuthorizationServer();
@@ -82,8 +82,8 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
 
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
         ];
 
         $server = new AuthorizationServer();
@@ -116,9 +116,9 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
 
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'meh',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'meh',
         ];
 
         $server = new AuthorizationServer();
@@ -150,9 +150,9 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
     {
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'refresh_token',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'refresh_token',
         ];
 
         $server = new AuthorizationServer();
@@ -218,10 +218,10 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
     {
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'refresh_token',
-            'scope'         =>  'foo',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'refresh_token',
+            'scope'         => 'foo',
         ];
 
         $server = new AuthorizationServer();
@@ -291,10 +291,10 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
 
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'refresh_token',
-            'scope'         =>  'foo',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'refresh_token',
+            'scope'         => 'foo',
         ];
 
         $server = new AuthorizationServer();
@@ -357,10 +357,10 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
     {
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'refresh_token',
-            'scope'         =>  'blah',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'refresh_token',
+            'scope'         => 'blah',
         ];
 
         $server = new AuthorizationServer();
@@ -426,9 +426,9 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
     {
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'client_secret' =>  'foobar',
-            'refresh_token' =>  'refresh_token',
+            'client_id'     => 'testapp',
+            'client_secret' => 'foobar',
+            'refresh_token' => 'refresh_token',
         ];
 
         $server = new AuthorizationServer();
@@ -503,8 +503,8 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
     {
         $_POST = [
             'grant_type'    => 'refresh_token',
-            'client_id'     =>  'testapp',
-            'refresh_token' =>  'refresh_token',
+            'client_id'     => 'testapp',
+            'refresh_token' => 'refresh_token',
         ];
 
         $server = new AuthorizationServer();
@@ -565,6 +565,68 @@ class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('refresh_token', $response));
         $this->assertTrue(array_key_exists('token_type', $response));
         $this->assertTrue(array_key_exists('expires_in', $response));
+    }
 
+    public function testCompleteFlowAccessTokenInvalid()
+    {
+        $this->setExpectedException('League\OAuth2\Server\Exception\InvalidRefreshException');
+
+        $_POST = [
+            'grant_type'    => 'refresh_token',
+            'client_id'     => 'testapp',
+            'refresh_token' => 'refresh_token',
+        ];
+
+        $server = new AuthorizationServer();
+        $grant = new RefreshTokenGrant();
+        $grant->setRequireClientSecret(false);
+
+        $clientStorage = M::mock('League\OAuth2\Server\Storage\ClientInterface');
+        $clientStorage->shouldReceive('setServer');
+        $clientStorage->shouldReceive('get')->andReturn(
+            (new ClientEntity($server))->hydrate(['id' => 'testapp'])
+        );
+
+        $sessionStorage = M::mock('League\OAuth2\Server\Storage\SessionInterface');
+        $sessionStorage->shouldReceive('setServer');
+        $sessionStorage->shouldReceive('getScopes')->shouldReceive('getScopes')->andReturn([]);
+        $sessionStorage->shouldReceive('associateScope');
+        $sessionStorage->shouldReceive('getByAccessToken')->andReturn(
+            (new SessionEntity($server))
+        );
+
+        $accessTokenStorage = M::mock('League\OAuth2\Server\Storage\AccessTokenInterface');
+        $accessTokenStorage->shouldReceive('setServer');
+        $accessTokenStorage->shouldReceive('get')->andReturn(null);
+        $accessTokenStorage->shouldReceive('delete');
+        $accessTokenStorage->shouldReceive('create');
+        $accessTokenStorage->shouldReceive('getScopes')->andReturn([
+            (new ScopeEntity($server))->hydrate(['id' => 'foo']),
+        ]);
+        $accessTokenStorage->shouldReceive('associateScope');
+
+        $refreshTokenStorage = M::mock('League\OAuth2\Server\Storage\RefreshTokenInterface');
+        $refreshTokenStorage->shouldReceive('setServer');
+        $refreshTokenStorage->shouldReceive('associateScope');
+        $refreshTokenStorage->shouldReceive('delete');
+        $refreshTokenStorage->shouldReceive('create');
+        $refreshTokenStorage->shouldReceive('get')->andReturn(
+            (new RefreshTokenEntity($server))->setId('refresh_token')->setExpireTime(time() + 86400)
+        );
+
+        $scopeStorage = M::mock('League\OAuth2\Server\Storage\ScopeInterface');
+        $scopeStorage->shouldReceive('setServer');
+        $scopeStorage->shouldReceive('get')->andReturn(
+            (new ScopeEntity($server))->hydrate(['id' => 'foo'])
+        );
+
+        $server->setClientStorage($clientStorage);
+        $server->setScopeStorage($scopeStorage);
+        $server->setSessionStorage($sessionStorage);
+        $server->setAccessTokenStorage($accessTokenStorage);
+        $server->setRefreshTokenStorage($refreshTokenStorage);
+
+        $server->addGrantType($grant);
+        $server->issueAccessToken();
     }
 }


### PR DESCRIPTION
Hi! We found problem when access token invalid or deleted and get error 

`Symfony\Component\Debug\Exception\FatalThrowableError in RefreshTokenGrant.php line 165
Call to a member function getSession() on null`