### PR TITLE
PHPStan level 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
-  - vendor/bin/phpstan analyse -l 6 -c phpstan.neon src tests
+  - vendor/bin/phpstan analyse -l 7 -c phpstan.neon src tests
 
 after_script:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Upgrade PHPStan checks to level 7 (PR #893)
+- Upgrade PHPStan checks to level 7 (PR #856)
 - Added event emitters for issued access and refresh tokens (PR #860)
 - Can now use Defuse\Crypto\Key for encryption/decryption of keys which is faster than the Cryto class (PR #812)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
+### Changed
 - Upgrade PHPStan checks to level 7 (PR #856)
+
+### Added
 - Added event emitters for issued access and refresh tokens (PR #860)
 - Can now use Defuse\Crypto\Key for encryption/decryption of keys which is faster than the Cryto class (PR #812)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Upgrade PHPStan checks to level 7 (PR #893)
 - Added event emitters for issued access and refresh tokens (PR #860)
 - Can now use Defuse\Crypto\Key for encryption/decryption of keys which is faster than the Cryto class (PR #812)
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The library uses [PHPUnit](https://phpunit.de/) for unit tests and [PHPStan](htt
 
 ```
 vendor/bin/phpunit
-vendor/bin/phpstan analyse -l 6 -c phpstan.neon src tests
+vendor/bin/phpstan analyse -l 7 -c phpstan.neon src tests
 ```
 
 ## Continous Integration

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,8 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 	- vendor/phpstan/phpstan-phpunit/strictRules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
+services:
+	-
+		class: LeagueTests\PHPStan\AbstractGrantExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Entities/AuthCodeEntityInterface.php
+++ b/src/Entities/AuthCodeEntityInterface.php
@@ -17,7 +17,7 @@ interface AuthCodeEntityInterface extends TokenInterface
     public function getRedirectUri();
 
     /**
-     * @param string|null $uri
+     * @param string $uri
      */
     public function setRedirectUri($uri);
 }

--- a/src/Entities/AuthCodeEntityInterface.php
+++ b/src/Entities/AuthCodeEntityInterface.php
@@ -12,12 +12,12 @@ namespace League\OAuth2\Server\Entities;
 interface AuthCodeEntityInterface extends TokenInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
     public function getRedirectUri();
 
     /**
-     * @param string $uri
+     * @param string|null $uri
      */
     public function setRedirectUri($uri);
 }

--- a/src/Entities/Traits/AuthCodeTrait.php
+++ b/src/Entities/Traits/AuthCodeTrait.php
@@ -25,7 +25,7 @@ trait AuthCodeTrait
     }
 
     /**
-     * @param string|null $uri
+     * @param string $uri
      */
     public function setRedirectUri($uri)
     {

--- a/src/Entities/Traits/AuthCodeTrait.php
+++ b/src/Entities/Traits/AuthCodeTrait.php
@@ -17,7 +17,7 @@ trait AuthCodeTrait
     protected $redirectUri;
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getRedirectUri()
     {
@@ -25,7 +25,7 @@ trait AuthCodeTrait
     }
 
     /**
-     * @param string $uri
+     * @param string|null $uri
      */
     public function setRedirectUri($uri)
     {

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -407,7 +407,10 @@ abstract class AbstractGrant implements GrantTypeInterface
         $authCode->setExpiryDateTime((new \DateTime())->add($authCodeTTL));
         $authCode->setClient($client);
         $authCode->setUserIdentifier($userIdentifier);
-        $authCode->setRedirectUri($redirectUri);
+
+        if ($redirectUri !== null) {
+            $authCode->setRedirectUri($redirectUri);
+        }
 
         foreach ($scopes as $scope) {
             $authCode->addScope($scope);

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -386,7 +386,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      * @param \DateInterval          $authCodeTTL
      * @param ClientEntityInterface  $client
      * @param string                 $userIdentifier
-     * @param string                 $redirectUri
+     * @param string|null            $redirectUri
      * @param ScopeEntityInterface[] $scopes
      *
      * @throws OAuthServerException

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -270,7 +270,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         $authorizationRequest->setGrantTypeId($this->getIdentifier());
         $authorizationRequest->setClient($client);
         $authorizationRequest->setRedirectUri($redirectUri);
-        $authorizationRequest->setState($stateParameter);
+
+        if ($stateParameter !== null) {
+            $authorizationRequest->setState($stateParameter);
+        }
+
         $authorizationRequest->setScopes($scopes);
 
         if ($this->enableCodeExchangeProof === true) {

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -177,7 +177,11 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         $authorizationRequest->setGrantTypeId($this->getIdentifier());
         $authorizationRequest->setClient($client);
         $authorizationRequest->setRedirectUri($redirectUri);
-        $authorizationRequest->setState($stateParameter);
+
+        if ($stateParameter !== null) {
+            $authorizationRequest->setState($stateParameter);          
+        }
+
         $authorizationRequest->setScopes($finalizedScopes);
 
         return $authorizationRequest;

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -179,7 +179,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         $authorizationRequest->setRedirectUri($redirectUri);
 
         if ($stateParameter !== null) {
-            $authorizationRequest->setState($stateParameter);          
+            $authorizationRequest->setState($stateParameter);
         }
 
         $authorizationRequest->setScopes($finalizedScopes);

--- a/src/RequestTypes/AuthorizationRequest.php
+++ b/src/RequestTypes/AuthorizationRequest.php
@@ -183,7 +183,7 @@ class AuthorizationRequest
     }
 
     /**
-     * @param string|null $state
+     * @param string $state
      */
     public function setState($state)
     {

--- a/src/RequestTypes/AuthorizationRequest.php
+++ b/src/RequestTypes/AuthorizationRequest.php
@@ -60,7 +60,7 @@ class AuthorizationRequest
     /**
      * The state parameter on the authorization request
      *
-     * @var string
+     * @var string|null
      */
     protected $state;
 
@@ -175,7 +175,7 @@ class AuthorizationRequest
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getState()
     {
@@ -183,7 +183,7 @@ class AuthorizationRequest
     }
 
     /**
-     * @param string $state
+     * @param string|null $state
      */
     public function setState($state)
     {

--- a/tests/PHPStan/AbstractGrantExtension.php
+++ b/tests/PHPStan/AbstractGrantExtension.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types = 1);
+
+namespace LeagueTests\PHPStan;
+
+use League\OAuth2\Server\Grant\AbstractGrant;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class AbstractGrantExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return AbstractGrant::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), [
+            'getRequestParameter',
+            'getQueryStringParameter',
+            'getCookieParameter',
+        ], true);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        return TypeCombinator::union(...[
+            new StringType(),
+            isset($methodCall->args[2]) ? $scope->getType($methodCall->args[2]->value) : new NullType(),
+        ]);
+    }
+}


### PR DESCRIPTION
This fixes few issues with nullables, and adds custom extension for PHPStan so it can correctly resolve return types of some methods in `AbstractGrant`.

Level 7 is currently the most strict one, so we can't do any better than this. 🥇 