### PR TITLE
Fixed docblock opener

### DIFF
--- a/src/Entities/Traits/EntityTrait.php
+++ b/src/Entities/Traits/EntityTrait.php
@@ -11,7 +11,7 @@ namespace League\OAuth2\Server\Entities\Traits;
 
 trait EntityTrait
 {
-    /*
+    /**
      * @var string
      */
     protected $identifier;


### PR DESCRIPTION
It's important for tools relying on docblock-provided types to perform static analysis (think phan, phpstan, psalm, etc)