### PR TITLE
fix for passphrase with private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.2.2] - released 2020-11-30
+- Fix issue where the private key passphrase isn't correctly passed to JWT library (PR #1164)
+
 ## [8.2.1] - released 2020-11-26
 ### Fixed
 - If you have a password on your private key, it is now passed correctly to the JWT configuration object. (PR #1159)

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,7 @@ trait AccessTokenTrait
     {
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
-            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase() ?: ''),
+            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase() ?? ''),
             InMemory::plainText('')
         );
     }

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -52,7 +52,7 @@ trait AccessTokenTrait
 
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
-            LocalFileReference::file($this->privateKey->getKeyPath()),
+            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()),
             $verificationKey
         );
     }

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -44,16 +44,10 @@ trait AccessTokenTrait
      */
     public function initJwtConfiguration()
     {
-        $privateKeyPassPhrase = $this->privateKey->getPassPhrase();
-
-        $verificationKey = empty($privateKeyPassPhrase) ?
-            InMemory::plainText('') :
-            InMemory::plainText($this->privateKey->getPassPhrase());
-
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
-            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()),
-            $verificationKey
+            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase() ?: ''),
+            InMemory::plainText('')
         );
     }
 


### PR DESCRIPTION
I had to make the following change for passphrase with private key to work. Otherwise the passphrase does not make it into any of the sign etc. functions in lcobucci/jwt library. (note this bug cropped up in the most recent versions of oauth2-server/jwt that tackled PHP8)

It is striking me as odd that we are also sending the passphrase as the verification key, which I am still looking into.