### PR TITLE
Use InvalidCredentials instead invalidGrant when user not found

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -104,7 +104,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidCredentials();
         }
 
         return $user;

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -205,7 +205,7 @@ class PasswordGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(10);
+        $this->expectExceptionCode(6);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }


### PR DESCRIPTION
On login using password gran client with invalid credentials it was returning invalid grant instead invalid credentials.

I am using Laravel Passport with invalid email and/or password.

```php
$http = new \GuzzleHttp\Client([
    'verify' => !in_array(env('APP_ENV'), ['local', 'testing']),
]);
$response = $http->post(route('passport.token'), [
    'form_params' => [
        'grant_type'    => 'password',
        'client_id'     => ?,
        'client_secret' => ?,
        'username'      => $request->get('email'),
        'password'      => $request->get('password'),
        'scope'         => null,
    ],
]);

return response($response->getBody()->getContents(), $response->getStatusCode());
```