### PR TITLE
Add oauth server

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "slim/slim": "^3.0.0"
+        "slim/slim": "^3.0.0",
+        "league/oauth2-server": "^8.0"
     },
     "require-dev": {
         "league/event": "^2.2",


### PR DESCRIPTION
Fixes:

```
127.0.0.1:49826 [500]: /client_credentials.php/access_token - Interface 'League\OAuth2\Server\Repositories\ClientRepositoryInterface' not found in /var/www/html/thirdparty-integration-example/src/Repositories/ClientRepository.php on line 15
```

when running the first example curl request.