### PR TITLE
Always validate auth code clients, even when public

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -95,14 +95,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         ResponseTypeInterface $responseType,
         DateInterval $accessTokenTTL
     ) {
-        list($clientId) = $this->getClientCredentials($request);
-
-        $client = $this->getClientEntityOrFail($clientId, $request);
-
-        // Only validate the client if it is confidential
-        if ($client->isConfidential()) {
-            $this->validateClient($request);
-        }
+        $client = $this->validateClient($request);
 
         $encryptedAuthCode = $this->getRequestParameter('code', $request, null);
 


### PR DESCRIPTION
The validateClient method is called for public clients when using the refresh_token and password grant type and the interface allows passing a null secret, so it's not necessary to skip calling the method for the authorization_code grant type.

When I saw that we skipped calling `validateSecret` for public clients in the auth code grant and that the `$mustValidateSecret` parameter was removed for 8.0 I assumed that meant `validateClient` would no longer be called for public clients. I later realized`validateClient` is called for public clients when using the password or refresh token grant.

If `validateClient` is called for public clients for the other grant types you will need to do something like `return !$client->isConfidential() || hash_equals($client->getSecret(), $clientSecret)` anyway, so it doesn't seem necessary to skip calling it here.

Hopefully by removing the unnecessary check it will be less misleading to other developers and increase the likelihood that they handle public clients appropriately in `validateClient`.

The `validateClient` method also calls `validateRedirectUri` which emits a `CLIENT_AUTHENTICATION_FAILED` event if validation fails. The `validateAuthorizationCode` also validates the redirect URI but does not emit an event. Calling `validateClient` regardless will ensure the event is consistently fired for invalid redirect URIs just in case someone is relying on it.