### PR TITLE
Abstract CryptKey public methods to the CryptKeyInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added (v9)
+- A CryptKeyInterface to allow developers to change the CryptKey implementation with greater ease (PR #1044)
+
 ### Fixed
 - Clients are now explicitly prevented from using the Client Credentials grant unless they are confidential to conform
  with the OAuth2 spec (PR #1035)

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -40,12 +40,12 @@ class AuthorizationServer implements EmitterAwareInterface
     protected $grantTypeAccessTokenTTL = [];
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     protected $privateKey;
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     protected $publicKey;
 
@@ -82,12 +82,12 @@ class AuthorizationServer implements EmitterAwareInterface
     /**
      * New server instance.
      *
-     * @param ClientRepositoryInterface      $clientRepository
+     * @param ClientRepositoryInterface $clientRepository
      * @param AccessTokenRepositoryInterface $accessTokenRepository
-     * @param ScopeRepositoryInterface       $scopeRepository
-     * @param CryptKey|string                $privateKey
-     * @param string|Key                     $encryptionKey
-     * @param null|ResponseTypeInterface     $responseType
+     * @param ScopeRepositoryInterface $scopeRepository
+     * @param CryptKeyInterface|string $privateKey
+     * @param string|Key $encryptionKey
+     * @param null|ResponseTypeInterface $responseType
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,
@@ -101,7 +101,7 @@ class AuthorizationServer implements EmitterAwareInterface
         $this->accessTokenRepository = $accessTokenRepository;
         $this->scopeRepository = $scopeRepository;
 
-        if ($privateKey instanceof CryptKey === false) {
+        if ($privateKey instanceof CryptKeyInterface === false) {
             $privateKey = new CryptKey($privateKey);
         }
 

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -82,12 +82,12 @@ class AuthorizationServer implements EmitterAwareInterface
     /**
      * New server instance.
      *
-     * @param ClientRepositoryInterface $clientRepository
+     * @param ClientRepositoryInterface      $clientRepository
      * @param AccessTokenRepositoryInterface $accessTokenRepository
-     * @param ScopeRepositoryInterface $scopeRepository
-     * @param CryptKeyInterface|string $privateKey
-     * @param string|Key $encryptionKey
-     * @param null|ResponseTypeInterface $responseType
+     * @param ScopeRepositoryInterface       $scopeRepository
+     * @param CryptKeyInterface|string       $privateKey
+     * @param string|Key                     $encryptionKey
+     * @param null|ResponseTypeInterface     $responseType
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -14,7 +14,7 @@ use InvalidArgumentException;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\ValidationData;
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -31,7 +31,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     private $accessTokenRepository;
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     protected $publicKey;
 
@@ -46,9 +46,9 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     /**
      * Set the public key
      *
-     * @param CryptKey $key
+     * @param CryptKeyInterface $key
      */
-    public function setPublicKey(CryptKey $key)
+    public function setPublicKey(CryptKeyInterface $key)
     {
         $this->publicKey = $key;
     }

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -101,11 +101,17 @@ class CryptKey implements CryptKeyInterface
         return 'file://' . $keyPath;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getKeyPath()
     {
         return $this->keyPath;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getPassPhrase()
     {
         return $this->passPhrase;

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -14,7 +14,7 @@ namespace League\OAuth2\Server;
 use LogicException;
 use RuntimeException;
 
-class CryptKey
+class CryptKey implements CryptKeyInterface
 {
     const RSA_KEY_PATTERN =
         '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----)\R.*(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)\R?$/s';
@@ -101,22 +101,12 @@ class CryptKey
         return 'file://' . $keyPath;
     }
 
-    /**
-     * Retrieve key path.
-     *
-     * @return string
-     */
-    public function getKeyPath()
+    public function getKeyPath(): string
     {
         return $this->keyPath;
     }
 
-    /**
-     * Retrieve key pass phrase.
-     *
-     * @return null|string
-     */
-    public function getPassPhrase()
+    public function getPassPhrase(): ?string
     {
         return $this->passPhrase;
     }

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -101,12 +101,12 @@ class CryptKey implements CryptKeyInterface
         return 'file://' . $keyPath;
     }
 
-    public function getKeyPath(): string
+    public function getKeyPath()
     {
         return $this->keyPath;
     }
 
-    public function getPassPhrase(): ?string
+    public function getPassPhrase()
     {
         return $this->passPhrase;
     }

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -102,7 +102,7 @@ class CryptKey implements CryptKeyInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getKeyPath()
     {
@@ -110,7 +110,7 @@ class CryptKey implements CryptKeyInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getPassPhrase()
     {

--- a/src/CryptKeyInterface.php
+++ b/src/CryptKeyInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace League\OAuth2\Server;
+
+interface CryptKeyInterface
+{
+    /**
+     * Retrieve key path.
+     *
+     * @return string
+     */
+    public function getKeyPath(): string;
+
+    /**
+     * Retrieve key pass phrase.
+     *
+     * @return null|string
+     */
+    public function getPassPhrase(): ?string;
+}

--- a/src/CryptKeyInterface.php
+++ b/src/CryptKeyInterface.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types=1);
 
 namespace League\OAuth2\Server;
 
@@ -10,12 +9,12 @@ interface CryptKeyInterface
      *
      * @return string
      */
-    public function getKeyPath(): string;
+    public function getKeyPath();
 
     /**
      * Retrieve key pass phrase.
      *
      * @return null|string
      */
-    public function getPassPhrase(): ?string;
+    public function getPassPhrase();
 }

--- a/src/Entities/AccessTokenEntityInterface.php
+++ b/src/Entities/AccessTokenEntityInterface.php
@@ -9,14 +9,14 @@
 
 namespace League\OAuth2\Server\Entities;
 
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 
 interface AccessTokenEntityInterface extends TokenInterface
 {
     /**
      * Set a private key used to encrypt the access token.
      */
-    public function setPrivateKey(CryptKey $privateKey);
+    public function setPrivateKey(CryptKeyInterface $privateKey);
 
     /**
      * Generate a string representation of the access token.

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -14,21 +14,21 @@ use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token;
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 
 trait AccessTokenTrait
 {
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     private $privateKey;
 
     /**
      * Set the private key used to encrypt this access token.
      */
-    public function setPrivateKey(CryptKey $privateKey)
+    public function setPrivateKey(CryptKeyInterface $privateKey)
     {
         $this->privateKey = $privateKey;
     }
@@ -36,11 +36,11 @@ trait AccessTokenTrait
     /**
      * Generate a JWT from the access token
      *
-     * @param CryptKey $privateKey
+     * @param CryptKeyInterface $privateKey
      *
      * @return Token
      */
-    private function convertToJWT(CryptKey $privateKey)
+    private function convertToJWT(CryptKeyInterface $privateKey)
     {
         return (new Builder())
             ->setAudience($this->getClient()->getIdentifier())

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -15,7 +15,7 @@ use DateTimeImmutable;
 use Error;
 use Exception;
 use League\Event\EmitterAwareTrait;
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
@@ -83,7 +83,7 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected $refreshTokenTTL;
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     protected $privateKey;
 
@@ -151,9 +151,9 @@ abstract class AbstractGrant implements GrantTypeInterface
     /**
      * Set the private key
      *
-     * @param CryptKey $key
+     * @param CryptKeyInterface $key
      */
-    public function setPrivateKey(CryptKey $key)
+    public function setPrivateKey(CryptKeyInterface $key)
     {
         $this->privateKey = $key;
     }

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -14,7 +14,7 @@ namespace League\OAuth2\Server\Grant;
 use DateInterval;
 use Defuse\Crypto\Key;
 use League\Event\EmitterAwareInterface;
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
@@ -131,9 +131,9 @@ interface GrantTypeInterface extends EmitterAwareInterface
     /**
      * Set the path to the private key.
      *
-     * @param CryptKey $privateKey
+     * @param CryptKeyInterface $privateKey
      */
-    public function setPrivateKey(CryptKey $privateKey);
+    public function setPrivateKey(CryptKeyInterface $privateKey);
 
     /**
      * Set the encryption key

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -23,7 +23,7 @@ class ResourceServer
     private $accessTokenRepository;
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     private $publicKey;
 
@@ -36,7 +36,7 @@ class ResourceServer
      * New server instance.
      *
      * @param AccessTokenRepositoryInterface       $accessTokenRepository
-     * @param CryptKey|string                      $publicKey
+     * @param CryptKeyInterface|string             $publicKey
      * @param null|AuthorizationValidatorInterface $authorizationValidator
      */
     public function __construct(
@@ -46,7 +46,7 @@ class ResourceServer
     ) {
         $this->accessTokenRepository = $accessTokenRepository;
 
-        if ($publicKey instanceof CryptKey === false) {
+        if ($publicKey instanceof CryptKeyInterface === false) {
             $publicKey = new CryptKey($publicKey);
         }
         $this->publicKey = $publicKey;

--- a/src/ResponseTypes/AbstractResponseType.php
+++ b/src/ResponseTypes/AbstractResponseType.php
@@ -11,7 +11,7 @@
 
 namespace League\OAuth2\Server\ResponseTypes;
 
-use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
@@ -31,7 +31,7 @@ abstract class AbstractResponseType implements ResponseTypeInterface
     protected $refreshToken;
 
     /**
-     * @var CryptKey
+     * @var CryptKeyInterface
      */
     protected $privateKey;
 
@@ -54,9 +54,9 @@ abstract class AbstractResponseType implements ResponseTypeInterface
     /**
      * Set the private key
      *
-     * @param CryptKey $key
+     * @param CryptKeyInterface $key
      */
-    public function setPrivateKey(CryptKey $key)
+    public function setPrivateKey(CryptKeyInterface $key)
     {
         $this->privateKey = $key;
     }

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -4,6 +4,7 @@ namespace LeagueTests;
 
 use DateInterval;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -152,7 +153,7 @@ class AuthorizationServerTest extends TestCase
         $encryptionKey = 'file://' . __DIR__ . '/Stubs/public.key';
 
         $responseTypePrototype = new class extends BearerTokenResponse {
-            /* @return null|\League\OAuth2\Server\CryptKeyInterface */
+            /* @return null|CryptKeyInterface */
             public function getPrivateKey()
             {
                 return $this->privateKey;

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -4,7 +4,6 @@ namespace LeagueTests;
 
 use DateInterval;
 use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
@@ -153,7 +152,7 @@ class AuthorizationServerTest extends TestCase
         $encryptionKey = 'file://' . __DIR__ . '/Stubs/public.key';
 
         $responseTypePrototype = new class extends BearerTokenResponse {
-            /* @return null|CryptKey */
+            /* @return null|\League\OAuth2\Server\CryptKeyInterface */
             public function getPrivateKey()
             {
                 return $this->privateKey;


### PR DESCRIPTION
The library provides flexible storage for all possible types of entities but strictly adheres to the use of the RSA key written to the file for signing JWT tokens. Using RSA, the size of the signature is almost 3 times larger than the key itself, so I would prefer to use a different key and signature algorithm. But the current implementation of CryptKey sets a strict requirement for RSA.

Of course, I can extend from CryptKey and override the constructor, but this is a way of avoiding the problem rather than solving it.

This solution is BC, so I expect it to be available only in the 9.0.0 release. Anyway, I think we need a lot more abstraction on the keys (see https://github.com/thephpleague/oauth2-server/issues/1007).