### PR TITLE
Cast client ids to strings before comparing them

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -199,7 +199,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             throw OAuthServerException::invalidRequest('code', 'Authorization code has been revoked');
         }
 
-        if ($authCodePayload->client_id !== $client->getIdentifier()) {
+        if ((string) $authCodePayload->client_id !== (string) $client->getIdentifier()) {
             throw OAuthServerException::invalidRequest('code', 'Authorization code was not issued to this client');
         }
 


### PR DESCRIPTION
Currently a request variable is compared with a stored string.
With strict comparison, this leads to issues when the provided client ID is e.g. an integer (by type).
This is a completely backwards-compatible change that relieves users from having to explicitly quote numerical client IDs.
