### PR TITLE
RefreshTokenGrant calls finalizeScopes method

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -59,6 +59,8 @@ class RefreshTokenGrant extends AbstractGrant
             }
         }
 
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);
+
         // Expire old tokens
         $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
         $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);


### PR DESCRIPTION
Hi,

I have an issue when using the refresh token grant when the authenticated resource owner access rights change. Scopes granted to the API client are correlated to these access rights : I don't want to grant a scope to the API Client if some conditions are not fulfilled by the resource owner profile.

In order to control if requested scopes are still valid upon application logic, the method `ScopeRepositoryInterface::finalizeScopes()` should be call before issuing a new access token.

Moreover, this method is called in all other Grant types.