### PR TITLE
comment ensure redirect_uri is present

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -70,6 +70,12 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         ResponseTypeInterface $responseType,
         \DateInterval $accessTokenTTL
     ) {
+        
+        // The redirect URI is required in this request.
+            $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
+            if (empty($authCodePayload->redirect_uri) === false && $redirectUri === null) {
+                throw OAuthServerException::invalidRequest('redirect_uri');
+            }
         // Validate request
         $client = $this->validateClient($request);
         $encryptedAuthCode = $this->getRequestParameter('code', $request, null);
@@ -93,15 +99,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 throw OAuthServerException::invalidRequest('code', 'Authorization code was not issued to this client');
             }
 
-            // The redirect URI is required in this request
-            $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
-            if (empty($authCodePayload->redirect_uri) === false && $redirectUri === null) {
-                throw OAuthServerException::invalidRequest('redirect_uri');
-            }
-
-            if ($authCodePayload->redirect_uri !== $redirectUri) {
-                throw OAuthServerException::invalidRequest('redirect_uri', 'Invalid redirect URI');
-            }
+            
 
             $scopes = [];
             foreach ($authCodePayload->scopes as $scopeId) {


### PR DESCRIPTION
#870 -- The assumption that this change would make is that the redirect_uri supplied by a client redeeming an authorization_code for an access token is that they supply just what's configured in the client. No verification happens inside the grant for the redirect_uri ... rather the stored redirect_uri is used purely for redirecting a user to a client with whatever parameters need to be in place ... and the verification happens at a code level.

Of course, the other assumption is that the way the authorization_code redirect_uri is generated is secure server-side and doesn't allow manipulation of the host portion or otherwise.