### PR TITLE
Fix Client Credentials Example

### DIFF
--- a/examples/src/Entities/ClientEntity.php
+++ b/examples/src/Entities/ClientEntity.php
@@ -26,4 +26,9 @@ class ClientEntity implements ClientEntityInterface
     {
         $this->redirectUri = $uri;
     }
+
+    public function setConfidential()
+    {
+        $this->isConfidential = true;
+    }
 }

--- a/examples/src/Repositories/ClientRepository.php
+++ b/examples/src/Repositories/ClientRepository.php
@@ -27,6 +27,7 @@ class ClientRepository implements ClientRepositoryInterface
         $client->setIdentifier($clientIdentifier);
         $client->setName(self::CLIENT_NAME);
         $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
 
         return $client;
     }


### PR DESCRIPTION
The client credentials grant was not working in the examples because the client was never set to confidential. This PR fixes that issue.