### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "defuse/php-encryption": "^2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0",
+        "phpunit/phpunit": "^4.8.38 || ^5.7.21",
         "zendframework/zend-diactoros": "^1.0"
     },
     "repositories": [

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -19,11 +19,12 @@ use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\ServerRequestFactory;
 
-class AuthorizationServerTest extends \PHPUnit_Framework_TestCase
+class AuthorizationServerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/CryptKeyTest.php
+++ b/tests/CryptKeyTest.php
@@ -3,8 +3,9 @@
 namespace LeagueTests\Utils;
 
 use League\OAuth2\Server\CryptKey;
+use PHPUnit\Framework\TestCase;
 
-class CryptKeyTest extends \PHPUnit_Framework_TestCase
+class CryptKeyTest extends TestCase
 {
     /**
      * @expectedException \LogicException

--- a/tests/CryptTraitTest.php
+++ b/tests/CryptTraitTest.php
@@ -3,8 +3,9 @@
 namespace LeagueTests\Utils;
 
 use LeagueTests\Stubs\CryptTraitStub;
+use PHPUnit\Framework\TestCase;
 
-class CryptTraitTest extends \PHPUnit_Framework_TestCase
+class CryptTraitTest extends TestCase
 {
     /**
      * @var \LeagueTests\Stubs\CryptTraitStub

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -18,9 +18,10 @@ use LeagueTests\Stubs\AuthCodeEntity;
 use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\ScopeEntity;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class AbstractGrantTest extends \PHPUnit_Framework_TestCase
+class AbstractGrantTest extends TestCase
 {
     public function testGetSet()
     {

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -22,9 +22,10 @@ use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class AuthCodeGrantTest extends \PHPUnit_Framework_TestCase
+class AuthCodeGrantTest extends TestCase
 {
     /**
      * @var CryptTraitStub

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -10,9 +10,10 @@ use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\StubResponseType;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class ClientCredentialsGrantTest extends \PHPUnit_Framework_TestCase
+class ClientCredentialsGrantTest extends TestCase
 {
     public function testGetIdentifier()
     {

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -18,9 +18,10 @@ use LeagueTests\Stubs\CryptTraitStub;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class ImplicitGrantTest extends \PHPUnit_Framework_TestCase
+class ImplicitGrantTest extends TestCase
 {
     /**
      * CryptTrait stub

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -15,9 +15,10 @@ use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class PasswordGrantTest extends \PHPUnit_Framework_TestCase
+class PasswordGrantTest extends TestCase
 {
     public function testGetIdentifier()
     {

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -16,9 +16,10 @@ use LeagueTests\Stubs\CryptTraitStub;
 use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class RefreshTokenGrantTest extends \PHPUnit_Framework_TestCase
+class RefreshTokenGrantTest extends TestCase
 {
     /**
      * @var CryptTraitStub

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -12,10 +12,11 @@ use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\StubResponseType;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
 
-class AuthorizationServerMiddlewareTest extends \PHPUnit_Framework_TestCase
+class AuthorizationServerMiddlewareTest extends TestCase
 {
     public function testValidResponse()
     {

--- a/tests/Middleware/ResourceServerMiddlewareTest.php
+++ b/tests/Middleware/ResourceServerMiddlewareTest.php
@@ -8,10 +8,11 @@ use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
 use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\ClientEntity;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 
-class ResourceServerMiddlewareTest extends \PHPUnit_Framework_TestCase
+class ResourceServerMiddlewareTest extends TestCase
 {
     public function testValidResponse()
     {

--- a/tests/ResourceServerTest.php
+++ b/tests/ResourceServerTest.php
@@ -6,9 +6,10 @@ namespace LeagueTests;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
+use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequestFactory;
 
-class ResourceServerTest extends \PHPUnit_Framework_TestCase
+class ResourceServerTest extends TestCase
 {
     public function testValidateAuthenticatedRequest()
     {

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -11,11 +11,12 @@ use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\ScopeEntity;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 
-class BearerResponseTypeTest extends \PHPUnit_Framework_TestCase
+class BearerResponseTypeTest extends TestCase
 {
     public function testGenerateHttpResponse()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to bump PHPUnit version to [4.8.36](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21) and [5.7.21](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#5721---2017-06-21) for compatibility with this `namespace`.