### PR TITLE
Test php 7.3 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: php
 
-dist: trusty
-sudo: false
+dist: xenial
+sudo: required
 
 cache:
   directories:
     - vendor
+
+addons:
+  apt:
+    packages:
+    # required for php7.3
+    - libzip4
 
 env:
   - DEPENDENCIES=""
@@ -15,6 +21,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3snapshot
 
 install:
   - composer update --no-interaction --prefer-dist $DEPENDENCIES


### PR DESCRIPTION
This PR adds php7.3 to the travis testing matrix.

Currently php 7.3 on travis is only available in the xenial image - therefore the switch.