### PR TITLE
Make AuthorizationServer stateless

### DIFF
--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -3,6 +3,7 @@
 namespace LeagueTests;
 
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -90,7 +91,7 @@ class AuthorizationServerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testGetResponseType()
+    public function testNewDefaultResponseType()
     {
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
 
@@ -103,10 +104,66 @@ class AuthorizationServerTest extends TestCase
         );
 
         $abstractGrantReflection = new \ReflectionClass($server);
-        $method = $abstractGrantReflection->getMethod('getResponseType');
+        $method = $abstractGrantReflection->getMethod('newResponseType');
         $method->setAccessible(true);
 
-        $this->assertInstanceOf(BearerTokenResponse::class, $method->invoke($server));
+        $responseTypeA = $method->invoke($server);
+        $responseTypeB = $method->invoke($server);
+        $this->assertInstanceOf(BearerTokenResponse::class, $responseTypeA);
+        $this->assertInstanceOf(BearerTokenResponse::class, $responseTypeB);
+        $this->assertNotSame($responseTypeA, $responseTypeB);
+    }
+
+    public function testNewResponseTypeFromPrototype()
+    {
+        $privateKey = 'file://' . __DIR__ . '/Stubs/private.key';
+        $encryptionKey = 'file://' . __DIR__ . '/Stubs/public.key';
+
+        $responseTypePrototype = new class extends BearerTokenResponse {
+            /* @return null|CryptKey */
+            public function getPrivateKey()
+            {
+                return $this->privateKey;
+            }
+
+            public function getEncryptionKey()
+            {
+                return $this->encryptionKey;
+            }
+        };
+
+        $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+
+        $server = new AuthorizationServer(
+            $clientRepository,
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock(),
+            $privateKey,
+            $encryptionKey,
+            $responseTypePrototype
+        );
+
+        $abstractGrantReflection = new \ReflectionClass($server);
+        $method = $abstractGrantReflection->getMethod('newResponseType');
+        $method->setAccessible(true);
+
+        $responseTypeA = $method->invoke($server);
+        $responseTypeB = $method->invoke($server);
+
+        // prototype should not get changed
+        $this->assertNull($responseTypePrototype->getPrivateKey());
+        $this->assertNull($responseTypePrototype->getEncryptionKey());
+
+        // generated instances should have keys setup
+        $this->assertSame($privateKey, $responseTypeA->getPrivateKey()->getKeyPath());
+        $this->assertSame($encryptionKey, $responseTypeA->getEncryptionKey());
+
+        // all instances should be different but based on the same prototype
+        $this->assertSame(get_class($responseTypePrototype), get_class($responseTypeA));
+        $this->assertSame(get_class($responseTypePrototype), get_class($responseTypeB));
+        $this->assertNotSame($responseTypePrototype, $responseTypeA);
+        $this->assertNotSame($responseTypePrototype, $responseTypeB);
+        $this->assertNotSame($responseTypeA, $responseTypeB);
     }
 
     public function testCompleteAuthorizationRequest()


### PR DESCRIPTION
I want to use this library by `zend-expressive-authentication-oauth2` and together with `zend-expressive-swoole`.

The problem I have now is that the `AuthenticationServer` is state full by (in my opinion bad deisgn):
1. The injected object `$responseType` gets modified by the server by setting the keys
2. The same object gets modified again by the authentication grants to inject tokens

What happens by me together with swoole is that an access and refresh token get injected on the first successful password authentication and after that the same swoole worker serves a successful client credentials authentication and the response contains the refresh token on the first password authentication. 👎 

To quickly solve that without introducing BC break I have changed the injected `responseType` to act as a prototype. Means it gets cloned on first injection to not modify the injected objected and secondly clone again on authentication response.

In general I thing this specific handling should be refactored by a better architecture but that for sure introduces a BC break.