### PR TITLE
Added link to Phalcon framework integration

### DIFF
--- a/framework-integrations.md
+++ b/framework-integrations.md
@@ -10,6 +10,7 @@ permalink: /framework-integrations/
 * [Drupal](https://www.drupal.org/project/simple_oauth)
 * [Laravel Passport (Official)](https://laravel.com/docs/passport)
 * [Nette Framework](https://github.com/lookyman/nette-oauth2-server)
+* [Phalcon Framework](https://github.com/tegaphilip/padlock)
 * Slim (or any PSR7-supporting framework) - See the examples in this repository
 
 Have you made a framework integration or written a blog post or tutorial? Please open a PR against the `gh-pages` branch and update this page.


### PR DESCRIPTION
The Phalcon Framework Integration shows examples for all of the grant types implemented by the base repository. One thing that has not been implemented though is the use of scopes.