### PR TITLE
Enforce Redirect URI for Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix typo in parameter hint. `code_challenged` changed to `code_challenge`. Thrown by Auth Code Grant when the code challenge does not match the regex. (PR #1130) 
+- Undefined offset was returned when no client redirect URI was set. Now throw an invalidClient exception if no redirect URI is set against a client (PR #1140)
 
 ## [8.1.1] - released 2020-07-01
 

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -216,7 +216,7 @@ abstract class AbstractGrant implements GrantTypeInterface
     {
         $client = $this->clientRepository->getClientEntity($clientId);
 
-        if ($client instanceof ClientEntityInterface === false) {
+        if ($client instanceof ClientEntityInterface === false || empty($client->getRedirectUri())) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
             throw OAuthServerException::invalidClient($request);
         }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -261,9 +261,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
         if ($redirectUri !== null) {
             $this->validateRedirectUri($redirectUri, $client, $request);
-        } elseif (empty($client->getRedirectUri()) ||
-            (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1)) {
+        } elseif (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
+
             throw OAuthServerException::invalidClient($request);
         }
 

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -63,7 +63,9 @@ class AuthorizationServerTest extends TestCase
     public function testRespondToRequest()
     {
         $client = new ClientEntity();
+
         $client->setConfidential();
+        $client->setRedirectUri('http://foo.bar');
 
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepository->method('getClientEntity')->willReturn($client);
@@ -284,6 +286,8 @@ class AuthorizationServerTest extends TestCase
     public function testValidateAuthorizationRequestWithMissingRedirectUri()
     {
         $client = new ClientEntity();
+        $client->setConfidential();
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -65,7 +65,7 @@ class AuthorizationServerTest extends TestCase
         $client = new ClientEntity();
 
         $client->setConfidential();
-        $client->setRedirectUri('http://foo.bar');
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepository->method('getClientEntity')->willReturn($client);

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -92,6 +92,7 @@ class AbstractGrantTest extends TestCase
     public function testValidateClientPublic()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo.bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -116,6 +117,7 @@ class AbstractGrantTest extends TestCase
     public function testValidateClientConfidential()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -92,7 +92,7 @@ class AbstractGrantTest extends TestCase
     public function testValidateClientPublic()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo.bar');
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -30,6 +30,7 @@ class ClientCredentialsGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setConfidential();
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -37,6 +37,8 @@ class PasswordGrantTest extends TestCase
     public function testRespondToRequest()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -81,6 +83,8 @@ class PasswordGrantTest extends TestCase
     public function testRespondToRequestNullRefreshToken()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -181,6 +185,8 @@ class PasswordGrantTest extends TestCase
     public function testRespondToRequestBadCredentials()
     {
         $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -44,6 +44,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -98,6 +100,7 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -154,6 +157,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -208,6 +213,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -261,6 +268,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -290,6 +299,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -322,6 +333,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -368,6 +381,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -411,6 +426,8 @@ class RefreshTokenGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -26,6 +26,7 @@ class AuthorizationServerMiddlewareTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setConfidential();
+        $client->setRedirectUri('http://foo/bar');
 
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepository->method('getClientEntity')->willReturn($client);

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -109,8 +109,10 @@ class AuthorizationServerMiddlewareTest extends TestCase
         $response = $exception->generateHttpResponse(new Response());
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('http://foo/bar?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
-            $response->getHeader('location')[0]);
+        $this->assertEquals(
+            'http://foo/bar?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
+            $response->getHeader('location')[0]
+        );
     }
 
     public function testOAuthErrorResponseRedirectUriFragment()
@@ -119,7 +121,9 @@ class AuthorizationServerMiddlewareTest extends TestCase
         $response = $exception->generateHttpResponse(new Response(), true);
 
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals('http://foo/bar#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
-            $response->getHeader('location')[0]);
+        $this->assertEquals(
+            'http://foo/bar#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
+            $response->getHeader('location')[0]
+        );
     }
 }


### PR DESCRIPTION
Force the registration of at least one redirect URI for a client. Fixes issue #1133 