### PR TITLE
Added docbloc to UniqueTokenIdentifierConstraintViolationException

### DIFF
--- a/src/Exception/UniqueTokenIdentifierConstraintViolationException.php
+++ b/src/Exception/UniqueTokenIdentifierConstraintViolationException.php
@@ -11,6 +11,9 @@ namespace League\OAuth2\Server\Exception;
 
 class UniqueTokenIdentifierConstraintViolationException extends OAuthServerException
 {
+    /**
+     * @return UniqueTokenIdentifierConstraintViolationException
+     */
     public static function create()
     {
         $errorMessage = 'Could not create unique access token identifier';


### PR DESCRIPTION
PhpStorm was throwing a warning since the UniqueTokenIdentifierConstraintViolationException::create method doesn't explicitly return an instance of itself and doesn't document it for the function.

I just added the docblock to make things happy. Not a big deal if it isn't merged, but it made my life easier. 👍 