### PR TITLE
Password Grant Should Issue an invalid_grant Error When Credentials are Incorrect

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -81,11 +81,13 @@ class PasswordGrant extends AbstractGrant
     protected function validateUser(ServerRequestInterface $request, ClientEntityInterface $client)
     {
         $username = $this->getRequestParameter('username', $request);
+
         if (is_null($username)) {
             throw OAuthServerException::invalidRequest('username');
         }
 
         $password = $this->getRequestParameter('password', $request);
+
         if (is_null($password)) {
             throw OAuthServerException::invalidRequest('password');
         }
@@ -96,10 +98,11 @@ class PasswordGrant extends AbstractGrant
             $this->getIdentifier(),
             $client
         );
+
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidCredentials();
+            throw OAuthServerException::invalidGrant();
         }
 
         return $user;

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -145,6 +145,7 @@ class PasswordGrantTest extends TestCase
 
     /**
      * @expectedException \League\OAuth2\Server\Exception\OAuthServerException
+     * @expectedExceptionCode 10
      */
     public function testRespondToRequestBadCredentials()
     {


### PR DESCRIPTION
This pull request is using code provided by @raarts that was originally submitted in PR #803.

It has been resubmitted here as it is a breaking change so will be included in the version 8 release.