### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 install:
   - composer update --no-interaction --prefer-dist $DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following versions of PHP are supported:
 * PHP 7.0
 * PHP 7.1
 * PHP 7.2
+* PHP 7.3
 
 The `openssl` extension is also required.
 


### PR DESCRIPTION
Adding support for PHP 7.3. Travis tests will now check PHP 7.3