### PR TITLE
Fix highlighting newlines.

### DIFF
--- a/auth-server-auth-code.md
+++ b/auth-server-auth-code.md
@@ -52,7 +52,7 @@ The authorization server will respond with a JSON object containing the followin
 
 Wherever you initialize your objects, initialize a new instance of the authorization server and bind the storage interfaces and authorization code grant:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $clientRepository = new ClientRepository(); // instance of ClientRepositoryInterface
 $scopeRepository = new ScopeRepository(); // instance of ScopeRepositoryInterface
@@ -86,7 +86,7 @@ $server->enableGrantType(
     $grant,
     new \DateInterval('PT1H') // access tokens will expire after 1 hour
 );
-{% endhighlight %}
+~~~
 
 ## Implementation
 
@@ -94,7 +94,7 @@ _Please note: These examples here demonstrate usage with the Slim Framework; Sli
 
 The client will redirect the user to an authorization endpoint.
 
-{% highlight php %}
+~~~ php
 $app->get('/authorize', function (ServerRequestInterface $request, ResponseInterface $response) use ($server) {
    
     try {
@@ -132,11 +132,11 @@ $app->get('/authorize', function (ServerRequestInterface $request, ResponseInter
         
     }
 });
-{% endhighlight %}
+~~~
 
 The client will request an access token using an authorization code so create an `/access_token` endpoint.
 
-{% highlight php %}
+~~~ php
 $app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($server) {
 
     try {
@@ -157,5 +157,5 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
         return $response->withStatus(500)->withBody($body);
     }
 });
-{% endhighlight %}
+~~~
 

--- a/auth-server-client-credentials.md
+++ b/auth-server-client-credentials.md
@@ -27,7 +27,7 @@ The authorization server will respond with a JSON object containing the followin
 
 Wherever you initialize your objects, initialize a new instance of the authorization server and bind the storage interfaces and authorization code grant:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $clientRepository = new ClientRepository(); // instance of ClientRepositoryInterface
 $scopeRepository = new ScopeRepository(); // instance of ScopeRepositoryInterface
@@ -52,7 +52,7 @@ $server->enableGrantType(
     new \League\OAuth2\Server\Grant\ClientCredentialsGrant(),
     new \DateInterval('PT1H') // access tokens will expire after 1 hour
 );
-{% endhighlight %}
+~~~
 
 ## Implementation
 
@@ -60,7 +60,7 @@ _Please note: These examples here demonstrate usage with the Slim Framework; Sli
 
 The client will request an access token so create an `/access_token` endpoint.
 
-{% highlight php %}
+~~~ php
 $app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
 
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
@@ -85,4 +85,4 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
         
     }
 });
-{% endhighlight %}
+~~~

--- a/auth-server-events.md
+++ b/auth-server-events.md
@@ -12,20 +12,20 @@ You can subscribe to these events by attaching listeners to the authorization se
 
 To access the emitter call this method:
 
-{% highlight php %}
+~~~ php
 $server->getEmitter(); // returns instance of \League\Event\EmitterInterface
-{% endhighlight %}
+~~~
 
 ## client.authentication.failed
 
-{% highlight php %}
+~~~ php
 $server->getEmitter()->addListener(
     'client.authentication.failed',
     function (\League\OAuth2\Server\RequestEvent $event) {
         // do something
     }
 );
-{% endhighlight %}
+~~~
 
 This event is emitted when a client fails to authenticate. You might wish to listen to this event in order to ban clients that fail to authenticate after `n` number of attempts.
 
@@ -33,14 +33,14 @@ You can retrieve the request object that was used by calling `getRequest()` on t
 
 ## user.authentication.failed
 
-{% highlight php %}
+~~~ php
 $server->getEmitter()->addListener(
     'user.authentication.failed',
     function (\League\OAuth2\Server\RequestEvent $event) {
         // do something
     }
 );
-{% endhighlight %}
+~~~
 
 This event is emitted when a user fails to authenticate. You might wish to listen to this event in order to reset passwords or ban users that fail to authenticate after `n` number of attempts.
 

--- a/auth-server-implicit.md
+++ b/auth-server-implicit.md
@@ -39,7 +39,7 @@ If the user approves the client they will be redirected back to the authorizatio
 
 Wherever you initialize your objects, initialize a new instance of the authorization server and bind the storage interfaces and authorization code grant:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $clientRepository = new ClientRepository(); // instance of ClientRepositoryInterface
 $scopeRepository = new ScopeRepository(); // instance of ScopeRepositoryInterface
@@ -64,7 +64,7 @@ $server->enableGrantType(
     new ImplicitGrant(new \DateInterval('PT1H')),
     new \DateInterval('PT1H') // access tokens will expire after 1 hour
 );
-{% endhighlight %}
+~~~
 
 ## Implementation
 
@@ -72,7 +72,7 @@ _Please note: These examples here demonstrate usage with the Slim Framework; Sli
 
 The client will redirect the user to an authorization endpoint.
 
-{% highlight php %}
+~~~ php
 $app->get('/authorize', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
 
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
@@ -113,4 +113,4 @@ $app->get('/authorize', function (ServerRequestInterface $request, ResponseInter
         
     }
 });
-{% endhighlight %}
+~~~

--- a/auth-server-password.md
+++ b/auth-server-password.md
@@ -32,7 +32,7 @@ The authorization server will respond with a JSON object containing the followin
 
 Wherever you initialize your objects, initialize a new instance of the authorization server and bind the storage interfaces and authorization code grant:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $clientRepository = new ClientRepository(); // instance of ClientRepositoryInterface
 $scopeRepository = new ScopeRepository(); // instance of ScopeRepositoryInterface
@@ -66,7 +66,7 @@ $server->enableGrantType(
     $grant,
     new \DateInterval('PT1H') // access tokens will expire after 1 hour
 );
-{% endhighlight %}
+~~~
 
 ## Implementation
 
@@ -74,7 +74,7 @@ _Please note: These examples here demonstrate usage with the Slim Framework; Sli
 
 The client will request an access token so create an `/access_token` endpoint.
 
-{% highlight php %}
+~~~ php
 $app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
 
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
@@ -99,4 +99,4 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
         
     }
 });
-{% endhighlight %}
+~~~

--- a/auth-server-refresh-token.md
+++ b/auth-server-refresh-token.md
@@ -29,7 +29,7 @@ The authorization server will respond with a JSON object containing the followin
 
 Wherever you initialize your objects, initialize a new instance of the authorization server and bind the storage interfaces and authorization code grant:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $clientRepository = new ClientRepository();
 $accessTokenRepository = new AccessTokenRepository();
@@ -58,13 +58,13 @@ $server->enableGrantType(
     $grant,
     new \DateInterval('PT1H') // new access tokens will expire after an hour
 );
-{% endhighlight %}
+~~~
 
 ## Implementation
 
 The client will request an access token so create an `/access_token` endpoint.
 
-{% highlight php %}
+~~~ php
 $app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
 
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
@@ -83,4 +83,4 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
         return $response->withStatus(500)->withBody($body);
     }
 });
-{% endhighlight %}
+~~~

--- a/installation.md
+++ b/installation.md
@@ -10,9 +10,9 @@ The recommended installation method is using [Composer](https://getcomposer.org)
 
 In your project root just run:
 
-{% highlight shell %}
+~~~ shell
 composer require league/oauth2-server
-{% endhighlight %}
+~~~
 
 Ensure that you’ve set up your project to [autoload Composer-installed packages](https://getcomposer.org/doc/01-basic-usage.md#autoloading).
 
@@ -24,27 +24,27 @@ The repositories are expected to return (on success) instances of [entity interf
 
 To generate the private key run this command on the terminal:
 
-{% highlight shell %}
+~~~ shell
 openssl genrsa -out private.key 2048
-{% endhighlight %}
+~~~
 
 If you want to provide a passphrase for your private key run this command instead:
 
-{% highlight shell %}
+~~~ shell
 openssl genrsa -passout pass:_passphrase_ -out private.key 2048
-{% endhighlight %}
+~~~
 
 then extract the public key from the private key:
 
-{% highlight shell %}
+~~~ shell
 openssl rsa -in private.key -pubout -out public.key
-{% endhighlight %}
+~~~
 
 or use your passphrase if provided on private key generation:
 
-{% highlight shell %}
+~~~ shell
 openssl rsa -in private.key -passin pass:_passphrase_ -pubout -out public.key
-{% endhighlight %}
+~~~
 
 The private key must be kept secret (i.e. out of the web-root of the authorization server). The authorization server also requires the public key.
 
@@ -56,6 +56,6 @@ The public key should be distributed to any services (for example resource serve
 
 To generate an encryption key for the `AuthorizationServer` run the following command in the terminal:
 
-{% highlight shell %}
+~~~ shell
 php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
-{% endhighlight %}
+~~~

--- a/resource-server-securing-api.md
+++ b/resource-server-securing-api.md
@@ -12,7 +12,7 @@ This library provides a PSR-7 friendly resource server middleware that can valid
 
 Wherever you intialize your objects, initialize a new instance of the resource server with the storage interfaces:
 
-{% highlight php %}
+~~~ php
 // Init our repositories
 $accessTokenRepository = new AccessTokenRepository(); // instance of AccessTokenRepositoryInterface
 
@@ -24,13 +24,13 @@ $server = new \League\OAuth2\Server\ResourceServer(
     $accessTokenRepository,
     $publicKeyPath
 );
-{% endhighlight %}
+~~~
 
 Then add the middleware to your stack:
 
-{% highlight php %}
+~~~ php
 new \League\OAuth2\Server\Middleware\ResourceServerMiddleware($server);
-{% endhighlight %}
+~~~
 
 ## Implementation
 

--- a/upgrade-guide.md
+++ b/upgrade-guide.md
@@ -25,6 +25,6 @@ All you need to do is replace the public key that was being passed into the cons
 
 To generate an encryption key for the `AuthorizationServer` run the following command in the terminal:
 
-{% highlight shell %}
+~~~ shell
 php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
-{% endhighlight %}
+~~~

--- a/v5-security-improvements.md
+++ b/v5-security-improvements.md
@@ -55,6 +55,6 @@ All you need to do is replace the public key that was being passed into the cons
 
 To generate an encryption key for the `AuthorizationServer` run the following command in the terminal:
 
-{% highlight shell %}
+~~~ shell
 php -r 'echo base64_encode(random_bytes(32)), PHP_EOL;'
-{% endhighlight %}
+~~~


### PR DESCRIPTION
The highlighting was messed up. By using this notation the newlines are preserved so the code samples show up correctly.

Before

<img width="1165" alt="screen shot 2018-01-29 at 10 31 39" src="https://user-images.githubusercontent.com/534693/35503165-a3acbd60-04df-11e8-9160-62e4e1be44e1.png">

After
<img width="1165" alt="screen shot 2018-01-29 at 10 31 22" src="https://user-images.githubusercontent.com/534693/35503179-b0f01ddc-04df-11e8-8679-da2466e09a2f.png">

