### PR TITLE
set properly access_token as a string

### DIFF
--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -28,7 +28,7 @@ class BearerTokenResponse extends AbstractResponseType
         $responseParams = [
             'token_type'   => 'Bearer',
             'expires_in'   => $expireDateTime - \time(),
-            'access_token' => (string) $this->accessToken,
+            'access_token' => $this->accessToken->getIdentifier(),
         ];
 
         if ($this->refreshToken instanceof RefreshTokenEntityInterface) {


### PR DESCRIPTION
When try to conver $access_token to string we receive a throw and fails. We already have token as a string, just use it.