### PR TITLE
Fix S256 code challenge method

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -144,7 +144,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 case 'S256':
                     if (
                         hash_equals(
-                            hash('sha256', strtr(rtrim(base64_encode($codeVerifier), '='), '+/', '-_')),
+                            strtr(rtrim(base64_encode(hash('sha256', $codeVerifier, true)), '='), '+/', '-_'),
                             $authCodePayload->code_challenge
                         ) === false
                     ) {

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -744,6 +744,10 @@ class AuthCodeGrantTest extends TestCase
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
+        // [RFC 7636] Appendix B.  Example for the S256 code_challenge_method
+        $codeVerifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+        $codeChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
         $request = new ServerRequest(
             [],
             [],
@@ -757,7 +761,7 @@ class AuthCodeGrantTest extends TestCase
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
                 'redirect_uri'  => 'http://foo/bar',
-                'code_verifier' => 'foobar',
+                'code_verifier' => $codeVerifier,
                 'code'          => $this->cryptStub->doEncrypt(
                     json_encode(
                         [
@@ -767,7 +771,7 @@ class AuthCodeGrantTest extends TestCase
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
                             'redirect_uri'          => 'http://foo/bar',
-                            'code_challenge'        => hash('sha256', strtr(rtrim(base64_encode('foobar'), '='), '+/', '-_')),
+                            'code_challenge'        => $codeChallenge,
                             'code_challenge_method' => 'S256',
                         ]
                     )


### PR DESCRIPTION
This PR fix the problem described in #828 ([see comment](https://github.com/thephpleague/oauth2-server/pull/828#issuecomment-358408459)).

According to [RFC7636#section-4.3](https://tools.ietf.org/html/rfc7636#section-4.3):

    If the "code_challenge_method" from Section 4.3 was "S256", the
    received "code_verifier" is hashed by SHA-256, base64url-encoded, and
    then compared to the "code_challenge", i.e.:

    BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) == code_challenge

So, the `hash('sha256',...)` must be done before the `base64_encode`.

The tests are modified to use example data from the [RFC7636#appendix-B](https://tools.ietf.org/html/rfc7636#appendix-B).