### PR TITLE
Use request redirect uri on invalid scope response

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -242,12 +242,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             }
         }
 
-        $scopes = $this->validateScopes(
-            $this->getQueryStringParameter('scope', $request),
-            is_array($client->getRedirectUri())
-                ? $client->getRedirectUri()[0]
-                : $client->getRedirectUri()
-        );
+        $scopes = $this->validateScopes($this->getQueryStringParameter('scope', $request), $redirectUri);
 
         $stateParameter = $this->getQueryStringParameter('state', $request);
 


### PR DESCRIPTION
RFC 6749, section 5.2 :
Server should use redirect_uri set on request to return error except for error concerning redirection URI