### PR TITLE
Add a hint when the user authentication fails. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - When storing a key, we no longer touch the file before writing it as this is an unnecessary step (PR #1064)
 - Prefix native PHP functions in namespaces with backslashes for micro-optimisations (PR #1071)
 
+### Changed (v9)
+- Added an exception hint when user credential check fails for the Password Grant (PR #XX)
+
 ### Removed
 - Support for PHP 7.1 (PR #1075)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Prefix native PHP functions in namespaces with backslashes for micro-optimisations (PR #1071)
 
 ### Changed (v9)
-- Added an exception hint when user credential check fails for the Password Grant (PR #XX)
+- Added an exception hint when user credential check fails for the Password Grant (PR #1098)
 
 ### Removed
 - Support for PHP 7.1 (PR #1075)

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -104,7 +104,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidGrant('Check the user credentials provided');
         }
 
         return $user;


### PR DESCRIPTION
This PR adds a helper hint to the exception thrown when a user's credentials are invalid. Fixes issue #1097 