### PR TITLE
Fix invalid annotation in AbstractGrant

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -88,7 +88,7 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected $privateKey;
 
     /**
-     * @string
+     * @var string
      */
     protected $defaultScope;
 


### PR DESCRIPTION
This was causing JMSTranslationBundle to not extract translations:

```[Semantical Error] The annotation "@string" in property League\OAuth2\Server\Grant\AbstractGrant::$defaultScope was never imported. Did you maybe forget to add a "use" statement for this annotation?```