### PR TITLE
Add getter for OAuthServerException::redirectUri property

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -294,14 +294,9 @@ class OAuthServerException extends Exception
 
         $payload = $this->getPayload();
 
-        if ($this->redirectUri !== null) {
-            if ($useFragment === true) {
-                $this->redirectUri .= (strstr($this->redirectUri, '#') === false) ? '#' : '&';
-            } else {
-                $this->redirectUri .= (strstr($this->redirectUri, '?') === false) ? '?' : '&';
-            }
-
-            return $response->withStatus(302)->withHeader('Location', $this->redirectUri . http_build_query($payload));
+        $redirectUri = $this->getRedirectUri($useFragment);
+        if ($redirectUri !== null) {
+            return $response->withStatus(302)->withHeader('Location', $redirectUri);
         }
 
         foreach ($headers as $header => $content) {
@@ -357,6 +352,31 @@ class OAuthServerException extends Exception
     public function hasRedirect()
     {
         return $this->redirectUri !== null;
+    }
+
+    /**
+     * Returns the redirectUri with all necessary args.
+     *
+     * Null will be returned if the exception doesn't contain the redirectUri.
+     *
+     * @param bool $useFragment True if errors should be in the URI fragment instead of query string
+     *
+     * @return string|null
+     */
+    public function getRedirectUri(bool $useFragment = false): ?string
+    {
+        if ($this->redirectUri === null) {
+            return null;
+        }
+
+        $redirectUri = $this->redirectUri;
+        if ($useFragment) {
+            $redirectUri .= strpos($this->redirectUri, '#') === false ? '#' : '&';
+        } else {
+            $redirectUri .= strpos($this->redirectUri, '?') === false ? '?' : '&';
+        }
+
+        return $redirectUri . http_build_query($this->getPayload());
     }
 
     /**

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -71,6 +71,14 @@ class OAuthServerExceptionTest extends TestCase
         $exceptionWithRedirect = OAuthServerException::accessDenied('some hint', 'https://example.com/error');
 
         $this->assertTrue($exceptionWithRedirect->hasRedirect());
+        $this->assertSame(
+            'https://example.com/error?error=access_denied&error_description=The+resource+owner+or+authorization+server+denied+the+request.&hint=some+hint&message=The+resource+owner+or+authorization+server+denied+the+request.',
+            $exceptionWithRedirect->getRedirectUri()
+        );
+        $this->assertSame(
+            'https://example.com/error#error=access_denied&error_description=The+resource+owner+or+authorization+server+denied+the+request.&hint=some+hint&message=The+resource+owner+or+authorization+server+denied+the+request.',
+            $exceptionWithRedirect->getRedirectUri(true)
+        );
     }
 
     public function testDoesNotHaveRedirect()
@@ -78,6 +86,7 @@ class OAuthServerExceptionTest extends TestCase
         $exceptionWithoutRedirect = OAuthServerException::accessDenied('Some hint');
 
         $this->assertFalse($exceptionWithoutRedirect->hasRedirect());
+        $this->assertNull($exceptionWithoutRedirect->getRedirectUri());
     }
 
     public function testHasPrevious()


### PR DESCRIPTION
In the current implementation, the only way to get the final `redirectUri` is to call the `generateHttpResponse` method and then read the `Location` header from the formed response. It is enough for a classic website, but it is inconvenient for SPA, which converts errors into an intermediate format and transfers it to the frontend.

This change abstracts logic of generation of the `redirectUri` into its own public getter.