### PR TITLE
Access tokens cannot be requested without a redirect_uri which according to spec they should

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -281,7 +281,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         $authorizationRequest = new AuthorizationRequest();
         $authorizationRequest->setGrantTypeId($this->getIdentifier());
         $authorizationRequest->setClient($client);
-        $authorizationRequest->setRedirectUri($redirectUri);
+        $authorizationRequest->setRedirectUri($this->getQueryStringParameter('redirect_uri', $request));
 
         if ($stateParameter !== null) {
             $authorizationRequest->setState($stateParameter);


### PR DESCRIPTION
According to  [rfc6749 section-4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3) the redirect_uri of a access_token request can be optional.
```text
redirect_uri
         REQUIRED, if the "redirect_uri" parameter was included in the
         authorization request as described in Section 4.1.1, and their
         values MUST be identical.
```

Currently this behavior is not possible with this library.
As soon as you create a `AuthorizationRequest` by calling `validateAuthorizationRequest` on the `AuthCodeGrant` it always contains a request_uri, even when the original request did not.

This is a problem because on a consecutive request to get an access_code the encrypted payload contains a redirect_uri making it required for that request.

All other code like `AuthCodeGrant#completeAuthorizationRequest` are able to handle AuthorizationRequests without a request_uri.

This is broken since version 7.0.0 before it did work.