### PR TITLE
Fix BasicAuth issues with Password Grant type

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -82,12 +82,14 @@ class PasswordGrant extends AbstractGrant
      */
     protected function validateUser(ServerRequestInterface $request, ClientEntityInterface $client)
     {
-        $username = $this->getRequestParameter('username', $request);
+        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
+        
+        $username = $this->getRequestParameter('username', $request, $basicAuthUser);
         if (is_null($username)) {
             throw OAuthServerException::invalidRequest('username');
         }
 
-        $password = $this->getRequestParameter('password', $request);
+        $password = $this->getRequestParameter('password', $request, $basicAuthPassword);
         if (is_null($password)) {
             throw OAuthServerException::invalidRequest('password');
         }


### PR DESCRIPTION
Currently we should send __username__ & __password__ in POST request parameters, but when we send them via BasicAuth it isn't validate in __respondToAccessTokenRequest__ method in __League\OAuth2\Server\Grant\PasswordGrant__.

__validateClient__ method which run in __respondToAccessTokenRequest__ method in __League\OAuth2\Server\Grant\PasswordGrant__ Class validate it but __validateUser__ don't.

So I add BasicAuth validation in __validateUser__ method same as __validateClient__ in __League\OAuth2\Server\Grant\AbstractGrant__  Class. 