### PR TITLE
Fix empty issue in PHP 5.4

### DIFF
--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -138,7 +138,9 @@ class ResourceServer extends AbstractServer
      */
     public function determineAccessToken($headerOnly = false)
     {
-        if (!empty($this->getRequest()->headers->get('Authorization'))) {
+	$authHeader = $this->getRequest()->headers->get('Authorization');
+
+        if (!empty($authHeader)) {
             $accessToken = $this->getTokenType()->determineAccessTokenInHeader($this->getRequest());
         } elseif ($headerOnly === false && (! $this->getTokenType() instanceof MAC)) {
             $accessToken = ($this->getRequest()->server->get('REQUEST_METHOD') === 'GET')


### PR DESCRIPTION
Fixes #914. This resolves an issue with the `empty()` function only being able to accept variables in PHP 5.4 or below.