### PR TITLE
Call get identifier on scope entities when building payload for auth …

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -356,7 +356,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 'code_challenge'        => $authorizationRequest->getCodeChallenge(),
                 'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
             ];
-            
+
             foreach ($authCode->getScopes() as $scope) {
                 $payload['scopes'][] = $scope->getIdentifier();
             }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -350,12 +350,16 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 'client_id'             => $authCode->getClient()->getIdentifier(),
                 'redirect_uri'          => $authCode->getRedirectUri(),
                 'auth_code_id'          => $authCode->getIdentifier(),
-                'scopes'                => $authCode->getScopes(),
+                'scopes'                => [],
                 'user_id'               => $authCode->getUserIdentifier(),
                 'expire_time'           => (new DateTimeImmutable())->add($this->authCodeTTL)->getTimestamp(),
                 'code_challenge'        => $authorizationRequest->getCodeChallenge(),
                 'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
             ];
+            
+            foreach ($authCode->getScopes() as $scope) {
+                $payload['scopes'][] = $scope->getIdentifier();
+            }
 
             $jsonPayload = \json_encode($payload);
 


### PR DESCRIPTION
Proposed fix for issue #1076  where scopes are encoded in auth code incorrectly.