### PR TITLE
Throw OAuthServerException::invalidCredentials for password grant

### DIFF
--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -104,7 +104,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidCredentials();
         }
 
         return $user;

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -211,7 +211,7 @@ class PasswordGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(10);
+        $this->expectExceptionCode(6);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }


### PR DESCRIPTION
**Problem:**
When then user/password combination is incorrect, the exception thrown by the Password Grant is `OAuthServerException::invalidGrant()`

There is no way of knowing that the user/pass combination is incorrect. 
A temporary solution would be to directly throw `OAuthServerException::invalidCredentials()` from the UserRepository implementation in case the user is not found but the `RequestEvent::USER_AUTHENTICATION_FAILED` event is not emitted anymore.

**Solution:**
Change it to `OAuthServerException::invalidCredentials()`
