### PR TITLE
Moved creation of AuthorizationRequest into separate function

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -268,7 +268,8 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
         $stateParameter = $this->getQueryStringParameter('state', $request);
 
-        $authorizationRequest = new AuthorizationRequest();
+        $authorizationRequest = $this->createAuthorizationRequest();
+
         $authorizationRequest->setGrantTypeId($this->getIdentifier());
         $authorizationRequest->setClient($client);
         $authorizationRequest->setRedirectUri($redirectUri);
@@ -308,6 +309,14 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         }
 
         return $authorizationRequest;
+    }
+
+    /**
+     * @return AuthorizationRequest
+     */
+    private function createAuthorizationRequest() {
+
+        return new AuthorizationRequest();
     }
 
     /**

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -314,7 +314,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     /**
      * @return AuthorizationRequest
      */
-    private function createAuthorizationRequest()
+    protected function createAuthorizationRequest()
     {
         return new AuthorizationRequest();
     }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -314,8 +314,8 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     /**
      * @return AuthorizationRequest
      */
-    private function createAuthorizationRequest() {
-
+    private function createAuthorizationRequest()
+    {
         return new AuthorizationRequest();
     }
 


### PR DESCRIPTION
#### Background
In our OAUTH server we were required to implement handling of `nonce` parameter which can be given as a part of authorization request.

For this requirement, we had to override some functionality and add a `nonce` as another property of `AuthorizationRequest`. 

It would be easier to override one simple function and return our own instance of `AuthorizationRequest` then overriding a whole `validateAuthorizationRequest` function.