### PR TITLE
Revert Enforcing of Client Redirect URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [8.2.4] - released 2020-12-09
+### Fixed
+- Reverted the enforcement of at least one redirect_uri for a client. This change has instead been moved to version 9 (PR #1169)
+
 ## [8.2.3] - released 2020-12-02
 ### Added
 - Re-added support for PHP 7.2 (PR #1165, #1167)
@@ -522,7 +526,8 @@ Version 5 is a complete code rewrite.
 
 - First major release
 
-[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.2.3...HEAD
+[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.2.4...HEAD
+[8.2.4]: https://github.com/thephpleague/oauth2-server/compare/8.2.3...8.2.4
 [8.2.3]: https://github.com/thephpleague/oauth2-server/compare/8.2.2...8.2.3
 [8.2.2]: https://github.com/thephpleague/oauth2-server/compare/8.2.1...8.2.2
 [8.2.1]: https://github.com/thephpleague/oauth2-server/compare/8.2.0...8.2.1

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -216,7 +216,7 @@ abstract class AbstractGrant implements GrantTypeInterface
     {
         $client = $this->clientRepository->getClientEntity($clientId);
 
-        if ($client instanceof ClientEntityInterface === false || empty($client->getRedirectUri())) {
+        if ($client instanceof ClientEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
             throw OAuthServerException::invalidClient($request);
         }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -261,7 +261,8 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
         if ($redirectUri !== null) {
             $this->validateRedirectUri($redirectUri, $client, $request);
-        } elseif (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1) {
+        } elseif (empty($client->getRedirectUri()) ||
+            (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1)) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
 
             throw OAuthServerException::invalidClient($request);


### PR DESCRIPTION
This PR reinstates the ability to have a client that does _not_ have a pre-registered redirect uri. This change was originally put in place to support RFC 6819 and the upcoming OAuth 2.1 spec. However, it is preventing people from using the client credentials grant.

Because this is a behaviour change and the package has been behaving in the manner for some time, we are reinstating this behaviour and will push the change to v9 instead. 

This PR fixes issues raised by developers in issue #1161