### PR TITLE
Change hint so it applies to both the auth and access token requests

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -92,7 +92,7 @@ class OAuthServerException extends \Exception
     public static function unsupportedGrantType()
     {
         $errorMessage = 'The authorization grant type is not supported by the authorization server.';
-        $hint = 'Check the `grant_type` parameter';
+        $hint = 'Check that all required parameters have been provided';
 
         return new static($errorMessage, 2, 'unsupported_grant_type', 400, $hint);
     }


### PR DESCRIPTION
The original hint told devs to check the _grant type_ parameter but this is never pass for an authorization request. Changed to make more generic