### PR TITLE
Wrong passwords are throwing "invalid_grant" error

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -104,7 +104,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidCredentials();
         }
 
         return $user;


### PR DESCRIPTION
I noticed that my wrong passwords are now throwing an "invalid_grant" error. I noticed that at some point that at some point `throw OAuthServerException::invalidCredentials();` was changed to `throw OAuthServerException::invalidGrant()`.

I'm attempting to change it back, because I don't think an "invalid_grant" error is correct when the credentials are incorrect.