### PR TITLE
spec compliant 'error_description' but keep 'message' for BC

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -59,8 +59,8 @@ class OAuthServerException extends Exception
         $this->hint = $hint;
         $this->redirectUri = $redirectUri;
         $this->payload = [
-            'error'   => $errorType,
-            'message' => $message,
+            'error'             => $errorType,
+            'error_description' => $message,
         ];
         if ($hint !== null) {
             $this->payload['hint'] = $hint;
@@ -74,7 +74,15 @@ class OAuthServerException extends Exception
      */
     public function getPayload()
     {
-        return $this->payload;
+        $payload = $this->payload;
+
+        // The "message" property is deprecated and replaced by "error_description"
+        // TODO: remove "message" property
+        if (isset($payload['error_description']) && !isset($payload['message'])) {
+            $payload['message'] = $payload['error_description'];
+        }
+
+        return $payload;
     }
 
     /**

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -104,7 +104,7 @@ class AuthorizationServerMiddlewareTest extends TestCase
         $response = $exception->generateHttpResponse(new Response());
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('http://foo/bar?error=invalid_scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope',
+        $this->assertEquals('http://foo/bar?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
             $response->getHeader('location')[0]);
     }
 
@@ -114,7 +114,7 @@ class AuthorizationServerMiddlewareTest extends TestCase
         $response = $exception->generateHttpResponse(new Response(), true);
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('http://foo/bar#error=invalid_scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope',
+        $this->assertEquals('http://foo/bar#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
             $response->getHeader('location')[0]);
     }
 }


### PR DESCRIPTION
see #958 

This is only fixing one part of the problem explained in #958.
I think the other problem with missing `state` parameter should be done separately.