### PR TITLE
Add Scope Entity Trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Moved  the `finalizeScopes()` call from `validateAuthorizationRequest` method to the `completeAuthorizationRequest` method so it is called just before the access token is issued (PR #923)
 
+### Added
+- Added a ScopeTrait to provide an implementation for jsonSerialize (PR #952)
+
 ## [7.2.0] - released 2018-06-23
 
 ### Changed

--- a/examples/src/Entities/ScopeEntity.php
+++ b/examples/src/Entities/ScopeEntity.php
@@ -11,13 +11,9 @@ namespace OAuth2ServerExamples\Entities;
 
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\ScopeTrait;
 
 class ScopeEntity implements ScopeEntityInterface
 {
-    use EntityTrait;
-
-    public function jsonSerialize()
-    {
-        return $this->getIdentifier();
-    }
+    use EntityTrait, ScopeTrait;
 }

--- a/src/Entities/Traits/ScopeTrait.php
+++ b/src/Entities/Traits/ScopeTrait.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author    Andrew Millington <andrew@noexceptions.io>
+ * @copyright Copyright (c) Andrew Millington
+ * @license   http://mit-license.org
+ *
+ * @link      https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\Entities\Traits;
+
+trait ScopeTrait
+{
+    /**
+     * Serialize the object to the scopes string identifier when using json_encode().
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->getIdentifier();
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getIdentifier();
+}


### PR DESCRIPTION
The scope entity interface implements the json serializable interface which forces implementers to create a jsonSerialize function.

The package expects this function to be implemented in a very specific way, only returning the string identifier of the scope. Any other implementation breaks the server.

Prior to this pull request, we had no concrete implementation of this function to use. Developers were forced to either inspect the code or refer to our examples section. This pull request addresses this issue.