### PR TITLE
Bugfix: Adding validation to check if the request client

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * OAuth 2.0 Refresh token grant
+ * OAuth 2.0 Refresh token grant.
  *
  * @package     league/oauth2-server
  * @author      Alex Bilbie <hello@alexbilbie.com>
@@ -20,7 +20,7 @@ use League\OAuth2\Server\Exception;
 use League\OAuth2\Server\Util\SecureKey;
 
 /**
- * Refresh token grant
+ * Refresh token grant.
  */
 class RefreshTokenGrant extends AbstractGrant
 {
@@ -30,16 +30,16 @@ class RefreshTokenGrant extends AbstractGrant
     protected $identifier = 'refresh_token';
 
     /**
-     * Refresh token TTL (default = 604800 | 1 week)
+     * Refresh token TTL (default = 604800 | 1 week).
      *
-     * @var integer
+     * @var int
      */
     protected $refreshTokenTTL = 604800;
 
     /**
-     * Rotate token (default = true)
+     * Rotate token (default = true).
      *
-     * @var integer
+     * @var int
      */
     protected $refreshTokenRotate = true;
 
@@ -47,12 +47,12 @@ class RefreshTokenGrant extends AbstractGrant
      * Whether to require the client secret when
      * completing the flow.
      *
-     * @var boolean
+     * @var bool
      */
     protected $requireClientSecret = true;
 
     /**
-     * Set the TTL of the refresh token
+     * Set the TTL of the refresh token.
      *
      * @param int $refreshTokenTTL
      *
@@ -74,7 +74,8 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Set the rotation boolean of the refresh token
+     * Set the rotation boolean of the refresh token.
+     *
      * @param bool $refreshTokenRotate
      */
     public function setRefreshTokenRotation($refreshTokenRotate = true)
@@ -83,7 +84,7 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Get rotation boolean of the refresh token
+     * Get rotation boolean of the refresh token.
      *
      * @return bool
      */
@@ -93,7 +94,6 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     *
      * @param bool $required True to require client secret during access
      *                       token request. False if not. Default = true
      */
@@ -124,8 +124,10 @@ class RefreshTokenGrant extends AbstractGrant
             throw new Exception\InvalidRequestException('client_id');
         }
 
-        $clientSecret = $this->server->getRequest()->request->get('client_secret',
-            $this->server->getRequest()->getPassword());
+        $clientSecret = $this->server->getRequest()->request->get(
+            'client_secret',
+            $this->server->getRequest()->getPassword()
+        );
         if ($this->shouldRequireClientSecret() && is_null($clientSecret)) {
             throw new Exception\InvalidRequestException('client_secret');
         }
@@ -228,7 +230,7 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Checks if the client used on the request is the same that owns this session
+     * Checks if the client used on the request is the same that owns this session.
      *
      * @param ClientEntity  $client
      * @param SessionEntity $session

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -5,6 +5,7 @@
  * @author      Alex Bilbie <hello@alexbilbie.com>
  * @copyright   Copyright (c) Alex Bilbie
  * @license     http://mit-license.org/
+ *
  * @link        https://github.com/thephpleague/oauth2-server
  */
 
@@ -112,7 +113,6 @@ class RefreshTokenGrant extends AbstractGrant
         return $this->requireClientSecret;
     }
 
-
     /**
      * {@inheritdoc}
      */
@@ -141,6 +141,7 @@ class RefreshTokenGrant extends AbstractGrant
 
         if (($client instanceof ClientEntity) === false) {
             $this->server->getEventEmitter()->emit(new Event\ClientAuthenticationFailedEvent($this->server->getRequest()));
+
             throw new Exception\InvalidClientException();
         }
 

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -2,7 +2,6 @@
 /**
  * OAuth 2.0 Refresh token grant.
  *
- * @package     league/oauth2-server
  * @author      Alex Bilbie <hello@alexbilbie.com>
  * @copyright   Copyright (c) Alex Bilbie
  * @license     http://mit-license.org/
@@ -64,7 +63,7 @@ class RefreshTokenGrant extends AbstractGrant
     }
 
     /**
-     * Get the TTL of the refresh token
+     * Get the TTL of the refresh token.
      *
      * @return int
      */

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -14,6 +14,7 @@ namespace League\OAuth2\Server\Grant;
 use League\OAuth2\Server\Entity\AccessTokenEntity;
 use League\OAuth2\Server\Entity\ClientEntity;
 use League\OAuth2\Server\Entity\RefreshTokenEntity;
+use League\OAuth2\Server\Entity\SessionEntity;
 use League\OAuth2\Server\Event;
 use League\OAuth2\Server\Exception;
 use League\OAuth2\Server\Util\SecureKey;
@@ -163,6 +164,11 @@ class RefreshTokenGrant extends AbstractGrant
 
         // Get the scopes for the original session
         $session = $oldAccessToken->getSession();
+
+        if (!$this->isClientValid($client, $session)) {
+            throw new Exception\InvalidClientException();
+        }
+
         $scopes = $this->formatScopes($session->getScopes());
 
         // Get and validate any requested scopes
@@ -219,5 +225,18 @@ class RefreshTokenGrant extends AbstractGrant
         }
 
         return $this->server->getTokenType()->generateResponse();
+    }
+
+    /**
+     * Checks if the client used on the request is the same that owns this session
+     *
+     * @param ClientEntity  $client
+     * @param SessionEntity $session
+     *
+     * @return bool
+     */
+    private function isClientValid(ClientEntity $client, SessionEntity $session)
+    {
+        return $client->getId() === $session->getClient()->getId();
     }
 }


### PR DESCRIPTION
Adds a validation to check that the client obtained from the request params is the same that owns the session. 

The way it is, any valid API client that obtains access to a refresh token can grant itself access to the API and impersonate the API client for which that API session was created. Adding this validation prevents this behavior, as the refresh token grant will check that the client params sent on the request are the ones for the client that owns the session.