### PR TITLE
Fix Key Passing where Priv Key has a Passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [8.2.1] - released 2020-11-26
 ### Fixed
-- If you have a password on your private key, it is now passed correctly to the JWT configuration object. (PR #XXXX)
+- If you have a password on your private key, it is now passed correctly to the JWT configuration object. (PR #1159)
 
 ## [8.2.0] - released 2020-11-25
 ### Added
@@ -515,7 +515,8 @@ Version 5 is a complete code rewrite.
 
 - First major release
 
-[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.2.0...HEAD
+[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.2.1...HEAD
+[8.2.1]: https://github.com/thephpleague/oauth2-server/compare/8.2.0...8.2.1
 [8.2.0]: https://github.com/thephpleague/oauth2-server/compare/8.1.1...8.2.0
 [8.1.1]: https://github.com/thephpleague/oauth2-server/compare/8.1.0...8.1.1
 [8.1.0]: https://github.com/thephpleague/oauth2-server/compare/8.0.0...8.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.2.1] - released 2020-11-26
+### Fixed
+- If you have a password on your private key, it is now passed correctly to the JWT configuration object. (PR #XXXX)
+
 ## [8.2.0] - released 2020-11-25
 ### Added
 - Add a `getRedirectUri` function to the `OAuthServerException` class (PR #1123)

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,9 @@ trait AccessTokenTrait
     {
         $privateKeyPassPhrase = $this->privateKey->getPassPhrase();
 
-        $verificationKey = empty($privateKeyPassPhrase) ? InMemory::plainText('') : $privateKeyPassPhrase;
+        $verificationKey = empty($privateKeyPassPhrase) ?
+            InMemory::plainText('') :
+            InMemory::plainText($this->privateKey->getPassPhrase());
 
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),


### PR DESCRIPTION
This PR fixes an issue where the private key passphrase is passed as a string rather than a Key object as per lcobucci/jwt's API.