### PR TITLE
Add method to facilitate BearerTokenValidator override when you want to append data to the jwt token

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -11,6 +11,7 @@ namespace League\OAuth2\Server\AuthorizationValidators;
 
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token;
 use Lcobucci\JWT\ValidationData;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\CryptTrait;
@@ -83,11 +84,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             }
 
             // Return the request with additional attributes
-            return $request
-                ->withAttribute('oauth_access_token_id', $token->getClaim('jti'))
-                ->withAttribute('oauth_client_id', $token->getClaim('aud'))
-                ->withAttribute('oauth_user_id', $token->getClaim('sub'))
-                ->withAttribute('oauth_scopes', $token->getClaim('scopes'));
+            return $this->appendAttributesFromToken($request, $token);
         } catch (\InvalidArgumentException $exception) {
             // JWT couldn't be parsed so return the request as is
             throw OAuthServerException::accessDenied($exception->getMessage());
@@ -95,5 +92,19 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             //JWR couldn't be parsed so return the request as is
             throw OAuthServerException::accessDenied('Error while decoding to JSON');
         }
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param Token $token
+     * @return ServerRequestInterface
+     */
+    protected function appendAttributesFromToken(ServerRequestInterface $request, Token $token)
+    {
+        return $request
+            ->withAttribute('oauth_access_token_id', $token->getClaim('jti'))
+            ->withAttribute('oauth_client_id', $token->getClaim('aud'))
+            ->withAttribute('oauth_user_id', $token->getClaim('sub'))
+            ->withAttribute('oauth_scopes', $token->getClaim('scopes'));
     }
 }


### PR DESCRIPTION
Currently, it's easy to implement the `convertToJWT` method in the `AccessTokenEntityInterface` implementation to add data to the JWT. However, i don't see any solution, except creating a new implementation of `BearerTokenValidator`, to add additional attributes from the token, to the returning `ServerRequestInterface` object. 

I have take a look at https://github.com/thephpleague/oauth2-server/pull/497 and i don't see the solution to resolve this.

I think this PR can provide a way to simply override the `BearerTokenValidator:: appendAttributesFromToken()` method and pass the custom `BearerTokenValidator` instance to the `ResourceServer` instance.