### PR TITLE
Revert Interface Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [7.3.1] - released 2018-11-15
+
+### Fixed
+- Fix issue with previous release where interface had changed for the AuthorizationServer. Reverted to the previous interface while maintaining functionality changes (PR #970)
+
 ## [7.3.0] - released 2018-11-13
 
 ### Changed
@@ -422,7 +427,8 @@ Version 5 is a complete code rewrite.
 
 - First major release
 
-[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/7.3.0...HEAD
+[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/7.3.1...HEAD
+[7.3.1]: https://github.com/thephpleague/oauth2-server/compare/7.3.0...7.3.1
 [7.3.0]: https://github.com/thephpleague/oauth2-server/compare/7.2.0...7.3.0
 [7.2.0]: https://github.com/thephpleague/oauth2-server/compare/7.1.1...7.2.0
 [7.1.1]: https://github.com/thephpleague/oauth2-server/compare/7.1.0...7.1.1

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -52,7 +52,7 @@ class AuthorizationServer implements EmitterAwareInterface
     /**
      * @var ResponseTypeInterface
      */
-    protected $responseTypePrototype;
+    protected $responseType;
 
     /**
      * @var ClientRepositoryInterface
@@ -87,7 +87,7 @@ class AuthorizationServer implements EmitterAwareInterface
      * @param ScopeRepositoryInterface       $scopeRepository
      * @param CryptKey|string                $privateKey
      * @param string|Key                     $encryptionKey
-     * @param null|ResponseTypeInterface     $responseTypePrototype
+     * @param null|ResponseTypeInterface     $responseType
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,
@@ -95,7 +95,7 @@ class AuthorizationServer implements EmitterAwareInterface
         ScopeRepositoryInterface $scopeRepository,
         $privateKey,
         $encryptionKey,
-        ResponseTypeInterface $responseTypePrototype = null
+        ResponseTypeInterface $responseType = null
     ) {
         $this->clientRepository = $clientRepository;
         $this->accessTokenRepository = $accessTokenRepository;
@@ -108,19 +108,19 @@ class AuthorizationServer implements EmitterAwareInterface
         $this->privateKey = $privateKey;
         $this->encryptionKey = $encryptionKey;
 
-        if ($responseTypePrototype === null) {
-            $responseTypePrototype = new BearerTokenResponse();
+        if ($responseType === null) {
+            $responseType = new BearerTokenResponse();
         } else {
-            $responseTypePrototype = clone $responseTypePrototype;
+            $responseType = clone $responseType;
         }
 
-        if ($responseTypePrototype instanceof AbstractResponseType) {
-            $responseTypePrototype->setPrivateKey($this->privateKey);
+        if ($responseType instanceof AbstractResponseType) {
+            $responseType->setPrivateKey($this->privateKey);
         }
 
-        $responseTypePrototype->setEncryptionKey($this->encryptionKey);
+        $responseType->setEncryptionKey($this->encryptionKey);
 
-        $this->responseTypePrototype = $responseTypePrototype;
+        $this->responseType = $responseType;
     }
 
     /**
@@ -200,7 +200,7 @@ class AuthorizationServer implements EmitterAwareInterface
             }
             $tokenResponse = $grantType->respondToAccessTokenRequest(
                 $request,
-                $this->newResponseType(),
+                $this->getResponseType(),
                 $this->grantTypeAccessTokenTTL[$grantType->getIdentifier()]
             );
 
@@ -217,9 +217,9 @@ class AuthorizationServer implements EmitterAwareInterface
      *
      * @return ResponseTypeInterface
      */
-    protected function newResponseType()
+    protected function getResponseType()
     {
-        return clone $this->responseTypePrototype;
+        return clone $this->responseType;
     }
 
     /**

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -91,7 +91,7 @@ class AuthorizationServerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testNewDefaultResponseType()
+    public function testGetResponseType()
     {
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
 
@@ -104,17 +104,13 @@ class AuthorizationServerTest extends TestCase
         );
 
         $abstractGrantReflection = new \ReflectionClass($server);
-        $method = $abstractGrantReflection->getMethod('newResponseType');
+        $method = $abstractGrantReflection->getMethod('getResponseType');
         $method->setAccessible(true);
 
-        $responseTypeA = $method->invoke($server);
-        $responseTypeB = $method->invoke($server);
-        $this->assertInstanceOf(BearerTokenResponse::class, $responseTypeA);
-        $this->assertInstanceOf(BearerTokenResponse::class, $responseTypeB);
-        $this->assertNotSame($responseTypeA, $responseTypeB);
+        $this->assertInstanceOf(BearerTokenResponse::class, $method->invoke($server));
     }
 
-    public function testNewResponseTypeFromPrototype()
+    public function testMultipleRequestsGetDifferentResponseTypeInstances()
     {
         $privateKey = 'file://' . __DIR__ . '/Stubs/private.key';
         $encryptionKey = 'file://' . __DIR__ . '/Stubs/public.key';
@@ -144,7 +140,7 @@ class AuthorizationServerTest extends TestCase
         );
 
         $abstractGrantReflection = new \ReflectionClass($server);
-        $method = $abstractGrantReflection->getMethod('newResponseType');
+        $method = $abstractGrantReflection->getMethod('getResponseType');
         $method->setAccessible(true);
 
         $responseTypeA = $method->invoke($server);


### PR DESCRIPTION
In the 7.3.0 release, some protected variables and functions were altered causing issues for some implementations when extending the AuthorizationServer class. This pull request reverts these changes to fix issue #968 