### PR TITLE
Reword the error message for invalid clients

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -121,7 +121,7 @@ class OAuthServerException extends \Exception
      */
     public static function invalidClient()
     {
-        $errorMessage = 'Client authentication failed';
+        $errorMessage = 'Client authentication failed, the redirect uri might not match';
 
         return new static($errorMessage, 4, 'invalid_client', 401);
     }


### PR DESCRIPTION
The error message for invalid clients is vague, adding some more information to check on an invalid client