### PR TITLE
Enable better extensibility of this library

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -172,6 +172,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             }
         }
 
+        // Handle extra authorization code parameters
+        $this->handleExtraAuthCodeParams($authCodePayload);
+
         // Issue and persist access + refresh tokens
         $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $authCodePayload->user_id, $scopes);
         $refreshToken = $this->issueRefreshToken($accessToken);
@@ -338,6 +341,8 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
             ];
 
+            $payload = array_merge($this->getExtraAuthCodeParams($authorizationRequest), $payload);
+
             $response = new RedirectResponse();
             $response->setRedirectUri(
                 $this->makeRedirectUri(
@@ -366,5 +371,27 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 ]
             )
         );
+    }
+
+    /**
+     * Add custom fields to your authorization code to save some data from the previous (authorize) state
+     * for when you are issuing the token at the token endpoint
+     *
+     * @param AuthorizationRequest $authorizationRequest
+     *
+     * @return array
+     */
+    protected function getExtraAuthCodeParams(AuthorizationRequest $authorizationRequest)
+    {
+        return [];
+    }
+
+    /**
+     * Handle the extra params specified in getExtraAuthCodeParams
+     *
+     * @param object $authCodePayload
+     */
+    protected function handleExtraAuthCodeParams(object $authCodePayload)
+    {
     }
 }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -12,6 +12,7 @@ namespace League\OAuth2\Server\Grant;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
@@ -341,7 +342,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
             ];
 
-            $payload = array_merge($this->getExtraAuthCodeParams($authorizationRequest), $payload);
+            $payload = array_merge($this->getExtraAuthCodeParams($authorizationRequest, $authCode), $payload);
 
             $response = new RedirectResponse();
             $response->setRedirectUri(
@@ -378,10 +379,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      * for when you are issuing the token at the token endpoint
      *
      * @param AuthorizationRequest $authorizationRequest
+     * @param AuthCodeEntityInterface $authCode
      *
      * @return array
      */
-    protected function getExtraAuthCodeParams(AuthorizationRequest $authorizationRequest)
+    protected function getExtraAuthCodeParams(AuthorizationRequest $authorizationRequest, AuthCodeEntityInterface $authCode)
     {
         return [];
     }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -9,10 +9,10 @@
 
 namespace League\OAuth2\Server\Grant;
 
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
-use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
@@ -378,7 +378,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      * Add custom fields to your authorization code to save some data from the previous (authorize) state
      * for when you are issuing the token at the token endpoint
      *
-     * @param AuthorizationRequest $authorizationRequest
+     * @param AuthorizationRequest    $authorizationRequest
      * @param AuthCodeEntityInterface $authCode
      *
      * @return array

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -391,7 +391,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      *
      * @param object $authCodePayload
      */
-    protected function handleExtraAuthCodeParams(object $authCodePayload)
+    protected function handleExtraAuthCodeParams($authCodePayload)
     {
     }
 }

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -63,9 +63,8 @@ class BearerTokenResponse extends AbstractResponseType
     }
 
     /**
-     * Add custom fields to your Bearer Token response here, then override
-     * AuthorizationServer::getResponseType() to pull in your version of
-     * this class rather than the default.
+     * Add custom fields to your Bearer Token response here, then pass an instance
+     * of your version of this class into the last parameter of the AuthorizationServer.
      *
      * @param AccessTokenEntityInterface $accessToken
      *


### PR DESCRIPTION
When looking at how to make the changes requested in #885 and #793 , I came up with the following method for adding information to access tokens:

- You can overwrite the `convertToJWT` method on your access token to add new claims directly from the access token data. 
However, you may have gotten this data (in the auth code grant) before making the authorization code (such as when you have your user login, and then want to include some data about that login in your access token). Therefore, we also needed a method to add custom data to that authorization code to transfer it 'between sessions'. Using php sessions for this purpose wouldn't always work, for instance if the server is finally using the code to reach the token endpoint, and we thus don't have the same session. This PR adds a method for adding data to the auth code, and a way to handle that data to put it back into your application before issuing the access token. (You can for instance make a TokenDataRepository, inject the data from that repo into the auth code, and then take it out of the auth code, back into the repo on the handle function).

- You can use a custom instance of the BearerTokenReponse for adding new params to both the responseParms (token_type, expires_in, access_token) by overwriting `getExtraParams` (also fixed #903 as it was a documentation error), and you can add parameters to the refresh token by also overwriting `generateHttpResponse`.

**TLDR**: you can now add extra information to:
- *the access token* through the `convertToJWT` method in your class implementing the `AccessTokenEntityInterface` interface.
- *the refresh token* by creating your own instance of the `BearerTokenResponse` class and overwriting `generateHttpResponse`
- *the auth code* by creating your own instance of the `AuthCodeGrant` class and overwriting the two empty methods for adding your own parameters
- *the token endpoint response* by creating your own instance of the `BearerTokenResponse` class and overwriting `getExtraParams`.

This PR enables people to have more control over their token contents, and enables the addition of data gained at login to the final access token, by passing it through the auth code.

_The PR has been tested, and should not introduce backwards incompatible changes. We may want to have more tests, but I cannot find an easy way to add them. Help would be welcome._