### PR TITLE
Add token revocation support

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -247,7 +247,8 @@ class AuthorizationServer implements EmitterAwareInterface
             }
         }
 
-        throw OAuthServerException::invalidRequest('token');
+        $errorMessage = 'Token revocation not supported.';
+        throw new OAuthServerException($errorMessage, 3, 'invalid_request', 400);
     }
 
     /**

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -211,6 +211,7 @@ class AuthorizationServer implements EmitterAwareInterface
 
         throw OAuthServerException::unsupportedGrantType();
     }
+
     /**
      * Enable the revoke token handler on the server.
      *
@@ -239,7 +240,11 @@ class AuthorizationServer implements EmitterAwareInterface
     public function respondToRevokeTokenRequest(ServerRequestInterface $request, ResponseInterface $response)
     {
         if ($this->revokeTokenHandler !== null) {
-            return $this->revokeTokenHandler->respondToRevokeTokenRequest($request, $response);
+            $revokeResponse = $this->revokeTokenHandler->respondToRevokeTokenRequest($request, $this->getResponseType());
+
+            if ($revokeResponse instanceof ResponseTypeInterface) {
+                return $revokeResponse->generateHttpResponse($response);
+            }
         }
 
         throw OAuthServerException::invalidRequest('token');

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -15,6 +15,7 @@ use DateTime;
 use Error;
 use Exception;
 use League\Event\EmitterAwareTrait;
+use League\OAuth2\Server\RequestValidatorTrait;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
@@ -41,7 +42,7 @@ use TypeError;
  */
 abstract class AbstractGrant implements GrantTypeInterface
 {
-    use EmitterAwareTrait, CryptTrait;
+    use EmitterAwareTrait, CryptTrait, RequestValidatorTrait;
 
     const SCOPE_DELIMITER_STRING = ' ';
 
@@ -91,6 +92,14 @@ abstract class AbstractGrant implements GrantTypeInterface
      * @string
      */
     protected $defaultScope;
+
+    /**
+     * @return ClientRepositoryInterface
+     */
+    public function getClientRepository()
+    {
+        return $this->clientRepository;
+    }
 
     /**
      * @param ClientRepositoryInterface $clientRepository
@@ -167,76 +176,6 @@ abstract class AbstractGrant implements GrantTypeInterface
     }
 
     /**
-     * Validate the client.
-     *
-     * @param ServerRequestInterface $request
-     *
-     * @throws OAuthServerException
-     *
-     * @return ClientEntityInterface
-     */
-    protected function validateClient(ServerRequestInterface $request)
-    {
-        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
-
-        $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
-        if ($clientId === null) {
-            throw OAuthServerException::invalidRequest('client_id');
-        }
-
-        // If the client is confidential require the client secret
-        $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);
-
-        $client = $this->clientRepository->getClientEntity(
-            $clientId,
-            $this->getIdentifier(),
-            $clientSecret,
-            true
-        );
-
-        if ($client instanceof ClientEntityInterface === false) {
-            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient();
-        }
-
-        $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
-
-        if ($redirectUri !== null) {
-            $this->validateRedirectUri($redirectUri, $client, $request);
-        }
-
-        return $client;
-    }
-
-    /**
-     * Validate redirectUri from the request.
-     * If a redirect URI is provided ensure it matches what is pre-registered
-     *
-     * @param string                 $redirectUri
-     * @param ClientEntityInterface  $client
-     * @param ServerRequestInterface $request
-     *
-     * @throws OAuthServerException
-     */
-    protected function validateRedirectUri(
-        string $redirectUri,
-        ClientEntityInterface $client,
-        ServerRequestInterface $request
-    ) {
-        if (\is_string($client->getRedirectUri())
-            && (strcmp($client->getRedirectUri(), $redirectUri) !== 0)
-        ) {
-            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient();
-        } elseif (\is_array($client->getRedirectUri())
-            && \in_array($redirectUri, $client->getRedirectUri(), true) === false
-        ) {
-            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient();
-        }
-    }
-
-    /**
      * Validate scopes in the request.
      *
      * @param string|array $scopes
@@ -279,97 +218,6 @@ abstract class AbstractGrant implements GrantTypeInterface
         return array_filter(explode(self::SCOPE_DELIMITER_STRING, trim($scopes)), function ($scope) {
             return !empty($scope);
         });
-    }
-
-    /**
-     * Retrieve request parameter.
-     *
-     * @param string                 $parameter
-     * @param ServerRequestInterface $request
-     * @param mixed                  $default
-     *
-     * @return null|string
-     */
-    protected function getRequestParameter($parameter, ServerRequestInterface $request, $default = null)
-    {
-        $requestParameters = (array) $request->getParsedBody();
-
-        return $requestParameters[$parameter] ?? $default;
-    }
-
-    /**
-     * Retrieve HTTP Basic Auth credentials with the Authorization header
-     * of a request. First index of the returned array is the username,
-     * second is the password (so list() will work). If the header does
-     * not exist, or is otherwise an invalid HTTP Basic header, return
-     * [null, null].
-     *
-     * @param ServerRequestInterface $request
-     *
-     * @return string[]|null[]
-     */
-    protected function getBasicAuthCredentials(ServerRequestInterface $request)
-    {
-        if (!$request->hasHeader('Authorization')) {
-            return [null, null];
-        }
-
-        $header = $request->getHeader('Authorization')[0];
-        if (strpos($header, 'Basic ') !== 0) {
-            return [null, null];
-        }
-
-        if (!($decoded = base64_decode(substr($header, 6)))) {
-            return [null, null];
-        }
-
-        if (strpos($decoded, ':') === false) {
-            return [null, null]; // HTTP Basic header without colon isn't valid
-        }
-
-        return explode(':', $decoded, 2);
-    }
-
-    /**
-     * Retrieve query string parameter.
-     *
-     * @param string                 $parameter
-     * @param ServerRequestInterface $request
-     * @param mixed                  $default
-     *
-     * @return null|string
-     */
-    protected function getQueryStringParameter($parameter, ServerRequestInterface $request, $default = null)
-    {
-        return isset($request->getQueryParams()[$parameter]) ? $request->getQueryParams()[$parameter] : $default;
-    }
-
-    /**
-     * Retrieve cookie parameter.
-     *
-     * @param string                 $parameter
-     * @param ServerRequestInterface $request
-     * @param mixed                  $default
-     *
-     * @return null|string
-     */
-    protected function getCookieParameter($parameter, ServerRequestInterface $request, $default = null)
-    {
-        return isset($request->getCookieParams()[$parameter]) ? $request->getCookieParams()[$parameter] : $default;
-    }
-
-    /**
-     * Retrieve server parameter.
-     *
-     * @param string                 $parameter
-     * @param ServerRequestInterface $request
-     * @param mixed                  $default
-     *
-     * @return null|string
-     */
-    protected function getServerParameter($parameter, ServerRequestInterface $request, $default = null)
-    {
-        return isset($request->getServerParams()[$parameter]) ? $request->getServerParams()[$parameter] : $default;
     }
 
     /**

--- a/src/RequestValidatorTrait.php
+++ b/src/RequestValidatorTrait.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server;
+
+use League\OAuth2\Server\RequestEvent;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Psr\Http\Message\ServerRequestInterface;
+
+trait RequestValidatorTrait
+{
+    /**
+     * Get the Emitter.
+     *
+     * @return EmitterInterface
+     */
+    abstract public function getEmitter();
+
+    /**
+     * @return ClientRepositoryInterface
+     */
+    abstract public function getClientRepository();
+
+    /**
+     * Return the grant identifier that can be used in matching up requests.
+     *
+     * @return string
+     */
+    abstract public function getIdentifier();
+
+    /**
+     * Validate the client.
+     *
+     * @param ServerRequestInterface    $request
+     *
+     * @throws OAuthServerException
+     *
+     * @return ClientEntityInterface
+     */
+    public function validateClient(ServerRequestInterface $request)
+    {
+        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
+
+        $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
+        if ($clientId === null) {
+            throw OAuthServerException::invalidRequest('client_id');
+        }
+
+        // If the client is confidential require the client secret
+        $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);
+
+        $client = $this->getClientRepository()->getClientEntity(
+            $clientId,
+            $this->getIdentifier(),
+            $clientSecret,
+            true
+        );
+
+        if ($client instanceof ClientEntityInterface === false) {
+            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient();
+        }
+
+        $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
+
+        if ($redirectUri !== null) {
+            $this->validateRedirectUri($redirectUri, $client, $request);
+        }
+
+        return $client;
+    }
+
+    /**
+     * Validate redirectUri from the request.
+     * If a redirect URI is provided ensure it matches what is pre-registered
+     *
+     * @param string                 $redirectUri
+     * @param ClientEntityInterface  $client
+     * @param ServerRequestInterface $request
+     *
+     * @throws OAuthServerException
+     */
+    public function validateRedirectUri(
+        $redirectUri,
+        ClientEntityInterface $client,
+        ServerRequestInterface $request
+    ) {
+        if (\is_string($client->getRedirectUri())
+            && (strcmp($client->getRedirectUri(), $redirectUri) !== 0)
+        ) {
+            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient();
+        } elseif (\is_array($client->getRedirectUri())
+            && \in_array($redirectUri, $client->getRedirectUri(), true) === false
+        ) {
+            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient();
+        }
+    }
+
+    /**
+     * Retrieve request parameter.
+     *
+     * @param string                 $parameter
+     * @param ServerRequestInterface $request
+     * @param mixed                  $default
+     *
+     * @return null|string
+     */
+    protected function getRequestParameter($parameter, ServerRequestInterface $request, $default = null)
+    {
+        $requestParameters = (array) $request->getParsedBody();
+
+        return isset($requestParameters[$parameter]) ? $requestParameters[$parameter] : $default;
+    }
+
+    /**
+     * Retrieve HTTP Basic Auth credentials with the Authorization header
+     * of a request. First index of the returned array is the username,
+     * second is the password (so list() will work). If the header does
+     * not exist, or is otherwise an invalid HTTP Basic header, return
+     * [null, null].
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return string[]|null[]
+     */
+    public function getBasicAuthCredentials(ServerRequestInterface $request)
+    {
+        if (!$request->hasHeader('Authorization')) {
+            return [null, null];
+        }
+
+        $header = $request->getHeader('Authorization')[0];
+        if (strpos($header, 'Basic ') !== 0) {
+            return [null, null];
+        }
+
+        if (!($decoded = base64_decode(substr($header, 6)))) {
+            return [null, null];
+        }
+
+        if (strpos($decoded, ':') === false) {
+            return [null, null]; // HTTP Basic header without colon isn't valid
+        }
+
+        return explode(':', $decoded, 2);
+    }
+
+    /**
+     * Retrieve query string parameter.
+     *
+     * @param string                 $parameter
+     * @param ServerRequestInterface $request
+     * @param mixed                  $default
+     *
+     * @return null|string
+     */
+    protected function getQueryStringParameter($parameter, ServerRequestInterface $request, $default = null)
+    {
+        return isset($request->getQueryParams()[$parameter]) ? $request->getQueryParams()[$parameter] : $default;
+    }
+
+    /**
+     * Retrieve cookie parameter.
+     *
+     * @param string                 $parameter
+     * @param ServerRequestInterface $request
+     * @param mixed                  $default
+     *
+     * @return null|string
+     */
+    protected function getCookieParameter($parameter, ServerRequestInterface $request, $default = null)
+    {
+        return isset($request->getCookieParams()[$parameter]) ? $request->getCookieParams()[$parameter] : $default;
+    }
+
+    /**
+     * Retrieve server parameter.
+     *
+     * @param string                 $parameter
+     * @param ServerRequestInterface $request
+     * @param mixed                  $default
+     *
+     * @return null|string
+     */
+    protected function getServerParameter($parameter, ServerRequestInterface $request, $default = null)
+    {
+        return isset($request->getServerParams()[$parameter]) ? $request->getServerParams()[$parameter] : $default;
+    }
+}

--- a/src/RevokeTokenHandler.php
+++ b/src/RevokeTokenHandler.php
@@ -126,7 +126,7 @@ class RevokeTokenHandler implements EmitterAwareInterface
      * @return string
      */
     public function getIdentifier() {
-		return null;
+		return '';
 	}
 
    /**

--- a/src/RevokeTokenHandler.php
+++ b/src/RevokeTokenHandler.php
@@ -22,7 +22,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
-use Psr\Http\Message\ResponseInterface;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
@@ -116,13 +116,13 @@ class RevokeTokenHandler implements EmitterAwareInterface
      * https://tools.ietf.org/html/rfc7009
      *
      * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
+     * @param ResponseTypeInterface  $response
      *
      * @throws OAuthServerException
      *
-     * @return ResponseInterface
+     * @return ResponseTypeInterface
      */
-    public function respondToRevokeTokenRequest(ServerRequestInterface $request, ResponseInterface $response)
+    public function respondToRevokeTokenRequest(ServerRequestInterface $request, ResponseTypeInterface $response)
     {
         if ($request->getMethod() !== 'POST') {
             throw OAuthServerException::invalidRequest('method');

--- a/src/RevokeTokenHandler.php
+++ b/src/RevokeTokenHandler.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server;
+
+use Exception;
+use InvalidArgumentException;
+use Lcobucci\JWT\Parser;
+use Lcobucci\JWT\Token;
+use League\Event\EmitterAwareInterface;
+use League\Event\EmitterAwareTrait;
+use League\OAuth2\Server\ClientValidator;
+use League\OAuth2\Server\CryptTrait;
+use League\OAuth2\Server\RequestValidatorTrait;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+
+class RevokeTokenHandler implements EmitterAwareInterface
+{
+    use EmitterAwareTrait, CryptTrait, RequestValidatorTrait;
+
+    /**
+     * @var ClientValidator
+     */
+    protected $clientValidator;
+
+    /**
+     * @var ClientRepositoryInterface
+     */
+    protected $clientRepository;
+
+    /**
+     * @var AccessTokenRepositoryInterface
+     */
+    private $accessTokenRepository;
+
+    /**
+     * @var RefreshTokenRepositoryInterface
+     */
+    private $refreshTokenRepository;
+
+    /**
+     * @var bool
+     */
+    private $canRevokeAccessTokens;
+
+    /**
+     * New handler instance.
+     *
+     * @param RefreshTokenRepositoryInterface $refreshTokenRepository
+     * @param bool                            $canRevokeAccessTokens
+     */
+    public function __construct(
+        RefreshTokenRepositoryInterface $refreshTokenRepository,
+        $canRevokeAccessTokens = true
+    )
+    {
+        $this->setRefreshTokenRepository($refreshTokenRepository);
+        $this->canRevokeAccessTokens = $canRevokeAccessTokens;
+    }
+
+    /**
+     * @return ClientRepositoryInterface
+     */
+    public function getClientRepository()
+    {
+        return $this->clientRepository;
+    }
+
+    /**
+     * @param ClientRepositoryInterface $clientRepository
+     */
+    public function setClientRepository(ClientRepositoryInterface $clientRepository)
+    {
+        $this->clientRepository = $clientRepository;
+    }
+
+    /**
+     * @param AccessTokenRepositoryInterface $accessTokenRepository
+     */
+    public function setAccessTokenRepository(AccessTokenRepositoryInterface $accessTokenRepository)
+    {
+        $this->accessTokenRepository = $accessTokenRepository;
+    }
+
+    /**
+     * @param RefreshTokenRepositoryInterface $refreshTokenRepository
+     */
+    public function setRefreshTokenRepository(RefreshTokenRepositoryInterface $refreshTokenRepository)
+    {
+        $this->refreshTokenRepository = $refreshTokenRepository;
+    }
+
+    /**
+     * Return the grant identifier that can be used in matching up requests.
+     *
+     * @return string
+     */
+    public function getIdentifier() {
+		return null;
+	}
+
+   /**
+     * Return an revoke token response.
+     * https://tools.ietf.org/html/rfc7009
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     *
+     * @throws OAuthServerException
+     *
+     * @return ResponseInterface
+     */
+    public function respondToRevokeTokenRequest(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        if ($request->getMethod() !== 'POST') {
+            throw OAuthServerException::invalidRequest('method');
+        }
+
+        $token = $this->getRequestParameter('token', $request);
+        $hint = $this->getRequestParameter('token_type_hint', $request);
+
+        // Validate request
+        $client = $this->validateClient($request);
+        $clientId = $client->getIdentifier();
+
+        if (is_null($token)) {
+            return $response;
+        }
+
+        // Attempt to read token
+        $accessToken = null;
+        $refreshToken = null;
+        if ($hint === 'access_token') {
+            $accessToken = $this->readAsAccessToken($token, $clientId);
+        } else if ($hint === 'refresh_token') {
+            $refreshToken = $this->readAsRefreshToken($token, $clientId);
+        } else {
+            $accessToken = $this->readAsAccessToken($token, $clientId);
+            if ($accessToken === null) {
+                $refreshToken = $this->readAsRefreshToken($token, $clientId);
+            }
+        }
+
+        // Revoke tokens
+        if ($accessToken !== null) {
+            if (!$this->canRevokeAccessTokens) {
+                $errorMessage = 'The authorization server does not support the revocation of the presented token type';
+                throw new OAuthServerException($errorMessage, 2, 'unsupported_token_type', 400);
+            }
+            $this->accessTokenRepository->revokeAccessToken($accessToken->getClaim('jti'));
+        } else if ($refreshToken !== null) {
+            $this->refreshTokenRepository->revokeRefreshToken($refreshToken['refresh_token_id']);
+            if ($this->canRevokeAccessTokens) {
+                $this->accessTokenRepository->revokeAccessToken($refreshToken['access_token_id']);
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $tokenParam
+     * @param string $clientId
+     *
+     * @return null|Token
+     */
+    protected function readAsAccessToken($tokenParam, $clientId) {
+        try {
+            $token = (new Parser())->parse($tokenParam);
+            $clientId = $token->getClaim('aud');
+            if ($clientId !== $clientId) {
+                return null;
+            }
+
+            return $token;
+        } catch (Exception $exception) {
+            // JWT couldn't be parsed so ignore
+            return null;
+        }
+    }
+
+    /**
+     * @param string $tokenParam
+     * @param string $clientId
+     *
+     * @return null|array
+     */
+    protected function readAsRefreshToken($tokenParam, $clientId) {
+        try {
+            $refreshToken = $this->decrypt($tokenParam);
+            $refreshTokenData = json_decode($refreshToken, true);
+            if ($refreshTokenData['client_id'] !== $clientId) {
+                return null;
+            }
+            return $refreshTokenData;
+        } catch (Exception $e) {
+            // token couldn't be decrypted so ignore
+        }
+    }
+}

--- a/src/RevokeTokenHandler.php
+++ b/src/RevokeTokenHandler.php
@@ -161,10 +161,11 @@ class RevokeTokenHandler implements EmitterAwareInterface
         // Attempt to read token
         $accessToken = null;
         $refreshToken = null;
-        if ($hint === 'access_token') {
-            $accessToken = $this->readAsAccessToken($token, $clientId);
-        } else if ($hint === 'refresh_token') {
+        if ($hint === 'refresh_token') {
             $refreshToken = $this->readAsRefreshToken($token, $clientId);
+            if ($refreshToken === null) {
+                $accessToken = $this->readAsAccessToken($token, $clientId);
+            }
         } else {
             $accessToken = $this->readAsAccessToken($token, $clientId);
             if ($accessToken === null) {

--- a/src/RevokeTokenHandler.php
+++ b/src/RevokeTokenHandler.php
@@ -16,7 +16,6 @@ use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token;
 use League\Event\EmitterAwareInterface;
 use League\Event\EmitterAwareTrait;
-use League\OAuth2\Server\ClientValidator;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\RequestValidatorTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -30,11 +29,6 @@ use RuntimeException;
 class RevokeTokenHandler implements EmitterAwareInterface
 {
     use EmitterAwareTrait, CryptTrait, RequestValidatorTrait;
-
-    /**
-     * @var ClientValidator
-     */
-    protected $clientValidator;
 
     /**
      * @var ClientRepositoryInterface

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -4,6 +4,7 @@ namespace LeagueTests;
 
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\RevokeTokenHandler;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -353,5 +354,73 @@ class AuthorizationServerTest extends TestCase
         );
 
         $server->validateAuthorizationRequest($request);
+    }
+
+    public function testRespondToRevokeRequestUnregistered()
+    {
+        $server = new AuthorizationServer(
+            $this->getMockBuilder(ClientRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/private.key',
+            base64_encode(random_bytes(36)),
+            new StubResponseType()
+        );
+
+        try {
+            $server->respondToRevokeTokenRequest(ServerRequestFactory::fromGlobals(), new Response);
+        } catch (OAuthServerException $e) {
+            $this->assertEquals('invalid_request', $e->getErrorType());
+            $this->assertEquals(400, $e->getHttpStatusCode());
+        }
+    }
+
+    public function testRespondToRevokeRequest()
+    {
+        $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepository->method('getClientEntity')->willReturn(new ClientEntity());
+
+        $scope = new ScopeEntity();
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope);
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
+
+        $server = new AuthorizationServer(
+            $clientRepository,
+            $accessTokenRepositoryMock,
+            $scopeRepositoryMock,
+            'file://' . __DIR__ . '/Stubs/private.key',
+            base64_encode(random_bytes(36)),
+            new StubResponseType()
+        );
+
+        $server->setDefaultScope(self::DEFAULT_SCOPE);
+        $server->enableRevokeTokenHandler(new RevokeTokenHandler(
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/public.key'
+        ));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'token' => 'abcdef',
+                'token_type_hint' => 'access_token',
+                'client_id' => 'foo',
+                'client_secret' => 'bar'
+            ]
+        );
+
+        $response = $server->respondToRevokeTokenRequest($request, new Response);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/tests/RevokeTokenHandlerTest.php
+++ b/tests/RevokeTokenHandlerTest.php
@@ -1,0 +1,490 @@
+<?php
+
+namespace LeagueTests;
+
+use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\RevokeTokenHandler;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+use LeagueTests\Stubs\AccessTokenEntity;
+use LeagueTests\Stubs\ClientEntity;
+use LeagueTests\Stubs\CryptTraitStub;
+use LeagueTests\Stubs\RefreshTokenEntity;
+use LeagueTests\Stubs\ScopeEntity;
+use LeagueTests\Stubs\StubResponseType;
+use PHPUnit\Framework\TestCase;
+use Zend\Diactoros\ServerRequest;
+
+class RevokeTokenHandlerTest extends TestCase
+{
+    /**
+     * @var CryptTraitStub
+     */
+    protected $cryptStub;
+
+    public function setUp()
+    {
+        $this->cryptStub = new CryptTraitStub();
+    }
+
+    public function testRespondToRequestValidAccessTokenWithHint()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $accessToken = new AccessTokenEntity();
+        $accessToken->setIdentifier('test');
+        $accessToken->setUserIdentifier(123);
+        $accessToken->setExpiryDateTime((new \DateTime())->sub(new \DateInterval('PT1H')));
+        $accessToken->setClient($client);
+        $accessTokenJWT = $accessToken->convertToJWT(new CryptKey('file://' . __DIR__ . '/Stubs/private.key'));
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => (string) $accessTokenJWT,
+                'token_type_hint' => 'access_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestValidAccessTokenWithoutHint()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $accessToken = new AccessTokenEntity();
+        $accessToken->setIdentifier('test');
+        $accessToken->setUserIdentifier(123);
+        $accessToken->setExpiryDateTime((new \DateTime())->sub(new \DateInterval('PT1H')));
+        $accessToken->setClient($client);
+        $accessTokenJWT = $accessToken->convertToJWT(new CryptKey('file://' . __DIR__ . '/Stubs/private.key'));
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => (string) $accessTokenJWT
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    /**
+     * @expectedException \League\OAuth2\Server\Exception\OAuthServerException
+     * @expectedExceptionCode 2
+     */
+    public function testRespondToRequestValidAccessTokenButCannotRevokeAccessTokens()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->never())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey, false);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $accessToken = new AccessTokenEntity();
+        $accessToken->setIdentifier('test');
+        $accessToken->setUserIdentifier(123);
+        $accessToken->setExpiryDateTime((new \DateTime())->sub(new \DateInterval('PT1H')));
+        $accessToken->setClient($client);
+        $accessTokenJWT = $accessToken->convertToJWT(new CryptKey('file://' . __DIR__ . '/Stubs/private.key'));
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => (string) $accessTokenJWT,
+                'token_type_hint' => 'access_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestValidRefreshTokenWithHint()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestValidRefreshTokenWithoutHint()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestValidRefreshTokenButCannotRevokeAccessTokens()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->never())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey, false);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestMissingToken()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->never())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestInvalidRefreshToken()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->never())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = 'foobar';
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    /**
+     * @expectedException \League\OAuth2\Server\Exception\OAuthServerException
+     * @expectedExceptionCode 4
+     */
+    public function testRespondToRequestClientMismatch()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->never())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'bar',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestExpiredRefreshToken()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() - 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+
+    public function testRespondToRequestRevokedRefreshToken()
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->expects($this->once())->method('revokeAccessToken');
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken');
+
+        $publicKey = new CryptKey('file://' . __DIR__ . '/Stubs/public.key');
+        $handler = new RevokeTokenHandler($refreshTokenRepositoryMock, $publicKey);
+        $handler->setClientRepository($clientRepositoryMock);
+        $handler->setAccessTokenRepository($accessTokenRepositoryMock);
+        $handler->setEncryptionKey($this->cryptStub->getKey());
+
+        $refreshToken = $this->cryptStub->doEncrypt(
+            json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => 'zyxwvu',
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = new ServerRequest();
+        $serverRequest = $serverRequest->withMethod('POST')->withParsedBody(
+            [
+                'client_id'       => 'foo',
+                'client_secret'   => 'bar',
+                'token'           => $refreshToken,
+                'token_type_hint' => 'refresh_token'
+            ]
+        );
+
+        $responseType = new StubResponseType();
+        $handler->respondToRevokeTokenRequest($serverRequest, $responseType);
+    }
+}


### PR DESCRIPTION
My attempt to implement a fix for #806.

- Moved some of the validation methods from `AbstractGrant` into a `RequestValidatorTrait` trait, so they can be used by non-grant classes. This trait includes some abstract methods, to get the client repository and the grant identifier. Those could be refactored into arguments to `validateClient`, if that's preferable.
- Added `RevokeTokenHandler` class to handle revocation. The constructor requires the refresh token repository and the public key as arguments. Uses existing repository methods for revocation.
- Added `enableRevokeTokenHandler` method to `AuthorizationServer` to be used during setup.
- Added `respondToRevokeTokenRequest` method to `AuthorizationServer`, to be used in a POST request, similar to `respondToAccessTokenRequest`. CORS support is up to the application.
- Example setup (based on [this](https://oauth2.thephpleague.com/authorization-server/refresh-token-grant/)):
```
// Init our repositories
$clientRepository = new ClientRepository();
$accessTokenRepository = new AccessTokenRepository();
$scopeRepository = new ScopeRepository();
$refreshTokenRepository = new RefreshTokenRepository();

// Path to public and private keys
$privateKey = 'file://path/to/private.key';
//$privateKey = new CryptKey('file://path/to/private.key', 'passphrase'); // if private key has a pass phrase
$encryptionKey = 'lxZFUEsBCJ2Yb14IF2ygAHI5N4+ZAUXXaSeeJm6+twsUmIen'; // generate using base64_encode(random_bytes(32))
$publicKey = 'file://path/to/public.key';

// Setup the authorization server
$server = new \League\OAuth2\Server\AuthorizationServer(
    $clientRepository,
    $accessTokenRepository,
    $scopeRepository,
    $privateKey,
    $encryptionKey
);

$handler = new \League\OAuth2\Server\RevokeTokenHandler($refreshTokenRepository, $publicKey);

// Enable the revoke token handler on the server
$server->enableRevokeTokenHandler($handler);
```
- Example implementation:
```
$app->post('/revoke', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {

    /* @var \League\OAuth2\Server\AuthorizationServer $server */
    $server = $app->getContainer()->get(AuthorizationServer::class);

    // Try to respond to the request
    try {
        return $server->respondToRevokeTokenRequest($request, $response);

    } catch (\League\OAuth2\Server\Exception\OAuthServerException $exception) {
        return $exception->generateHttpResponse($response);

    } catch (\Exception $exception) {
        $body = new Stream('php://temp', 'r+');
        $body->write($exception->getMessage());
        return $response->withStatus(500)->withBody($body);
    }
});
```
- You can set `$canRevokeAccessTokens` in the `RevokeTokenHandler` constructor if you want to allow access tokens to be revoked, since the spec describes this as optional.
- If you revoke a refresh token, and the above setting is true, it will also revoke the associated access token.
- If you revoke an access token, it will **not** revoke the associated refresh token, since I don't think this is possible without adding a new repository method.