### PR TITLE
Introducing backwards compatibility in CryptTrait for decrypting password-encrypted data when a \Defuse\Crypto\Key is used

### DIFF
--- a/src/CryptTrait.php
+++ b/src/CryptTrait.php
@@ -56,7 +56,15 @@ trait CryptTrait
     {
         try {
             if ($this->encryptionKey instanceof Key) {
-                return Crypto::decrypt($encryptedData, $this->encryptionKey);
+                try {
+                    return Crypto::decrypt($encryptedData, $this->encryptionKey);
+                } catch (\Exception $e) {
+                    // This may have been encrypted with encryptWithPassword(), pull
+                    // the data out of the key and use that to decrypt.
+                    // $this->encryptionKey should not be assigned to the raw bytes so
+                    // subsequent calls to decrypt can work with the key object.
+                    return Crypto::decryptWithPassword($encryptedData, $this->encryptionKey->getRawBytes());
+                }
             }
 
             return Crypto::decryptWithPassword($encryptedData, $this->encryptionKey);

--- a/tests/Utils/CryptTraitTest.php
+++ b/tests/Utils/CryptTraitTest.php
@@ -3,6 +3,7 @@
 namespace LeagueTests\Utils;
 
 use Defuse\Crypto\Key;
+use Defuse\Crypto\Encoding;
 use LeagueTests\Stubs\CryptTraitStub;
 use PHPUnit\Framework\TestCase;
 
@@ -37,5 +38,50 @@ class CryptTraitTest extends TestCase
 
         $this->assertNotEquals($payload, $encrypted);
         $this->assertEquals($payload, $plainText);
+    }
+
+    public function testEncryptWithPasswordDecryptBackwardsCompatibility()
+    {
+        $payload = 'this is a test';
+        $key = random_bytes(32);
+
+        // Set to our original password key
+        $this->cryptStub->setEncryptionKey($key);
+
+        // Encrypt with password
+        $encrypted = $this->cryptStub->doEncrypt($payload);
+
+        $this->assertNotEquals($payload, $encrypted);
+
+        // Switch to using a Key object - we must do this in a roundabout way as the Key object has a private constructor
+        $keyObject = Key::loadFromAsciiSafeString(
+            Encoding::saveBytesToChecksummedAsciiSafeString(
+                Key::KEY_CURRENT_VERSION,
+                $key
+            )
+        );
+        $this->cryptStub->setEncryptionKey($keyObject);
+
+        // Decrypt after we switched to a Key object, with the same underlying data
+        $plainText = $this->cryptStub->doDecrypt($encrypted);
+
+        // Verify the ciphertext encrypted with the old algorithm can be decrypted even after we switched to the new Key format
+        $this->assertEquals($payload, $plainText);
+    }
+
+    public function testEncryptWithPasswordDecryptBackwardsCompatibilityBadKey()
+    {
+        $payload = 'this is a test';
+
+        // Encrypt with password
+        $encrypted = $this->cryptStub->doEncrypt($payload);
+        $this->assertNotEquals($payload, $encrypted);
+
+        // Switch to using a Key object with different underlying data
+        $this->cryptStub->setEncryptionKey(Key::createNewRandomKey());
+
+        // This should fail to decrypt as we changed the key
+        $this->expectException(\LogicException::class);
+        $this->cryptStub->doDecrypt($encrypted);
     }
 }

--- a/tests/Utils/CryptTraitTest.php
+++ b/tests/Utils/CryptTraitTest.php
@@ -2,8 +2,8 @@
 
 namespace LeagueTests\Utils;
 
-use Defuse\Crypto\Key;
 use Defuse\Crypto\Encoding;
+use Defuse\Crypto\Key;
 use LeagueTests\Stubs\CryptTraitStub;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
At the moment, in order for someone using this package to adopt the significant performance improvement made in https://github.com/thephpleague/oauth2-server/pull/814, they must have all their refresh tokens invalidated, as old refresh tokens encrypted with a password encryption key cannot be decrypted with the Key object, even if the underlying data is the same, due to how the key is created.

In order to make switching from the old encryption method to the new one non-disruptive, this change will first try to decrypt data with a Key object if one is specified, otherwise it will pull the raw bytes out of the encryption key and act as if it the raw key bytes are a password.

In practice, this enables https://github.com/laravel/passport/pull/820 to be done in a non-disruptive fashion, allowing the library to gain the performance benefit.