### PR TITLE
Add CodeIgniter 4 community integration to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ We use [Travis CI](https://travis-ci.org/), [Scrutinizer](https://scrutinizer-ci
 * [OAuth 2 Server for CakePHP 3](https://github.com/uafrica/oauth-server)
 * [OAuth 2 Server for Mezzio](https://github.com/mezzio/mezzio-authentication-oauth2)
 * [Trikoder OAuth 2 Bundle (Symfony)](https://github.com/trikoder/oauth2-bundle)
+* [Heimdall for CodeIgniter 4](https://github.com/ezralazuardy/heimdall)
 
 ## Changelog
 


### PR DESCRIPTION
I recently published a CodeIgniter 4.x library which aims to simplify the need of implementing OAuth 2.0 in CodeIgniter 4 framework, based on this library. You can check it out here: https://github.com/ezralazuardy/heimdall.

I've implemented all functionality and OAuth 2.0 flow based on this library too, with some extension added such as OIDC support.

The main reason why I started develop this library is because the lack of PSR-7 classes integration in CodeIgniter 4. As stated in [CodeIgniter 4 docs](https://codeigniter.com/user_guide/intro/psr.html),

> CodeIgniter does not strive for compatibility with PSR-7 recommendation.

CodeIgniter 4 framework also compatible with some number of PHP FIG's proposals though, but the CodeIgniter's PSR-7: HTTP Message Interface is different from the standard recommendation, and that's mean you need to re-implement the PSR-7 classes if you need it to work with the standard recommendation.

I think that's hard for newcomer to implement this, since this library is PSR compliant.

And btw, thanks for this awesome library! ❤️.