### PR TITLE
Added ability to specify query delimiter character in the implicit grant

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -31,10 +31,10 @@ class ImplicitGrant extends AbstractAuthorizeGrant
      */
     private $queryDelimiter;
 
-	/**
-	 * @param \DateInterval $accessTokenTTL
-	 * @param string $queryDelimiter
-	 */
+    /**
+     * @param \DateInterval $accessTokenTTL
+     * @param string $queryDelimiter
+     */
     public function __construct(\DateInterval $accessTokenTTL, $queryDelimiter = '#')
     {
         $this->accessTokenTTL = $accessTokenTTL;

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -27,11 +27,18 @@ class ImplicitGrant extends AbstractAuthorizeGrant
     private $accessTokenTTL;
 
     /**
-     * @param \DateInterval $accessTokenTTL
+     * @var string
      */
-    public function __construct(\DateInterval $accessTokenTTL)
+    private $queryDelimiter;
+
+	/**
+	 * @param \DateInterval $accessTokenTTL
+	 * @param string $queryDelimiter
+	 */
+    public function __construct(\DateInterval $accessTokenTTL, $queryDelimiter = '#')
     {
         $this->accessTokenTTL = $accessTokenTTL;
+        $this->queryDelimiter = $queryDelimiter;
     }
 
     /**
@@ -204,7 +211,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
                         'expires_in'   => $accessToken->getExpiryDateTime()->getTimestamp() - (new \DateTime())->getTimestamp(),
                         'state'        => $authorizationRequest->getState(),
                     ],
-                    '#'
+                    $this->queryDelimiter
                 )
             );
 


### PR DESCRIPTION
Ability to specify query delimiter, such as `?` instead of the hard-coded `#`