### PR TITLE
Adding validation to Refresh Token Grant ensuring old access token is valid

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -161,6 +161,11 @@ class RefreshTokenGrant extends AbstractGrant
 
         $oldAccessToken = $oldRefreshToken->getAccessToken();
 
+        // Ensure the old refresh token has a valid access token referred by it
+        if (($oldAccessToken instanceof AccessTokenEntity) === false) {
+            throw new Exception\InvalidRefreshException();
+        }
+
         // Get the scopes for the original session
         $session = $oldAccessToken->getSession();
         $scopes = $this->formatScopes($session->getScopes());


### PR DESCRIPTION
Adding validation to Refresh Token Grant ensuring refresh token has a valid access token

When Access Token Storage is unable to find the Access Token referred by the Refresh Token (by it being deleted), we should throw an Invalid Refresh Token Exception. If we don't throw such exception, $oldAccessToken has null as value and then $oldAccessToken->getSession() fails with an "Call to a member function getSession() on null" error.