### PR TITLE
Update the client interface docs

### DIFF
--- a/repository-interface-client.md
+++ b/repository-interface-client.md
@@ -8,15 +8,17 @@ permalink: /client-repository-interface/
 
 ## getClientEntity() : ClientEntityInterface
 
-This method is called to validate a client's credentials.
-
-The client secret may or may not be provided depending on the request sent by the client. The boolean `$mustValidateSecret` parameter will indicate whether or not the client secret must be validated. If the client is confidential (i.e. is capable of securely storing a secret) and `$mustValidateSecret === true` then the secret must be validated.
-
-You can use the grant type to determine if the client is permitted to use the grant type.
-
-If the client's credentials are validated you should return an instance of `\League\OAuth2\Server\Entities\Interfaces\ClientEntityInterface`
-
-There are two traits you can use to help you implement some of the `ClientEntityInterface` methods:
+This method should return an implementation of `\League\OAuth2\Server\Entities\ClientEntityInterface`. You can use the following traits to help you implement the required methods from that interface:
 
 * `\League\OAuth2\Server\Entities\Traits\ClientTrait`
 * `\League\OAuth2\Server\Entities\Traits\EntityTrait`
+
+## validateClient() : bool
+
+This method is called to validate a client's credentials.
+
+The client secret may or may not be provided depending on the request sent by the client. If the client is confidential (i.e. is capable of securely storing a secret) then the secret must be validated.
+
+You can use the grant type to determine if the client is permitted to use the grant type.
+
+If the client's credentials are validated you should return `true`, otherwise return `false`.


### PR DESCRIPTION
This PR updates the docs for the client entity interface to correspond to the methods you need to implement as of the 8.0 release.

- Correct the getClientEntity method documentation
- Document the validateClient method