### PR TITLE
Added Expressive in the community integration of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ We use [Travis CI](https://travis-ci.org/), [Scrutinizer](https://scrutinizer-ci
 * [Drupal](https://www.drupal.org/project/simple_oauth)
 * [Laravel Passport](https://github.com/laravel/passport)
 * [OAuth 2 Server for CakePHP 3](https://github.com/uafrica/oauth-server)
+* [OAuth 2 Server for Expressive](https://github.com/zendframework/zend-expressive-authentication-oauth2)
 
 ## Changelog
 


### PR DESCRIPTION
I added the [Expressive integration](https://github.com/zendframework/zend-expressive-authentication-oauth2) in the community section of README. Thanks for your awesome library!