### PR TITLE
Remove JTI Claim From JWT Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - `enableCodeExchangeProof` flag (PR #938)
 - Support for PHP 7.0 (PR #1014)
+- Remove JTI claim from JWT header (PR #)
 
 ## [7.4.0] - released 2019-05-05
 

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -44,7 +44,7 @@ trait AccessTokenTrait
     {
         return (new Builder())
             ->setAudience($this->getClient()->getIdentifier())
-            ->setId($this->getIdentifier(), true)
+            ->setId($this->getIdentifier())
             ->setIssuedAt(time())
             ->setNotBefore(time())
             ->setExpiration($this->getExpiryDateTime()->getTimestamp())


### PR DESCRIPTION
This pull request removes the JTI claim from the JWT header. As far as I can tell, this replication is not necessary so is safe to remove. This was flagged in laravel/passport#363 