### PR TITLE
Made the Client be aware of scopes

### DIFF
--- a/src/Entities/ScopeInterface.php
+++ b/src/Entities/ScopeInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Entities;
+
+interface ScopeInterface
+{
+    /**
+     * Associate a scope with the entity.
+     *
+     * @param ScopeEntityInterface $scope
+     */
+    public function addScope(ScopeEntityInterface $scope);
+
+    /**
+     * Return an array of scopes associated with the entity.
+     *
+     * @return ScopeEntityInterface[]
+     */
+    public function getScopes();
+}

--- a/src/Entities/TokenInterface.php
+++ b/src/Entities/TokenInterface.php
@@ -9,7 +9,7 @@
 
 namespace League\OAuth2\Server\Entities;
 
-interface TokenInterface
+interface TokenInterface extends ScopeInterface
 {
     /**
      * Get the token's identifier.
@@ -66,18 +66,4 @@ interface TokenInterface
      * @param ClientEntityInterface $client
      */
     public function setClient(ClientEntityInterface $client);
-
-    /**
-     * Associate a scope with the token.
-     *
-     * @param ScopeEntityInterface $scope
-     */
-    public function addScope(ScopeEntityInterface $scope);
-
-    /**
-     * Return an array of scopes associated with the token.
-     *
-     * @return ScopeEntityInterface[]
-     */
-    public function getScopes();
 }

--- a/src/Entities/Traits/ScopeEntityTrait.php
+++ b/src/Entities/Traits/ScopeEntityTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace League\OAuth2\Server\Entities\Traits;
+
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+
+trait ScopeEntityTrait
+{
+    /**
+     * @var ScopeEntityInterface[]
+     */
+    protected $scopes = [];
+
+    /**
+     * Associate a scope with the token.
+     *
+     * @param ScopeEntityInterface $scope
+     */
+    public function addScope(ScopeEntityInterface $scope)
+    {
+        $this->scopes[$scope->getIdentifier()] = $scope;
+    }
+
+    /**
+     * Return an array of scopes associated with the token.
+     *
+     * @return ScopeEntityInterface[]
+     */
+    public function getScopes()
+    {
+        return array_values($this->scopes);
+    }
+}

--- a/src/Entities/Traits/TokenEntityTrait.php
+++ b/src/Entities/Traits/TokenEntityTrait.php
@@ -10,14 +10,10 @@
 namespace League\OAuth2\Server\Entities\Traits;
 
 use League\OAuth2\Server\Entities\ClientEntityInterface;
-use League\OAuth2\Server\Entities\ScopeEntityInterface;
 
 trait TokenEntityTrait
 {
-    /**
-     * @var ScopeEntityInterface[]
-     */
-    protected $scopes = [];
+    use ScopeEntityTrait;
 
     /**
      * @var \DateTime
@@ -33,26 +29,6 @@ trait TokenEntityTrait
      * @var ClientEntityInterface
      */
     protected $client;
-
-    /**
-     * Associate a scope with the token.
-     *
-     * @param ScopeEntityInterface $scope
-     */
-    public function addScope(ScopeEntityInterface $scope)
-    {
-        $this->scopes[$scope->getIdentifier()] = $scope;
-    }
-
-    /**
-     * Return an array of scopes associated with the token.
-     *
-     * @return ScopeEntityInterface[]
-     */
-    public function getScopes()
-    {
-        return array_values($this->scopes);
-    }
 
     /**
      * Get the token's expiry date time.

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -268,6 +268,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         foreach ($entity->getScopes() as $scope) {
             $scopesList[] = $scope->getIdentifier();
         }
+
         return $scopesList;
     }
 

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -222,8 +222,9 @@ abstract class AbstractGrant implements GrantTypeInterface
      * @param string                $scopes
      * @param string                $redirectUri
      *
-     * @return ScopeEntityInterface[]
      * @throws OAuthServerException
+     *
+     * @return ScopeEntityInterface[]
      */
     public function validateScopes(ClientEntityInterface $client, $scopes, $redirectUri = null)
     {
@@ -257,6 +258,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      * Retrieve the scope identifiers from an Entity.
      *
      * @param ScopeInterface $entity
+     *
      * @return string[]
      */
     private function getScopeIdentifiers(ScopeInterface $entity)

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -234,7 +234,8 @@ abstract class AbstractGrant implements GrantTypeInterface
         $validScopes = [];
 
         if ($client instanceof ScopeInterface) {
-            if ($clientScopes = $this->getScopeIdentifiers($client)) {
+            $clientScopes = $this->getScopeIdentifiers($client);
+            if (count($clientScopes) > 0) {
                 $scopesList = array_intersect($clientScopes, $scopesList);
             }
         }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -18,6 +18,7 @@ use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\ScopeInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -217,20 +218,26 @@ abstract class AbstractGrant implements GrantTypeInterface
     /**
      * Validate scopes in the request.
      *
-     * @param string $scopes
-     * @param string $redirectUri
-     *
-     * @throws OAuthServerException
+     * @param ClientEntityInterface $client
+     * @param string                $scopes
+     * @param string                $redirectUri
      *
      * @return ScopeEntityInterface[]
+     * @throws OAuthServerException
      */
-    public function validateScopes($scopes, $redirectUri = null)
+    public function validateScopes(ClientEntityInterface $client, $scopes, $redirectUri = null)
     {
         $scopesList = array_filter(explode(self::SCOPE_DELIMITER_STRING, trim($scopes)), function ($scope) {
             return !empty($scope);
         });
 
         $validScopes = [];
+
+        if ($client instanceof ScopeInterface) {
+            if ($clientScopes = $this->getScopeIdentifiers($client)) {
+                $scopesList = array_intersect($clientScopes, $scopesList);
+            }
+        }
 
         foreach ($scopesList as $scopeItem) {
             $scope = $this->scopeRepository->getScopeEntityByIdentifier($scopeItem);
@@ -243,6 +250,22 @@ abstract class AbstractGrant implements GrantTypeInterface
         }
 
         return $validScopes;
+    }
+
+    /**
+     * Retrieve the scope identifiers from an Entity.
+     *
+     * @param ScopeInterface $entity
+     * @return string[]
+     */
+    private function getScopeIdentifiers(ScopeInterface $entity)
+    {
+        $scopesList = [];
+
+        foreach ($entity->getScopes() as $scope) {
+            $scopesList[] = $scope->getIdentifier();
+        }
+        return $scopesList;
     }
 
     /**

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -204,6 +204,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      * Fetch the client_id parameter from the query string.
      *
      * @return string|null
+     *
      * @throws OAuthServerException
      */
     protected function getClientIdFromRequest($request)

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -278,6 +278,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         }
 
         $scopes = $this->validateScopes(
+            $client,
             $this->getQueryStringParameter('scope', $request, $this->defaultScope),
             $redirectUri
         );

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -30,7 +30,7 @@ class ClientCredentialsGrant extends AbstractGrant
     ) {
         // Validate request
         $client = $this->validateClient($request);
-        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
+        $scopes = $this->validateScopes($client, $this->getRequestParameter('scope', $request, $this->defaultScope));
 
         // Finalize the requested scopes
         $finalizedScopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -160,6 +160,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         }
 
         $scopes = $this->validateScopes(
+            $client,
             $this->getQueryStringParameter('scope', $request, $this->defaultScope),
             $redirectUri
         );

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -49,7 +49,7 @@ class PasswordGrant extends AbstractGrant
     ) {
         // Validate request
         $client = $this->validateClient($request);
-        $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
+        $scopes = $this->validateScopes($client, $this->getRequestParameter('scope', $request, $this->defaultScope));
         $user = $this->validateUser($request, $client);
 
         // Finalize the requested scopes

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -43,7 +43,7 @@ class RefreshTokenGrant extends AbstractGrant
         // Validate request
         $client = $this->validateClient($request);
         $oldRefreshToken = $this->validateOldRefreshToken($request, $client->getIdentifier());
-        $scopes = $this->validateScopes($this->getRequestParameter(
+        $scopes = $this->validateScopes($client, $this->getRequestParameter(
             'scope',
             $request,
             implode(self::SCOPE_DELIMITER_STRING, $oldRefreshToken['scopes']))

--- a/tests/Stubs/ClientScopeEntity.php
+++ b/tests/Stubs/ClientScopeEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LeagueTests\Stubs;
+
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeInterface;
+use League\OAuth2\Server\Entities\Traits\ClientTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\ScopeEntityTrait;
+
+class ClientScopeEntity implements ClientEntityInterface, ScopeInterface
+{
+    use EntityTrait, ClientTrait, ScopeEntityTrait;
+
+    public function setRedirectUri($uri)
+    {
+        $this->redirectUri = $uri;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
but only when the Client implements the ScopeInterface and the ScopesTrait. So it's like optional. 

Moved Scope related code to it's own interface and trait, otherwise it would end up with code duplication.

This relates to #886 