### PR TITLE
Fix fatal error in examples caused by ClientRepositoryInterface change

### DIFF
--- a/examples/src/Repositories/ClientRepository.php
+++ b/examples/src/Repositories/ClientRepository.php
@@ -17,7 +17,7 @@ class ClientRepository implements ClientRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getClientEntity($clientIdentifier, $grantType, $clientSecret = null, $mustValidateSecret = true)
+    public function getClientEntity($clientIdentifier, $grantType = null, $clientSecret = null, $mustValidateSecret = true)
     {
         $clients = [
             'myawesomeapp' => [


### PR DESCRIPTION
The following fatal is thrown when attempting to execute the examples.

```
Fatal error: Declaration of OAuth2ServerExamples\Repositories\ClientRepository::getClientEntity($clientIdentifier, $grantType, $clientSecret = NULL, $mustValidateSecret = true) must be compatible with League\OAuth2\Server\Repositories\ClientRepositoryInterface::getClientEntity($clientIdentifier, $grantType = NULL, $clientSecret = NULL, $mustValidateSecret = true)
```
