### PR TITLE
Refactoring tests

### DIFF
--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -106,7 +106,7 @@ class AuthorizationServerTest extends TestCase
         $method = $abstractGrantReflection->getMethod('getResponseType');
         $method->setAccessible(true);
 
-        $this->assertTrue($method->invoke($server) instanceof BearerTokenResponse);
+        $this->assertInstanceOf(BearerTokenResponse::class, $method->invoke($server));
     }
 
     public function testCompleteAuthorizationRequest()
@@ -138,8 +138,9 @@ class AuthorizationServerTest extends TestCase
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
-        $this->assertTrue(
-            $server->completeAuthorizationRequest($authRequest, new Response) instanceof ResponseInterface
+        $this->assertInstanceOf(
+            ResponseInterface::class,
+            $server->completeAuthorizationRequest($authRequest, new Response)
         );
     }
 
@@ -186,7 +187,7 @@ class AuthorizationServerTest extends TestCase
             ]
         );
 
-        $this->assertTrue($server->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $server->validateAuthorizationRequest($request));
     }
 
     public function testValidateAuthorizationRequestWithMissingRedirectUri()

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -342,7 +342,7 @@ class AbstractGrantTest extends TestCase
         $accessToken = new AccessTokenEntity();
         /** @var RefreshTokenEntityInterface $refreshToken */
         $refreshToken = $issueRefreshTokenMethod->invoke($grantMock, $accessToken);
-        $this->assertTrue($refreshToken instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $refreshToken);
         $this->assertEquals($accessToken, $refreshToken->getAccessToken());
     }
 
@@ -367,7 +367,7 @@ class AbstractGrantTest extends TestCase
             123,
             [new ScopeEntity()]
         );
-        $this->assertTrue($accessToken instanceof AccessTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $accessToken);
     }
 
     public function testIssueAuthCode()
@@ -383,7 +383,8 @@ class AbstractGrantTest extends TestCase
         $issueAuthCodeMethod = $abstractGrantReflection->getMethod('issueAuthCode');
         $issueAuthCodeMethod->setAccessible(true);
 
-        $this->assertTrue(
+        $this->assertInstanceOf(
+            AuthCodeEntityInterface::class,
             $issueAuthCodeMethod->invoke(
                 $grantMock,
                 new \DateInterval('PT1H'),
@@ -391,7 +392,7 @@ class AbstractGrantTest extends TestCase
                 123,
                 'http://foo/bar',
                 [new ScopeEntity()]
-            ) instanceof AuthCodeEntityInterface
+            )
         );
     }
 
@@ -467,7 +468,7 @@ class AbstractGrantTest extends TestCase
         $method = $abstractGrantReflection->getMethod('generateUniqueIdentifier');
         $method->setAccessible(true);
 
-        $this->assertTrue(is_string($method->invoke($grantMock)));
+        $this->assertInternalType('string', $method->invoke($grantMock));
     }
 
     public function testCanRespondToAuthorizationRequest()

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -111,7 +111,7 @@ class AuthCodeGrantTest extends TestCase
             ]
         );
 
-        $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
     }
 
     public function testValidateAuthorizationRequestRedirectUriArray()
@@ -149,7 +149,7 @@ class AuthCodeGrantTest extends TestCase
             ]
         );
 
-        $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
     }
 
     public function testValidateAuthorizationRequestCodeChallenge()
@@ -189,7 +189,7 @@ class AuthCodeGrantTest extends TestCase
             ]
         );
 
-        $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
     }
 
     /**
@@ -545,7 +545,7 @@ class AuthCodeGrantTest extends TestCase
         );
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     /**
@@ -636,8 +636,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     public function testRespondToAccessTokenRequestCodeChallengePlain()
@@ -707,8 +707,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     public function testRespondToAccessTokenRequestCodeChallengeS256()
@@ -778,8 +778,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     /**
@@ -1390,7 +1390,7 @@ class AuthCodeGrantTest extends TestCase
         );
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     /**
@@ -1416,7 +1416,7 @@ class AuthCodeGrantTest extends TestCase
         );
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     /**
@@ -1441,7 +1441,7 @@ class AuthCodeGrantTest extends TestCase
             new \DateInterval('PT10M')
         );
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     public function testRefreshTokenRepositoryUniqueConstraintCheck()
@@ -1508,8 +1508,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     /**
@@ -1579,8 +1579,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     /**
@@ -1650,8 +1650,8 @@ class AuthCodeGrantTest extends TestCase
         /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new \DateInterval('PT10M'));
 
-        $this->assertTrue($response->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($response->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $response->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
     }
 
     /**

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -56,7 +56,7 @@ class ClientCredentialsGrantTest extends TestCase
         $responseType = new StubResponseType();
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
 
-        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $responseType->getAccessToken());
     }
 
     /**

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -116,7 +116,7 @@ class ImplicitGrantTest extends TestCase
             ]
         );
 
-        $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
     }
 
     public function testValidateAuthorizationRequestRedirectUriArray()
@@ -151,7 +151,7 @@ class ImplicitGrantTest extends TestCase
             ]
         );
 
-        $this->assertTrue($grant->validateAuthorizationRequest($request) instanceof AuthorizationRequest);
+        $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
     }
 
     /**
@@ -290,7 +290,7 @@ class ImplicitGrantTest extends TestCase
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     /**
@@ -334,7 +334,7 @@ class ImplicitGrantTest extends TestCase
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
 
-        $this->assertTrue($grant->completeAuthorizationRequest($authRequest) instanceof RedirectResponse);
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
     /**

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -74,8 +74,8 @@ class PasswordGrantTest extends TestCase
         $responseType = new StubResponseType();
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
 
-        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($responseType->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $responseType->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $responseType->getRefreshToken());
     }
 
     /**

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -90,8 +90,8 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
 
-        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($responseType->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $responseType->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $responseType->getRefreshToken());
     }
 
     public function testRespondToReducedScopes()
@@ -147,8 +147,8 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new \DateInterval('PT5M'));
 
-        $this->assertTrue($responseType->getAccessToken() instanceof AccessTokenEntityInterface);
-        $this->assertTrue($responseType->getRefreshToken() instanceof RefreshTokenEntityInterface);
+        $this->assertInstanceOf(AccessTokenEntityInterface::class, $responseType->getAccessToken());
+        $this->assertInstanceOf(RefreshTokenEntityInterface::class, $responseType->getRefreshToken());
     }
 
     /**

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -48,7 +48,7 @@ class BearerResponseTypeTest extends TestCase
 
         $response = $responseType->generateHttpResponse(new Response());
 
-        $this->assertTrue($response instanceof ResponseInterface);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('no-cache', $response->getHeader('pragma')[0]);
         $this->assertEquals('no-store', $response->getHeader('cache-control')[0]);
@@ -56,10 +56,10 @@ class BearerResponseTypeTest extends TestCase
 
         $response->getBody()->rewind();
         $json = json_decode($response->getBody()->getContents());
-        $this->assertEquals('Bearer', $json->token_type);
-        $this->assertTrue(isset($json->expires_in));
-        $this->assertTrue(isset($json->access_token));
-        $this->assertTrue(isset($json->refresh_token));
+        $this->assertAttributeEquals('Bearer', 'token_type', $json);
+        $this->assertObjectHasAttribute('expires_in', $json);
+        $this->assertObjectHasAttribute('access_token', $json);
+        $this->assertObjectHasAttribute('refresh_token', $json);
     }
 
     public function testGenerateHttpResponseWithExtraParams()
@@ -92,7 +92,7 @@ class BearerResponseTypeTest extends TestCase
 
         $response = $responseType->generateHttpResponse(new Response());
 
-        $this->assertTrue($response instanceof ResponseInterface);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('no-cache', $response->getHeader('pragma')[0]);
         $this->assertEquals('no-store', $response->getHeader('cache-control')[0]);
@@ -100,13 +100,13 @@ class BearerResponseTypeTest extends TestCase
 
         $response->getBody()->rewind();
         $json = json_decode($response->getBody()->getContents());
-        $this->assertEquals('Bearer', $json->token_type);
-        $this->assertTrue(isset($json->expires_in));
-        $this->assertTrue(isset($json->access_token));
-        $this->assertTrue(isset($json->refresh_token));
+        $this->assertAttributeEquals('Bearer', 'token_type', $json);
+        $this->assertObjectHasAttribute('expires_in', $json);
+        $this->assertObjectHasAttribute('access_token', $json);
+        $this->assertObjectHasAttribute('refresh_token', $json);
 
-        $this->assertTrue(isset($json->foo));
-        $this->assertEquals('bar', $json->foo);
+        $this->assertObjectHasAttribute('foo', $json);
+        $this->assertAttributeEquals('bar', 'foo', $json);
     }
 
     public function testDetermineAccessTokenInHeaderValidToken()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertInstanceOf` instead of `instanceof` operator;
- `assertInternalType` instead of `is_*` functions;
- `assertObjectHasAttribute` instead of `isset` function;
- `assertAttributeEquals` instead of `assertEquals`.