### PR TITLE
Fix client validation in ClientCredentials-Grant example

### DIFF
--- a/examples/src/Repositories/ClientRepository.php
+++ b/examples/src/Repositories/ClientRepository.php
@@ -48,14 +48,16 @@ class ClientRepository implements ClientRepositoryInterface
 
         // Check if client is registered
         if (\array_key_exists($clientIdentifier, $clients) === false) {
-            return;
+            return false;
         }
 
         if (
             $clients[$clientIdentifier]['is_confidential'] === true
             && \password_verify($clientSecret, $clients[$clientIdentifier]['secret']) === false
         ) {
-            return;
+            return false;
         }
+        
+        return true;
     }
 }


### PR DESCRIPTION
The provided example for the ClientCredentials-Grant authorizes any client, even with non-existent credentials. This is caused by the fact that the function `validateClient` in the provided `ClientRepository.php` within the examples returns always `NULL`.

For a proper client validation the function `validateClient` must return `true` if the validation has succeeded or `false` if it has failed. This fix adds correct return values to the function.