### PR TITLE
Fix confusing auth behavior when used with a common .htaccess pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The server will now only recognise and handle an authorization header if the value of the header is non-empty. This is to circumvent issues where some common frameworks set this header even if no value is present (PR #1170)
+
 ## [8.2.3] - released 2020-12-02
 ### Added
 - Re-added support for PHP 7.2 (PR #1165, #1167)

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -334,13 +334,12 @@ class OAuthServerException extends Exception
         // respond with an HTTP 401 (Unauthorized) status code and
         // include the "WWW-Authenticate" response header field
         // matching the authentication scheme used by the client.
-        // @codeCoverageIgnoreStart
-        if ($this->errorType === 'invalid_client' && $this->serverRequest->hasHeader('Authorization') === true) {
+        if ($this->errorType === 'invalid_client' && $this->requestHasAuthorizationHeader()) {
             $authScheme = \strpos($this->serverRequest->getHeader('Authorization')[0], 'Bearer') === 0 ? 'Bearer' : 'Basic';
 
             $headers['WWW-Authenticate'] = $authScheme . ' realm="OAuth"';
         }
-        // @codeCoverageIgnoreEnd
+
         return $headers;
     }
 
@@ -385,5 +384,33 @@ class OAuthServerException extends Exception
     public function getHint()
     {
         return $this->hint;
+    }
+
+    /**
+     * Check if the request has a non-empty 'Authorization' header value.
+     *
+     * Returns true if the header is present and not an empty string, false
+     * otherwise.
+     *
+     * @return bool
+     */
+    private function requestHasAuthorizationHeader()
+    {
+        if (!$this->serverRequest->hasHeader('Authorization')) {
+            return false;
+        }
+
+        $authorizationHeader = $this->serverRequest->getHeader('Authorization');
+
+        // Common .htaccess configurations yield an empty string for the
+        // 'Authorization' header when one is not provided by the client.
+        // For practical purposes that case should be treated as though the
+        // header isn't present.
+        // See https://github.com/thephpleague/oauth2-server/issues/1162
+        if (empty($authorizationHeader) || empty($authorizationHeader[0])) {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
**Why:** It is common for .htaccess files - including the default one
provided by Drupal Core - to coerce the `Authorization` header to the
empty string if not specified by the client. Without this fix, that
results in a `WWW-Authenticate: Basic` header response which causes
the browser to show a useless basic authentication dialog.

For more info see https://github.com/thephpleague/oauth2-server/issues/1162