### PR TITLE
Add Symfony community integration to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ We use [Travis CI](https://travis-ci.org/), [Scrutinizer](https://scrutinizer-ci
 * [Laravel Passport](https://github.com/laravel/passport)
 * [OAuth 2 Server for CakePHP 3](https://github.com/uafrica/oauth-server)
 * [OAuth 2 Server for Expressive](https://github.com/zendframework/zend-expressive-authentication-oauth2)
+* [Trikoder OAuth 2 Bundle (Symfony)](https://github.com/trikoder/oauth2-bundle)
 
 ## Changelog
 


### PR DESCRIPTION
We recently published a Symfony 4.x bundle which aims to integrate `thephpleague/oauth2-server` with the framework. You can check it out here:

https://github.com/trikoder/oauth2-bundle

We implemented all authorization flows which we needed for our API based projects, but there are still some [stuff](https://github.com/trikoder/oauth2-bundle/issues) left to implement to make it feature complete. Contributions are very much welcomed, of course. :smiley: 

The purpose of this PR is to raise awareness for this community integration (we were kinda surprised that no one has done a Symfony based one yet) and provide more plug-and-play OAuth 2.0 solutions to the Symfony ecosystem (such as [FriendsOfSymfony/FOSOAuthServerBundle](https://github.com/FriendsOfSymfony/FOSOAuthServerBundle)). 
