### PR TITLE
 Fixed respondToAccessTokenRequest using Http Basic Auth

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -171,15 +171,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      */
     protected function validateClient(ServerRequestInterface $request)
     {
-        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
-
-        $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
-
-        if (is_null($clientId)) {
-            throw OAuthServerException::invalidRequest('client_id');
-        }
-
-        $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);
+        list($clientId, $clientSecret) = $this->getClientCredentials($request);
 
         if ($this->clientRepository->validateClient($clientId, $clientSecret, $this->getIdentifier()) === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
@@ -197,6 +189,29 @@ abstract class AbstractGrant implements GrantTypeInterface
         }
 
         return $client;
+    }
+
+    /**
+     * Gets the client credentials from the request from the request body or
+     * the Http Basic Authorization header
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return array
+     */
+    protected function getClientCredentials(ServerRequestInterface $request)
+    {
+        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
+
+        $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
+
+        if (is_null($clientId)) {
+            throw OAuthServerException::invalidRequest('client_id');
+        }
+
+        $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);
+
+        return [$clientId, $clientSecret];
     }
 
     /**

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -90,11 +90,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         ResponseTypeInterface $responseType,
         \DateInterval $accessTokenTTL
     ) {
-        $clientId = $this->getRequestParameter('client_id', $request, null);
-
-        if ($clientId === null) {
-            throw OAuthServerException::invalidRequest('client_id');
-        }
+        list($clientId) = $this->getClientCredentials($request);
 
         $client = $this->clientRepository->getClientEntity($clientId);
 

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -642,7 +642,7 @@ class AuthCodeGrantTest extends TestCase
             'POST',
             'php://input',
             [
-                //'Authorization' => 'Basic Zm9vOmJhcg==',
+                'Authorization' => 'Basic Zm9vOmJhcg==',
             ],
             [],
             [],


### PR DESCRIPTION
** Note ** This PR targets 8.0.0-branch instead of the master branch. The Contribution Guidelines don't allow it. But this issue does not exist in the master-branch.

Resolves https://github.com/thephpleague/oauth2-server/issues/961

Changes:

 - Fixes 8.0.0 regression by re-accepting `client_id` from `Authorization` header in `AuthCodeGrant` `respondToAccessTokenRequest`.
 - Added regression test