### PR TITLE
Introduce AuthorizationRequestInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added (v9)
 - A CryptKeyInterface to allow developers to change the CryptKey implementation with greater ease (PR #1044)
 - The authorization server can now finalize scopes when a client uses a refresh token (PR #1094)
+- An AuthorizationRequestInterface to make it easier to extend the AuthorizationRequest (PR #1110)
 
 ### Added
 - Added support for PHP 7.4 (PR #1075)

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -18,7 +18,7 @@ use League\OAuth2\Server\Grant\GrantTypeInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
-use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\AbstractResponseType;
 use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
@@ -148,7 +148,7 @@ class AuthorizationServer implements EmitterAwareInterface
      *
      * @throws OAuthServerException
      *
-     * @return AuthorizationRequest
+     * @return AuthorizationRequestInterface
      */
     public function validateAuthorizationRequest(ServerRequestInterface $request)
     {
@@ -164,13 +164,15 @@ class AuthorizationServer implements EmitterAwareInterface
     /**
      * Complete an authorization request
      *
-     * @param AuthorizationRequest $authRequest
-     * @param ResponseInterface    $response
+     * @param AuthorizationRequestInterface $authRequest
+     * @param ResponseInterface             $response
      *
      * @return ResponseInterface
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authRequest, ResponseInterface $response)
-    {
+    public function completeAuthorizationRequest(
+        AuthorizationRequestInterface $authRequest,
+        ResponseInterface $response
+    ) {
         return $this->enabledGrantTypes[$authRequest->getGrantTypeId()]
             ->completeAuthorizationRequest($authRequest)
             ->generateHttpResponse($response);

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -31,7 +31,7 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\RequestEvent;
-use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use LogicException;
 use Psr\Http\Message\ServerRequestInterface;
 use TypeError;
@@ -592,7 +592,7 @@ abstract class AbstractGrant implements GrantTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    public function completeAuthorizationRequest(AuthorizationRequestInterface $authorizationRequest)
     {
         throw new LogicException('This grant cannot complete an authorization request');
     }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -22,6 +22,7 @@ use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use LogicException;
@@ -327,7 +328,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     /**
      * {@inheritdoc}
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    public function completeAuthorizationRequest(AuthorizationRequestInterface $authorizationRequest)
     {
         if ($authorizationRequest->getUser() instanceof UserEntityInterface === false) {
             throw new LogicException('An instance of UserEntityInterface should be set on the AuthorizationRequest');
@@ -392,11 +393,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     /**
      * Get the client redirect URI if not set in the request.
      *
-     * @param AuthorizationRequest $authorizationRequest
+     * @param AuthorizationRequestInterface $authorizationRequest
      *
      * @return string
      */
-    private function getClientRedirectUri(AuthorizationRequest $authorizationRequest)
+    private function getClientRedirectUri(AuthorizationRequestInterface $authorizationRequest)
     {
         return \is_array($authorizationRequest->getClient()->getRedirectUri())
                 ? $authorizationRequest->getClient()->getRedirectUri()[0]

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -18,7 +18,7 @@ use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
-use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -74,7 +74,7 @@ interface GrantTypeInterface extends EmitterAwareInterface
      *
      * @param ServerRequestInterface $request
      *
-     * @return AuthorizationRequest
+     * @return AuthorizationRequestInterface
      */
     public function validateAuthorizationRequest(ServerRequestInterface $request);
 
@@ -83,11 +83,11 @@ interface GrantTypeInterface extends EmitterAwareInterface
      * The AuthorizationRequest object's $userId property must be set to the authenticated user and the
      * $authorizationApproved property must reflect their desire to authorize or deny the client.
      *
-     * @param AuthorizationRequest $authorizationRequest
+     * @param AuthorizationRequestInterface $authorizationRequest
      *
      * @return ResponseTypeInterface
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest);
+    public function completeAuthorizationRequest(AuthorizationRequestInterface $authorizationRequest);
 
     /**
      * The grant type should return true if it is able to respond to this request.

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -15,6 +15,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use LogicException;
@@ -164,7 +165,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
     /**
      * {@inheritdoc}
      */
-    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    public function completeAuthorizationRequest(AuthorizationRequestInterface $authorizationRequest)
     {
         if ($authorizationRequest->getUser() instanceof UserEntityInterface === false) {
             throw new LogicException('An instance of UserEntityInterface should be set on the AuthorizationRequest');

--- a/src/RequestTypes/AuthorizationRequest.php
+++ b/src/RequestTypes/AuthorizationRequest.php
@@ -13,7 +13,7 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 
-class AuthorizationRequest
+class AuthorizationRequest implements AuthorizationRequestInterface
 {
     /**
      * The grant type identifier

--- a/src/RequestTypes/AuthorizationRequestInterface.php
+++ b/src/RequestTypes/AuthorizationRequestInterface.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * @author      Patrick Rodacker <dev@rodacker.de>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server\RequestTypes;
+
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+
+interface AuthorizationRequestInterface
+{
+    /**
+     * @return UserEntityInterface|null
+     */
+    public function getUser();
+
+    /**
+     * @param string $state
+     */
+    public function setState($state);
+
+    /**
+     * @return ClientEntityInterface
+     */
+    public function getClient();
+
+    /**
+     * @param bool $authorizationApproved
+     */
+    public function setAuthorizationApproved($authorizationApproved);
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     */
+    public function setScopes(array $scopes);
+
+    /**
+     * @param string|null $redirectUri
+     */
+    public function setRedirectUri($redirectUri);
+
+    /**
+     * @return string|null
+     */
+    public function getRedirectUri();
+
+    /**
+     * @return string
+     */
+    public function getCodeChallengeMethod();
+
+    /**
+     * @param string $grantTypeId
+     */
+    public function setGrantTypeId($grantTypeId);
+
+    /**
+     * @param UserEntityInterface $user
+     */
+    public function setUser(UserEntityInterface $user);
+
+    /**
+     * @param ClientEntityInterface $client
+     */
+    public function setClient(ClientEntityInterface $client);
+
+    /**
+     * @param string $codeChallenge
+     */
+    public function setCodeChallenge($codeChallenge);
+
+    /**
+     * @return bool
+     */
+    public function isAuthorizationApproved();
+
+    /**
+     * @return string|null
+     */
+    public function getState();
+
+    /**
+     * @return string
+     */
+    public function getCodeChallenge();
+
+    /**
+     * @param string $codeChallengeMethod
+     */
+    public function setCodeChallengeMethod($codeChallengeMethod);
+
+    /**
+     * @return ScopeEntityInterface[]
+     */
+    public function getScopes();
+
+    /**
+     * @return string
+     */
+    public function getGrantTypeId();
+}

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -2018,6 +2018,7 @@ class AuthCodeGrantTest extends TestCase
             'response_type' => 'code',
             'client_id'     => 'foo',
             'redirect_uri'  => 'http://foo/bar',
+            'state'         => 'foo',
         ]);
 
         $this->expectException(OAuthServerException::class);

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -475,6 +475,29 @@ class AuthCodeGrantTest extends TestCase
         $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
     }
 
+    public function testCompleteAuthorizationRequestWithMultipleRedirectUrisOnClient()
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(['uriOne', 'uriTwo']);
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(true);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+        $authRequest->setUser(new UserEntity());
+
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
+        $grant = new AuthCodeGrant(
+            $authCodeRepository,
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+
+        $this->assertInstanceOf(RedirectResponse::class, $grant->completeAuthorizationRequest($authRequest));
+    }
+
     public function testCompleteAuthorizationRequestDenied()
     {
         $authRequest = new AuthorizationRequest();


### PR DESCRIPTION
This PR introduces a new `AuthorizationRequestInterface` which is implemented by the current `AuthorizationRequest`. This way implementors are provided with a more flexible way to override certain parts of the authorization grant types than with the concrete class alone.

In my case I was looking into a way to use a decorated authorization request to be able to add the `nonce` attribute used of an OpenID Connect (OICD) implementation. I understand that this library is only supporting the OAuth2 specs and nothing related to OIDC (see https://github.com/thephpleague/oauth2-server/issues/962) which is totally fine with me. 

This PR raises the flexibility of the library without doing any harm 🙂 