### PR TITLE
change errorType to invalid_grant on invalid refresh_token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ after_script:
 branches:
   only:
     - master
+    - 9.0.0-WIP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added (v9)
 - A CryptKeyInterface to allow developers to change the CryptKey implementation with greater ease (PR #1044)
 
+### Fixed (v9)
+- If a refresh token has expired, been revoked, cannot be decrypted, or does not belong to the correct client, the server will now issue an `invalid_grant` error and a HTTP 400 response. In previous versions the server incorrectly issued an `invalid_request` and HTTP 401 response (PR #993)
+
 ### Fixed
 - Clients are now explicitly prevented from using the Client Credentials grant unless they are confidential to conform
  with the OAuth2 spec (PR #1035)

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -226,7 +226,7 @@ class OAuthServerException extends Exception
      */
     public static function invalidRefreshToken($hint = null, Throwable $previous = null)
     {
-        return new static('The refresh token is invalid.', 8, 'invalid_grant', 401, $hint, null, $previous);
+        return new static('The refresh token is invalid.', 8, 'invalid_grant', 400, $hint, null, $previous);
     }
 
     /**

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -226,7 +226,7 @@ class OAuthServerException extends Exception
      */
     public static function invalidRefreshToken($hint = null, Throwable $previous = null)
     {
-        return new static('The refresh token is invalid.', 8, 'invalid_request', 401, $hint, null, $previous);
+        return new static('The refresh token is invalid.', 8, 'invalid_grant', 401, $hint, null, $previous);
     }
 
     /**


### PR DESCRIPTION
Fix Spec compliance according to [this issue](https://github.com/thephpleague/oauth2-server/issues/993).
Now invalid_grant is returned instead of invalid_request.