### PR TITLE
Decouple error responses from exception

### DIFF
--- a/examples/public/auth_code.php
+++ b/examples/public/auth_code.php
@@ -59,7 +59,6 @@ $app = new App([
         return $server;
     },
 ]);
-
 $app->get('/authorize', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
     $server = $app->getContainer()->get(AuthorizationServer::class);
@@ -79,7 +78,7 @@ $app->get('/authorize', function (ServerRequestInterface $request, ResponseInter
         // Return the HTTP redirect response
         return $server->completeAuthorizationRequest($authRequest, $response);
     } catch (OAuthServerException $exception) {
-        return $exception->generateHttpResponse($response);
+        return $server->generateHttpResponse($exception, $response);
     } catch (\Exception $exception) {
         $body = new Stream('php://temp', 'r+');
         $body->write($exception->getMessage());
@@ -95,7 +94,7 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
     try {
         return $server->respondToAccessTokenRequest($request, $response);
     } catch (OAuthServerException $exception) {
-        return $exception->generateHttpResponse($response);
+        return $server->generateHttpResponse($exception, $response);
     } catch (\Exception $exception) {
         $body = new Stream('php://temp', 'r+');
         $body->write($exception->getMessage());

--- a/examples/public/client_credentials.php
+++ b/examples/public/client_credentials.php
@@ -64,7 +64,7 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
     } catch (OAuthServerException $exception) {
 
         // All instances of OAuthServerException can be formatted into a HTTP response
-        return $exception->generateHttpResponse($response);
+        return $server->generateHttpResponse($exception, $response);
     } catch (\Exception $exception) {
 
         // Unknown exception

--- a/examples/public/implicit.php
+++ b/examples/public/implicit.php
@@ -68,7 +68,7 @@ $app->get('/authorize', function (ServerRequestInterface $request, ResponseInter
         // Return the HTTP redirect response
         return $server->completeAuthorizationRequest($authRequest, $response);
     } catch (OAuthServerException $exception) {
-        return $exception->generateHttpResponse($response);
+        return $server->generateHttpResponse($exception, $response);
     } catch (\Exception $exception) {
         $body = new Stream('php://temp', 'r+');
         $body->write($exception->getMessage());

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -57,7 +57,7 @@ $app->post(
         } catch (OAuthServerException $exception) {
 
             // All instances of OAuthServerException can be converted to a PSR-7 response
-            return $exception->generateHttpResponse($response);
+            return $server->generateHttpResponse($exception, $response);
         } catch (\Exception $exception) {
 
             // Catch unexpected exceptions

--- a/examples/public/refresh_token.php
+++ b/examples/public/refresh_token.php
@@ -62,7 +62,7 @@ $app->post('/access_token', function (ServerRequestInterface $request, ResponseI
     try {
         return $server->respondToAccessTokenRequest($request, $response);
     } catch (OAuthServerException $exception) {
-        return $exception->generateHttpResponse($response);
+        return $server->generateHttpResponse($exception, $response);
     } catch (\Exception $exception) {
         $response->getBody()->write($exception->getMessage());
 

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -13,6 +13,8 @@ use DateInterval;
 use Defuse\Crypto\Key;
 use League\Event\EmitterAwareInterface;
 use League\Event\EmitterAwareTrait;
+use League\OAuth2\Server\Exception\ExceptionResponseHandler;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\GrantTypeInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -80,14 +82,20 @@ class AuthorizationServer implements EmitterAwareInterface
     private $defaultScope = '';
 
     /**
+     * @var ExceptionResponseHandlerInterface
+     */
+    private $exceptionResponseHandler;
+
+    /**
      * New server instance.
      *
-     * @param ClientRepositoryInterface      $clientRepository
-     * @param AccessTokenRepositoryInterface $accessTokenRepository
-     * @param ScopeRepositoryInterface       $scopeRepository
-     * @param CryptKeyInterface|string       $privateKey
-     * @param string|Key                     $encryptionKey
-     * @param null|ResponseTypeInterface     $responseType
+     * @param ClientRepositoryInterface                 $clientRepository
+     * @param AccessTokenRepositoryInterface            $accessTokenRepository
+     * @param ScopeRepositoryInterface                  $scopeRepository
+     * @param CryptKeyInterface|string                  $privateKey
+     * @param string|Key                                $encryptionKey
+     * @param null|ResponseTypeInterface                $responseType
+     * @param null|ExceptionResponseHandlerInterface    $exceptionResponseHandler
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,
@@ -95,7 +103,8 @@ class AuthorizationServer implements EmitterAwareInterface
         ScopeRepositoryInterface $scopeRepository,
         $privateKey,
         $encryptionKey,
-        ResponseTypeInterface $responseType = null
+        ResponseTypeInterface $responseType = null,
+        ExceptionResponseHandlerInterface $exceptionResponseHandler = null
     ) {
         $this->clientRepository = $clientRepository;
         $this->accessTokenRepository = $accessTokenRepository;
@@ -115,6 +124,11 @@ class AuthorizationServer implements EmitterAwareInterface
         }
 
         $this->responseType = $responseType;
+
+        if ($exceptionResponseHandler === null) {
+            $exceptionResponseHandler = new ExceptionResponseHandler();
+        }
+        $this->exceptionResponseHandler = $exceptionResponseHandler;
     }
 
     /**
@@ -234,5 +248,14 @@ class AuthorizationServer implements EmitterAwareInterface
     public function setDefaultScope($defaultScope)
     {
         $this->defaultScope = $defaultScope;
+    }
+
+    public function generateHttpResponse(
+        OAuthServerException $exception,
+        ResponseInterface $response,
+        $useFragment = false,
+        $jsonOptions = 0
+    ) {
+        return $this->exceptionResponseHandler->generateHttpResponse($exception, $response, $useFragment, $jsonOptions);
     }
 }

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -15,6 +15,7 @@ use League\Event\EmitterAwareInterface;
 use League\Event\EmitterAwareTrait;
 use League\OAuth2\Server\Exception\ExceptionResponseHandler;
 use League\OAuth2\Server\Exception\ExceptionResponseHandlerInterface;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\GrantTypeInterface;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
@@ -29,7 +30,8 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class AuthorizationServer implements EmitterAwareInterface
 {
-    use EmitterAwareTrait;
+    use EmitterAwareTrait,
+        ExceptionResponseHandlerTrait;
 
     /**
      * @var GrantTypeInterface[]
@@ -248,14 +250,5 @@ class AuthorizationServer implements EmitterAwareInterface
     public function setDefaultScope($defaultScope)
     {
         $this->defaultScope = $defaultScope;
-    }
-
-    public function generateHttpResponse(
-        OAuthServerException $exception,
-        ResponseInterface $response,
-        $useFragment = false,
-        $jsonOptions = 0
-    ) {
-        return $this->exceptionResponseHandler->generateHttpResponse($exception, $response, $useFragment, $jsonOptions);
     }
 }

--- a/src/Exception/ExceptionResponseHandler.php
+++ b/src/Exception/ExceptionResponseHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace League\OAuth2\Server\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+class ExceptionResponseHandler implements ExceptionResponseHandlerInterface
+{
+    /**
+     * Generate a HTTP response.
+     *
+     * @param OAuthServerException  $exception
+     * @param ResponseInterface     $response
+     * @param bool                  $useFragment True if errors should be in the URI fragment instead of query string
+     * @param int                   $jsonOptions options passed to json_encode
+     *
+     * @return ResponseInterface
+     */
+    public function generateHttpResponse(
+        OAuthServerException $exception,
+        ResponseInterface $response,
+        $useFragment = false,
+        $jsonOptions = 0
+    ) {
+        $headers = $exception->getHttpHeaders();
+
+        $payload = $exception->getPayload();
+
+        $redirectUri = $exception->getRedirectUri();
+        if ($redirectUri !== null) {
+            if ($useFragment === true) {
+                $redirectUri .= (\strstr($redirectUri, '#') === false) ? '#' : '&';
+            } else {
+                $redirectUri .= (\strstr($redirectUri, '?') === false) ? '?' : '&';
+            }
+
+            return $response->withStatus(302)->withHeader('Location', $redirectUri . \http_build_query($payload));
+        }
+
+        foreach ($headers as $header => $content) {
+            $response = $response->withHeader($header, $content);
+        }
+
+        $responseBody = \json_encode($payload, $jsonOptions) ?: 'JSON encoding of payload failed';
+
+        $response->getBody()->write($responseBody);
+
+        return $response->withStatus($exception->getHttpStatusCode());
+    }
+}

--- a/src/Exception/ExceptionResponseHandler.php
+++ b/src/Exception/ExceptionResponseHandler.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 class ExceptionResponseHandler implements ExceptionResponseHandlerInterface
 {
     /**
-     * Generate a HTTP response.
+     * Generate a HTTP response from am OAuthServerException
      *
      * @param OAuthServerException  $exception
      * @param ResponseInterface     $response
@@ -30,13 +30,7 @@ class ExceptionResponseHandler implements ExceptionResponseHandlerInterface
 
         $redirectUri = $exception->getRedirectUri();
         if ($redirectUri !== null) {
-            if ($useFragment === true) {
-                $redirectUri .= (\strstr($redirectUri, '#') === false) ? '#' : '&';
-            } else {
-                $redirectUri .= (\strstr($redirectUri, '?') === false) ? '?' : '&';
-            }
-
-            return $response->withStatus(302)->withHeader('Location', $redirectUri . \http_build_query($payload));
+            return $this->generateRedirectResponse($redirectUri, $response, $payload, $useFragment);
         }
 
         foreach ($headers as $header => $content) {
@@ -48,5 +42,31 @@ class ExceptionResponseHandler implements ExceptionResponseHandlerInterface
         $response->getBody()->write($responseBody);
 
         return $response->withStatus($exception->getHttpStatusCode());
+    }
+
+    /**
+     * Generate a HTTP response from am OAuthServerException
+     *
+     * @param string            $redirectUri
+     * @param ResponseInterface $response
+     * @param string[]          $payload
+     * @param bool              $useFragment
+     *
+     * @return ResponseInterface
+     */
+    protected function generateRedirectResponse(
+        string $redirectUri,
+        ResponseInterface $response,
+        $payload,
+        $useFragment
+    ): ResponseInterface {
+        if ($useFragment === true) {
+            $querySeparator = '#';
+        } else {
+            $querySeparator = '?';
+        }
+        $redirectUri .= (\strstr($redirectUri, '?') === false) ? $querySeparator : '&';
+
+        return $response->withStatus(302)->withHeader('Location', $redirectUri . \http_build_query($payload));
     }
 }

--- a/src/Exception/ExceptionResponseHandlerInterface.php
+++ b/src/Exception/ExceptionResponseHandlerInterface.php
@@ -7,7 +7,7 @@ use Psr\Http\Message\ResponseInterface;
 interface ExceptionResponseHandlerInterface
 {
     /**
-     * Generate a HTTP response from a OAuthServerException
+     * Generate a HTTP response from am OAuthServerException
      *
      * @param OAuthServerException  $exception
      * @param ResponseInterface     $response

--- a/src/Exception/ExceptionResponseHandlerInterface.php
+++ b/src/Exception/ExceptionResponseHandlerInterface.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace League\OAuth2\Server\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface ExceptionResponseHandlerInterface
+{
+    /**
+     * Generate a HTTP response from a OAuthServerException
+     *
+     * @param OAuthServerException  $exception
+     * @param ResponseInterface     $response
+     * @param bool                  $useFragment True if errors should be in the URI fragment instead of query string
+     * @param int                   $jsonOptions options passed to json_encode
+     *
+     * @return ResponseInterface
+     */
+    public function generateHttpResponse(
+        OAuthServerException $exception,
+        ResponseInterface $response,
+        $useFragment = false,
+        $jsonOptions = 0
+    );
+}

--- a/src/Exception/ExceptionResponseHandlerTrait.php
+++ b/src/Exception/ExceptionResponseHandlerTrait.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace League\OAuth2\Server\Exception;
+
+use Psr\Http\Message\ResponseInterface;
+
+trait ExceptionResponseHandlerTrait
+{
+    /**
+     * Generate a HTTP response from am OAuthServerException
+     *
+     * @param OAuthServerException  $exception
+     * @param ResponseInterface     $response
+     * @param bool                  $useFragment True if errors should be in the URI fragment instead of query string
+     * @param int                   $jsonOptions options passed to json_encode
+     *
+     * @return ResponseInterface
+     */
+    public function generateHttpResponse(
+        OAuthServerException $exception,
+        ResponseInterface $response,
+        $useFragment = false,
+        $jsonOptions = 0
+    ) {
+        return $this->exceptionResponseHandler->generateHttpResponse($exception, $response, $useFragment, $jsonOptions);
+    }
+}

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -280,42 +280,6 @@ class OAuthServerException extends Exception
     }
 
     /**
-     * Generate a HTTP response.
-     *
-     * @param ResponseInterface $response
-     * @param bool              $useFragment True if errors should be in the URI fragment instead of query string
-     * @param int               $jsonOptions options passed to json_encode
-     *
-     * @return ResponseInterface
-     */
-    public function generateHttpResponse(ResponseInterface $response, $useFragment = false, $jsonOptions = 0)
-    {
-        $headers = $this->getHttpHeaders();
-
-        $payload = $this->getPayload();
-
-        if ($this->redirectUri !== null) {
-            if ($useFragment === true) {
-                $this->redirectUri .= (\strstr($this->redirectUri, '#') === false) ? '#' : '&';
-            } else {
-                $this->redirectUri .= (\strstr($this->redirectUri, '?') === false) ? '?' : '&';
-            }
-
-            return $response->withStatus(302)->withHeader('Location', $this->redirectUri . \http_build_query($payload));
-        }
-
-        foreach ($headers as $header => $content) {
-            $response = $response->withHeader($header, $content);
-        }
-
-        $responseBody = \json_encode($payload, $jsonOptions) ?: 'JSON encoding of payload failed';
-
-        $response->getBody()->write($responseBody);
-
-        return $response->withStatus($this->getHttpStatusCode());
-    }
-
-    /**
      * Get all headers that have to be send with the error response.
      *
      * @return array Array with header values

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -376,4 +376,12 @@ class OAuthServerException extends Exception
     {
         return $this->hint;
     }
+
+    /**
+     * @return null|string
+     */
+    public function getRedirectUri()
+    {
+        return $this->redirectUri;
+    }
 }

--- a/src/Middleware/AuthorizationServerMiddleware.php
+++ b/src/Middleware/AuthorizationServerMiddleware.php
@@ -42,12 +42,10 @@ class AuthorizationServerMiddleware
         try {
             $response = $this->server->respondToAccessTokenRequest($request, $response);
         } catch (OAuthServerException $exception) {
-            return $exception->generateHttpResponse($response);
-            // @codeCoverageIgnoreStart
+            return $this->server->generateHttpResponse($exception, $response);
         } catch (Exception $exception) {
-            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
-                ->generateHttpResponse($response);
-            // @codeCoverageIgnoreEnd
+            $serverException = new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500);
+            return $this->server->generateHttpResponse($serverException, $response);
         }
 
         // Pass the request and response on to the next responder in the chain

--- a/src/Middleware/ResourceServerMiddleware.php
+++ b/src/Middleware/ResourceServerMiddleware.php
@@ -42,12 +42,10 @@ class ResourceServerMiddleware
         try {
             $request = $this->server->validateAuthenticatedRequest($request);
         } catch (OAuthServerException $exception) {
-            return $exception->generateHttpResponse($response);
-            // @codeCoverageIgnoreStart
+            return $this->server->generateHttpResponse($exception, $response);
         } catch (Exception $exception) {
-            return (new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500))
-                ->generateHttpResponse($response);
-            // @codeCoverageIgnoreEnd
+            $serverException = new OAuthServerException($exception->getMessage(), 0, 'unknown_error', 500);
+            return $this->server->generateHttpResponse($serverException, $response);
         }
 
         // Pass the request and response on to the next responder in the chain

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -11,12 +11,17 @@ namespace League\OAuth2\Server;
 
 use League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface;
 use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
+use League\OAuth2\Server\Exception\ExceptionResponseHandler;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerInterface;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ResourceServer
 {
+    use ExceptionResponseHandlerTrait;
+
     /**
      * @var AccessTokenRepositoryInterface
      */
@@ -33,16 +38,23 @@ class ResourceServer
     private $authorizationValidator;
 
     /**
+     * @var ExceptionResponseHandlerInterface
+     */
+    private $exceptionResponseHandler;
+
+    /**
      * New server instance.
      *
-     * @param AccessTokenRepositoryInterface       $accessTokenRepository
-     * @param CryptKeyInterface|string             $publicKey
-     * @param null|AuthorizationValidatorInterface $authorizationValidator
+     * @param AccessTokenRepositoryInterface            $accessTokenRepository
+     * @param CryptKeyInterface|string                  $publicKey
+     * @param null|AuthorizationValidatorInterface      $authorizationValidator
+     * @param null|ExceptionResponseHandlerInterface    $exceptionResponseHandler
      */
     public function __construct(
         AccessTokenRepositoryInterface $accessTokenRepository,
         $publicKey,
-        AuthorizationValidatorInterface $authorizationValidator = null
+        AuthorizationValidatorInterface $authorizationValidator = null,
+        ExceptionResponseHandlerInterface $exceptionResponseHandler = null
     ) {
         $this->accessTokenRepository = $accessTokenRepository;
 
@@ -52,6 +64,11 @@ class ResourceServer
         $this->publicKey = $publicKey;
 
         $this->authorizationValidator = $authorizationValidator;
+
+        if ($exceptionResponseHandler === null) {
+            $exceptionResponseHandler = new ExceptionResponseHandler();
+        }
+        $this->exceptionResponseHandler = $exceptionResponseHandler;
     }
 
     /**

--- a/tests/Exception/ExceptionResponseHandlerTest.php
+++ b/tests/Exception/ExceptionResponseHandlerTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace LeagueTests\Exception;
+
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use League\OAuth2\Server\Exception\ExceptionResponseHandler;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Grant\AbstractGrant;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionResponseHandlerTest extends TestCase
+{
+    /**
+     * @var ExceptionResponseHandler
+     */
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->handler = new ExceptionResponseHandler();
+    }
+
+    public function testHandlerImplementsContract(): void
+    {
+        $this->assertInstanceOf(ExceptionResponseHandlerInterface::class, $this->handler);
+    }
+
+    public function testGenerateRedirectResponseStatusCodeForInvalidScopeExceptionWithRedirectUri()
+    {
+        $exception = OAuthServerException::invalidScope('foo', 'https://bar.test');
+        $response = $this->handler->generateHttpResponse($exception, new Response());
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testGenerateRedirectResponseLocationHeaderForInvalidScopeExceptionWithRedirectUri()
+    {
+        $redirectUri = 'https://bar.test';
+        $exception = OAuthServerException::invalidScope('foo', $redirectUri);
+        $response = $this->handler->generateHttpResponse($exception, new Response());
+
+        $payload = $exception->getPayload();
+        $query = \http_build_query($payload);
+        $expectedRedirectUri = $redirectUri . '?' . $query;
+        $header = $response->getHeader('Location')[0];
+        $this->assertSame($expectedRedirectUri, $header);
+    }
+
+    public function testGenerateRedirectResponseLocationHeaderForInvalidScopeExceptionWithRedirectUriUsingFragment()
+    {
+        $redirectUri = 'https://bar.test';
+        $exception = OAuthServerException::invalidScope('foo', $redirectUri);
+        $response = $this->handler->generateHttpResponse($exception, new Response(), true);
+
+        $payload = $exception->getPayload();
+        $query = \http_build_query($payload);
+        $expectedRedirectUri = $redirectUri . '#' . $query;
+        $header = $response->getHeader('Location')[0];
+        $this->assertSame($expectedRedirectUri, $header);
+    }
+
+    public function testInvalidClientExceptionSetsAuthenticateHeader()
+    {
+        $serverRequest = (new ServerRequest())
+            ->withParsedBody([
+                                 'client_id' => 'foo',
+                             ])
+            ->withAddedHeader('Authorization', 'Basic fakeauthdetails');
+
+        try {
+            $this->issueInvalidClientException($serverRequest);
+        } catch (OAuthServerException $e) {
+            $response = $this->handler->generateHttpResponse($e, new Response());
+
+            $this->assertTrue($response->hasHeader('WWW-Authenticate'));
+        }
+    }
+
+    public function testInvalidClientExceptionOmitsAuthenticateHeader()
+    {
+        $serverRequest = (new ServerRequest())
+            ->withParsedBody([
+                                 'client_id' => 'foo',
+                             ]);
+
+        try {
+            $this->issueInvalidClientException($serverRequest);
+        } catch (OAuthServerException $e) {
+            $response = $this->handler->generateHttpResponse($e, new Response());
+
+            $this->assertFalse($response->hasHeader('WWW-Authenticate'));
+        }
+    }
+
+    /**
+     * Issue an invalid client exception
+     *
+     * @throws OAuthServerException
+     */
+    private function issueInvalidClientException($serverRequest)
+    {
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('validateClient')->willReturn(false);
+
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $grantMock->setClientRepository($clientRepositoryMock);
+
+        $abstractGrantReflection = new \ReflectionClass($grantMock);
+
+        $validateClientMethod = $abstractGrantReflection->getMethod('validateClient');
+        $validateClientMethod->setAccessible(true);
+
+        $validateClientMethod->invoke($grantMock, $serverRequest);
+    }
+}

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -96,4 +96,12 @@ class OAuthServerExceptionTest extends TestCase
 
         $this->assertNull($exceptionWithoutPrevious->getPrevious());
     }
+
+    public function testGetRedirectUri(): void
+    {
+        $redirectUri = 'https://bar.test';
+        $exception = OAuthServerException::invalidScope('foo', $redirectUri);
+
+        $this->assertSame($redirectUri, $exception->getRedirectUri());
+    }
 }

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -12,60 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 class OAuthServerExceptionTest extends TestCase
 {
-    public function testInvalidClientExceptionSetsAuthenticateHeader()
-    {
-        $serverRequest = (new ServerRequest())
-            ->withParsedBody([
-                'client_id' => 'foo',
-            ])
-            ->withAddedHeader('Authorization', 'Basic fakeauthdetails');
-
-        try {
-            $this->issueInvalidClientException($serverRequest);
-        } catch (OAuthServerException $e) {
-            $response = $e->generateHttpResponse(new Response());
-
-            $this->assertTrue($response->hasHeader('WWW-Authenticate'));
-        }
-    }
-
-    public function testInvalidClientExceptionOmitsAuthenticateHeader()
-    {
-        $serverRequest = (new ServerRequest())
-            ->withParsedBody([
-                'client_id' => 'foo',
-            ]);
-
-        try {
-            $this->issueInvalidClientException($serverRequest);
-        } catch (OAuthServerException $e) {
-            $response = $e->generateHttpResponse(new Response());
-
-            $this->assertFalse($response->hasHeader('WWW-Authenticate'));
-        }
-    }
-
-    /**
-     * Issue an invalid client exception
-     *
-     * @throws OAuthServerException
-     */
-    private function issueInvalidClientException($serverRequest)
-    {
-        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepositoryMock->method('validateClient')->willReturn(false);
-
-        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
-        $grantMock->setClientRepository($clientRepositoryMock);
-
-        $abstractGrantReflection = new \ReflectionClass($grantMock);
-
-        $validateClientMethod = $abstractGrantReflection->getMethod('validateClient');
-        $validateClientMethod->setAccessible(true);
-
-        $validateClientMethod->invoke($grantMock, $serverRequest);
-    }
-
     public function testHasRedirect()
     {
         $exceptionWithRedirect = OAuthServerException::accessDenied('some hint', 'https://example.com/error');

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -3,9 +3,11 @@
 namespace LeagueTests\Middleware;
 
 use DateInterval;
+use Laminas\Diactoros\Request;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequestFactory;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\ExceptionResponseHandler;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use League\OAuth2\Server\Middleware\AuthorizationServerMiddleware;
@@ -17,6 +19,8 @@ use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class AuthorizationServerMiddlewareTest extends TestCase
 {
@@ -105,7 +109,8 @@ class AuthorizationServerMiddlewareTest extends TestCase
     public function testOAuthErrorResponseRedirectUri()
     {
         $exception = OAuthServerException::invalidScope('test', 'http://foo/bar');
-        $response = $exception->generateHttpResponse(new Response());
+        $exceptionResponseHandler = new ExceptionResponseHandler();
+        $response = $exceptionResponseHandler->generateHttpResponse($exception, new Response());
 
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://foo/bar?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
@@ -115,10 +120,36 @@ class AuthorizationServerMiddlewareTest extends TestCase
     public function testOAuthErrorResponseRedirectUriFragment()
     {
         $exception = OAuthServerException::invalidScope('test', 'http://foo/bar');
-        $response = $exception->generateHttpResponse(new Response(), true);
+        $exceptionResponseHandler = new ExceptionResponseHandler();
+        $response = $exceptionResponseHandler->generateHttpResponse($exception, new Response(), true);
 
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals('http://foo/bar#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
             $response->getHeader('location')[0]);
+    }
+
+    public function testExceptionIsTurnedIntoOAuthServerException(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $serverMock = $this->createMock(AuthorizationServer::class);
+        $serverMock->expects($this->once())
+            ->method('respondToAccessTokenRequest')
+            ->willThrowException(new \Exception('foo'));
+
+        $serverMock->expects($this->once())
+            ->method('generateHttpResponse')
+            ->willReturn($responseMock);
+
+        $middleware = new AuthorizationServerMiddleware($serverMock);
+
+        $response = $middleware->__invoke(
+            $this->createMock(ServerRequestInterface::class),
+            new Response(),
+            function () {
+                return \func_get_args()[1];
+            }
+        );
+
+        $this->assertSame($responseMock, $response);
     }
 }

--- a/tests/ResourceServerTest.php
+++ b/tests/ResourceServerTest.php
@@ -3,11 +3,15 @@
 
 namespace LeagueTests;
 
+use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequestFactory;
+use League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface;
+use League\OAuth2\Server\Exception\ExceptionResponseHandlerInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 class ResourceServerTest extends TestCase
 {
@@ -23,5 +27,32 @@ class ResourceServerTest extends TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals('Missing "Authorization" header', $e->getHint());
         }
+    }
+
+    public function testGenerateHttpResponseFromExceptionIsProxiesExceptionResponseHandlerMethod()
+    {
+        $exception = OAuthServerException::invalidScope('foo', 'https://bar.test');
+        $existingResponse = new Response();
+        $useFragment = true;
+        $jsonOptions = 0;
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $exceptionResponseHandlerMock = $this->createMock(ExceptionResponseHandlerInterface::class);
+        $exceptionResponseHandlerMock
+            ->expects($this->once())
+            ->method('generateHttpResponse')
+            ->with($exception, $existingResponse, $useFragment, $jsonOptions)
+            ->willReturn($responseMock);
+
+        $server = new ResourceServer(
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/public.key',
+            $this->getMockBuilder(AuthorizationValidatorInterface::class)->getMock(),
+            $exceptionResponseHandlerMock
+        );
+
+        $response = $server->generateHttpResponse($exception, $existingResponse, $useFragment, $jsonOptions);
+
+        $this->assertSame($responseMock, $response);
     }
 }


### PR DESCRIPTION
This PR decouples the generation of the error responses from the OAuthServerException by moving the function to a new ExceptionResponseHandlerInterface with a default ExceptionResponseHandler implementation. 

The handler gets injected into the authorization and resource server and is used via a `::generateHttpRepsones` proxy method. 

This way required changes are minized while open up the library to support translated error response payloads in a second step.