### PR TITLE
Fixed ordering so we only hash after base64 encoding

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -144,7 +144,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 case 'S256':
                     if (
                         hash_equals(
-                            strtr(rtrim(base64_encode(hash('sha256', $codeVerifier)), '='), '+/', '-_'),
+                            hash('sha256', strtr(rtrim(base64_encode($codeVerifier), '='), '+/', '-_')),
                             $authCodePayload->code_challenge
                         ) === false
                     ) {

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -767,7 +767,7 @@ class AuthCodeGrantTest extends TestCase
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => strtr(rtrim(base64_encode(hash('sha256', 'foobar')), '='), '+/', '-_'),
+                            'code_challenge'        => hash('sha256', strtr(rtrim(base64_encode('foobar'), '='), '+/', '-_')),
                             'code_challenge_method' => 'S256',
                         ]
                     )


### PR DESCRIPTION
As per the examples in Apendix A of [RFC 7636](https://tools.ietf.org/html/rfc7636), we should be hashing the verifier code _after_ we have base 64 encoded, and not prior to. This pull request fixes an outstanding issue with our PKCE implementation.