### PR TITLE
Update RefreshTokenGrant.php

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -99,7 +99,7 @@ class RefreshTokenGrant extends AbstractGrant
         }
 
         $refreshTokenData = json_decode($refreshToken, true);
-        if ($refreshTokenData['client_id'] !== $clientId) {
+        if ($refreshTokenData['client_id'] != $clientId) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::REFRESH_TOKEN_CLIENT_FAILED, $request));
             throw OAuthServerException::invalidRefreshToken('Token is not linked to client');
         }


### PR DESCRIPTION
function validateOldRefreshToken(ServerRequestInterface $request, $clientId) requires $clientId as a string, but $refreshTokenData['client_id'] is an integer.
See https://stackoverflow.com/questions/51907450/laravel-passport-invalid-refresh-token-token-is-not-linked-to-client/51952225