### PR TITLE
Throw exception for preg_match() errors in CryptKey [Fixes #1046]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [8.0.0] - released 2019-07-13
 
 ### Added
 - Flag, `requireCodeChallengeForPublicClients`, used to reject public clients that do not provide a code challenge for the Auth Code Grant; use AuthCodeGrant::disableRequireCodeCallengeForPublicClients() to turn off this requirement (PR #938)
@@ -466,7 +466,8 @@ Version 5 is a complete code rewrite.
 
 - First major release
 
-[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/7.4.0...HEAD
+[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.0.0...HEAD
+[8.0.0]: https://github.com/thephpleague/oauth2-server/compare/7.4.0...8.0.0
 [7.4.0]: https://github.com/thephpleague/oauth2-server/compare/7.3.3...7.4.0
 [7.3.3]: https://github.com/thephpleague/oauth2-server/compare/7.3.2...7.3.3
 [7.3.2]: https://github.com/thephpleague/oauth2-server/compare/7.3.1...7.3.2

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -36,7 +36,7 @@ class CryptKey
      */
     public function __construct($keyPath, $passPhrase = null, $keyPermissionsCheck = true)
     {
-        if ($rsaMatch = preg_match(self::RSA_KEY_PATTERN, $keyPath)) {
+        if ($rsaMatch = preg_match(static::RSA_KEY_PATTERN, $keyPath)) {
             $keyPath = $this->saveKeyToFile($keyPath);
         } elseif ($rsaMatch === false) {
             throw new \RuntimeException(

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -36,8 +36,12 @@ class CryptKey
      */
     public function __construct($keyPath, $passPhrase = null, $keyPermissionsCheck = true)
     {
-        if (preg_match(self::RSA_KEY_PATTERN, $keyPath)) {
+        if ($rsaMatch = preg_match(self::RSA_KEY_PATTERN, $keyPath)) {
             $keyPath = $this->saveKeyToFile($keyPath);
+        } elseif ($rsaMatch === false) {
+            throw new \RuntimeException(
+                sprintf("PCRE error [%d] encountered during key match attempt", preg_last_error())
+            );
         }
 
         if (strpos($keyPath, 'file://') !== 0) {

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -51,4 +51,20 @@ class CryptKeyTest extends TestCase
             $key->getKeyPath()
         );
     }
+
+    /**
+     * Test whether we get a RuntimeException if a PCRE error is encountered.
+     * 
+     * @link https://www.php.net/manual/en/function.preg-last-error.php
+     */
+    public function testPcreErrorExceptions()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/^PCRE error/');
+
+        new class('foobar foobar foobar') extends CryptKey 
+        {
+            const RSA_KEY_PATTERN = '/(?:\D+|<\d+>)*[!?]/';
+        };
+    }
 }

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -54,7 +54,7 @@ class CryptKeyTest extends TestCase
 
     /**
      * Test whether we get a RuntimeException if a PCRE error is encountered.
-     * 
+     *
      * @link https://www.php.net/manual/en/function.preg-last-error.php
      */
     public function testPcreErrorExceptions()
@@ -62,8 +62,7 @@ class CryptKeyTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessageRegExp('/^PCRE error/');
 
-        new class('foobar foobar foobar') extends CryptKey 
-        {
+        new class('foobar foobar foobar') extends CryptKey {
             const RSA_KEY_PATTERN = '/(?:\D+|<\d+>)*[!?]/';
         };
     }


### PR DESCRIPTION
- Throw RuntimeException if an error occurs during preg_match() in
  League\OAuth2\Server\CryptKey::__construct().