### PR TITLE
Prevent public clients from using the client_credentials grant type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Clients are now prevented from using the Client Credentials grant unless they are confidential (PR #1035)
+
 ## [8.0.0] - released 2019-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Clients are now prevented from using the Client Credentials grant unless they are confidential (PR #1035)
+- Clients are now explicitly prevented from using the Client Credentials grant unless they are confidential to conform
+ with the OAuth2 spec (PR #1035)
 
 ## [8.0.0] - released 2019-07-13
 

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -36,6 +36,7 @@ class ClientCredentialsGrant extends AbstractGrant
 
         if (!$client->isConfidential()) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+
             throw OAuthServerException::invalidClient($request);
         }
 

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -12,6 +12,7 @@
 namespace League\OAuth2\Server\Grant;
 
 use DateInterval;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -29,8 +30,18 @@ class ClientCredentialsGrant extends AbstractGrant
         ResponseTypeInterface $responseType,
         DateInterval $accessTokenTTL
     ) {
+        list($clientId) = $this->getClientCredentials($request);
+
+        $client = $this->getClientEntityOrFail($clientId, $request);
+
+        if (!$client->isConfidential()) {
+            $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+            throw OAuthServerException::invalidClient($request);
+        }
+
         // Validate request
-        $client = $this->validateClient($request);
+        $this->validateClient($request);
+
         $scopes = $this->validateScopes($this->getRequestParameter('scope', $request, $this->defaultScope));
 
         // Finalize the requested scopes

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -62,8 +62,11 @@ class AuthorizationServerTest extends TestCase
 
     public function testRespondToRequest()
     {
+        $client = new ClientEntity();
+        $client->setConfidential();
+
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepository->method('getClientEntity')->willReturn(new ClientEntity());
+        $clientRepository->method('getClientEntity')->willReturn($client);
 
         $scope = new ScopeEntity();
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -29,6 +29,7 @@ class ClientCredentialsGrantTest extends TestCase
     public function testRespondToRequest()
     {
         $client = new ClientEntity();
+        $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -30,6 +30,7 @@ class ClientCredentialsGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setConfidential();
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -24,8 +24,11 @@ class AuthorizationServerMiddlewareTest extends TestCase
 
     public function testValidResponse()
     {
+        $client = new ClientEntity();
+        $client->setConfidential();
+
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepository->method('getClientEntity')->willReturn(new ClientEntity());
+        $clientRepository->method('getClientEntity')->willReturn($client);
 
         $scopeEntity = new ScopeEntity;
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();


### PR DESCRIPTION
This PR updates the `ClientCredentialsGrant` to fail if the client is not confidential.

According to the OAuth specification the client credentials grant type should only be used with confidential clients.

> The client MUST authenticate with the authorization server as described in Section 3.2.1.

https://tools.ietf.org/html/rfc6749#section-4.4.2

While it's possible to check this in the `validateClient` method it's possible the user failed to do so. As explained in #1034 the example repository is not checking this and the docs don't tell you to check this either so it's likely other developers have missed this.

By checking it in the `ClientCredentialsGrant` we don't need to require the user to implement the check themselves.

I had to update a few tests that were relying on this behavior.