### PR TITLE
Split convertToJWT method in AccessTokenTrait to separate methods

### DIFF
--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -61,8 +61,6 @@ trait AccessTokenTrait
      * Set data parameters to token builder.
      *
      * @param Builder $builder
-     *
-     * @return void
      */
     protected function setDataToBuilder(Builder $builder)
     {
@@ -73,16 +71,13 @@ trait AccessTokenTrait
             ->setNotBefore(time())
             ->setExpiration($this->getExpiryDateTime()->getTimestamp())
             ->setSubject($this->getUserIdentifier())
-            ->set('scopes', $this->getScopes())
-        ;
+            ->set('scopes', $this->getScopes());
     }
 
     /**
      * Sign data in token builder.
      *
      * @param Builder $builder
-     *
-     * @return void
      */
     protected function signDataInBuider(Builder $builder, CryptKey $privateKey)
     {


### PR DESCRIPTION
Hello. I have some troubles with inheritance for `AccessTokenTrait`. If I want to cahnge `convertToJWT` I need to rewrite whole method. So I split it into separate methods which can be painlessly overwrited by inheritor class. There are no changes in interfaces or pubic methods signatures.