### PR TITLE
Useful error descriptions

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -157,16 +157,6 @@ class OAuthServerException extends Exception
     }
 
     /**
-     * Invalid credentials error.
-     *
-     * @return static
-     */
-    public static function invalidCredentials()
-    {
-        return new static('The user credentials were incorrect.', 6, 'invalid_credentials', 401);
-    }
-
-    /**
      * Server error.
      *
      * @param Throwable $previous

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -180,18 +180,6 @@ class OAuthServerException extends Exception
     }
 
     /**
-     * Invalid refresh token.
-     *
-     * @param Throwable   $previous
-     *
-     * @return static
-     */
-    public static function invalidRefreshToken(Throwable $previous = null)
-    {
-        return new static('The refresh token is invalid.', 8, 'invalid_grant', 400, null, $previous);
-    }
-
-    /**
      * Access denied.
      *
      * @param null|string $redirectUri
@@ -199,10 +187,10 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function accessDenied($redirectUri = null, Throwable $previous = null)
+    public static function accessDenied($errorMessage, $redirectUri = null, Throwable $previous = null)
     {
         return new static(
-            'The resource owner or authorization server denied the request.',
+            $errorMessage,
             9,
             'access_denied',
             401,
@@ -214,15 +202,20 @@ class OAuthServerException extends Exception
     /**
      * Invalid grant.
      *
+     * @param string    $errorMessage
+     * @param Throwable $previous
+     *
      * @return static
      */
-    public static function invalidGrant($message)
+    public static function invalidGrant($errorMessage, Throwable $previous)
     {
         return new static(
-            $message,
+            $errorMessage,
             10,
             'invalid_grant',
             400,
+            null,
+            $previous
         );
     }
 

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -207,7 +207,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function invalidGrant($errorMessage, Throwable $previous)
+    public static function invalidGrant($errorMessage, Throwable $previous = null)
     {
         return new static(
             $errorMessage,

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -146,15 +146,13 @@ class OAuthServerException extends Exception
     /**
      * Invalid scope error.
      *
-     * @param string      $scope       The bad scope
-     * @param null|string $redirectUri A HTTP URI to redirect the user back to
+     * @param string      $errorMessage The error message
+     * @param null|string $redirectUri  A HTTP URI to redirect the user back to
      *
      * @return static
      */
-    public static function invalidScope($scope, $redirectUri = null)
+    public static function invalidScope($errorMessage, $redirectUri = null)
     {
-        $errorMessage = 'The requested scope is invalid, unknown, or malformed';
-
         return new static($errorMessage, 5, 'invalid_scope', 400, $redirectUri);
     }
 

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -129,13 +129,14 @@ class OAuthServerException extends Exception
     /**
      * Invalid client error.
      *
+     * @param string                 $errorMessage
      * @param ServerRequestInterface $serverRequest
      *
      * @return static
      */
-    public static function invalidClient(ServerRequestInterface $serverRequest)
+    public static function invalidClient($errorMessage, ServerRequestInterface $serverRequest)
     {
-        $exception = new static('Client authentication failed', 4, 'invalid_client', 401);
+        $exception = new static($errorMessage, 4, 'invalid_client', 401);
 
         $exception->setServerRequest($serverRequest);
 

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -297,7 +297,10 @@ abstract class AbstractGrant implements GrantTypeInterface
             $scope = $this->scopeRepository->getScopeEntityByIdentifier($scopeItem);
 
             if ($scope instanceof ScopeEntityInterface === false) {
-                throw OAuthServerException::invalidScope($scopeItem, $redirectUri);
+                throw OAuthServerException::invalidScope(
+                    $scopeItem . ' is not a recognised scope identifier',
+                    $redirectUri
+                );
             }
 
             $validScopes[] = $scope;

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -239,7 +239,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
 
         if (\is_null($clientId)) {
-            throw OAuthServerException::invalidRequest('client_id');
+            throw OAuthServerException::invalidRequest('client_id parameter is missing from the request');
         }
 
         $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -182,7 +182,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         if ($this->clientRepository->validateClient($clientId, $clientSecret, $this->getIdentifier()) === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('Client authentication failure', $request);
         }
 
         $client = $this->getClientEntityOrFail($clientId, $request);
@@ -218,7 +218,7 @@ abstract class AbstractGrant implements GrantTypeInterface
 
         if ($client instanceof ClientEntityInterface === false || empty($client->getRedirectUri())) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('Client instance could not be retrieved or client redirect_uri missing', $request);
         }
 
         return $client;
@@ -266,12 +266,12 @@ abstract class AbstractGrant implements GrantTypeInterface
             && (\strcmp($client->getRedirectUri(), $redirectUri) !== 0)
         ) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('Invalid redirect_uri provided', $request);
         } elseif (\is_array($client->getRedirectUri())
             && \in_array($redirectUri, $client->getRedirectUri(), true) === false
         ) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('Invalid redirect_uri provided', $request);
         }
     }
 

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -262,7 +262,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         } elseif (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('No redirect_uri to use with the request', $request);
         }
 
         $defaultClientRedirectUri = \is_array($client->getRedirectUri())

--- a/src/Grant/ClientCredentialsGrant.php
+++ b/src/Grant/ClientCredentialsGrant.php
@@ -37,7 +37,7 @@ class ClientCredentialsGrant extends AbstractGrant
         if (!$client->isConfidential()) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('The client is not confidential', $request);
         }
 
         // Validate request

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -133,7 +133,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         } elseif (\is_array($client->getRedirectUri()) && \count($client->getRedirectUri()) !== 1
             || empty($client->getRedirectUri())) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
-            throw OAuthServerException::invalidClient($request);
+            throw OAuthServerException::invalidClient('Could not find a redirect_uri to use with the request', $request);
         } else {
             $redirectUri = \is_array($client->getRedirectUri())
                 ? $client->getRedirectUri()[0]

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -121,7 +121,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         );
 
         if (\is_null($clientId)) {
-            throw OAuthServerException::invalidRequest('client_id');
+            throw OAuthServerException::invalidRequest('client_id parameter is missing from the request');
         }
 
         $client = $this->getClientEntityOrFail($clientId, $request);

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -88,13 +88,13 @@ class PasswordGrant extends AbstractGrant
         $username = $this->getRequestParameter('username', $request);
 
         if (\is_null($username)) {
-            throw OAuthServerException::invalidRequest('username');
+            throw OAuthServerException::invalidRequest('username parameter is missing from the request');
         }
 
         $password = $this->getRequestParameter('password', $request);
 
         if (\is_null($password)) {
-            throw OAuthServerException::invalidRequest('password');
+            throw OAuthServerException::invalidRequest('password parameter is missing from the request');
         }
 
         $user = $this->userRepository->getUserEntityByUserCredentials(

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -107,7 +107,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidGrant('Could not retrieve the user instance');
         }
 
         return $user;

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -57,7 +57,7 @@ class RefreshTokenGrant extends AbstractGrant
         // the request doesn't include any new scopes
         foreach ($scopes as $scope) {
             if (\in_array($scope->getIdentifier(), $oldRefreshToken['scopes'], true) === false) {
-                throw OAuthServerException::invalidScope($scope->getIdentifier());
+                throw OAuthServerException::invalidScope('Scope ' . $scope->getIdentifier() . ' cannot be granted');
             }
         }
 

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -95,7 +95,7 @@ class RefreshTokenGrant extends AbstractGrant
     {
         $encryptedRefreshToken = $this->getRequestParameter('refresh_token', $request);
         if (\is_null($encryptedRefreshToken)) {
-            throw OAuthServerException::invalidRequest('refresh_token');
+            throw OAuthServerException::invalidRequest('refresh_token parameter is missing from the request');
         }
 
         // Validate refresh token

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -102,21 +102,21 @@ class RefreshTokenGrant extends AbstractGrant
         try {
             $refreshToken = $this->decrypt($encryptedRefreshToken);
         } catch (Exception $e) {
-            throw OAuthServerException::invalidRefreshToken('Cannot decrypt the refresh token', $e);
+            throw OAuthServerException::invalidGrant('Cannot decrypt the refresh token', $e);
         }
 
         $refreshTokenData = \json_decode($refreshToken, true);
         if ($refreshTokenData['client_id'] !== $clientId) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::REFRESH_TOKEN_CLIENT_FAILED, $request));
-            throw OAuthServerException::invalidRefreshToken('Token is not linked to client');
+            throw OAuthServerException::invalidGrant('Refresh token is not linked to given client');
         }
 
         if ($refreshTokenData['expire_time'] < \time()) {
-            throw OAuthServerException::invalidRefreshToken('Token has expired');
+            throw OAuthServerException::invalidGrant('Refresh token has expired');
         }
 
         if ($this->refreshTokenRepository->isRefreshTokenRevoked($refreshTokenData['refresh_token_id']) === true) {
-            throw OAuthServerException::invalidRefreshToken('Token has been revoked');
+            throw OAuthServerException::invalidGrant('Refresh token has been revoked');
         }
 
         return $refreshTokenData;

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -92,7 +92,7 @@ class OAuthServerExceptionTest extends TestCase
 
     public function testDoesNotHavePrevious()
     {
-        $exceptionWithoutPrevious = OAuthServerException::accessDenied();
+        $exceptionWithoutPrevious = OAuthServerException::accessDenied('Generic error message');
 
         $this->assertNull($exceptionWithoutPrevious->getPrevious());
     }

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -1131,7 +1131,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals('Authorization code malformed', $e->getHint());
+            $this->assertEquals('The auth_code_id property is missing from the auth code', $e->getMessage());
         }
     }
 
@@ -1184,7 +1184,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Authorization code has expired');
+            $this->assertEquals('Authorization code has expired', $e->getMessage());
         }
     }
 
@@ -1248,8 +1248,8 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Authorization code has been revoked');
-            $this->assertEquals($e->getErrorType(), 'invalid_grant');
+            $this->assertEquals('Authorization code has been revoked', $e->getMessage());
+            $this->assertEquals('invalid_grant', $e->getErrorType());
         }
     }
 
@@ -1310,7 +1310,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Authorization code was not issued to this client');
+            $this->assertEquals('Authorization code was not issued to this client', $e->getMessage());
         }
     }
 
@@ -1360,7 +1360,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Cannot decrypt the authorization code');
+            $this->assertEquals('Cannot decrypt the authorization code', $e->getMessage());
         }
     }
 
@@ -1433,7 +1433,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Failed to verify `code_verifier`.');
+            $this->assertEquals('Failed to verify `code_verifier`.', $e->getMessage());
         }
     }
 
@@ -1506,7 +1506,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Code Verifier must follow the specifications of RFC-7636.');
+            $this->assertEquals('The code_verifier contains illegal characters', $e->getMessage());
         }
     }
 
@@ -1579,7 +1579,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Code Verifier must follow the specifications of RFC-7636.');
+            $this->assertEquals('The code_verifier contains illegal characters', $e->getMessage());
         }
     }
 
@@ -1652,7 +1652,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Code Verifier must follow the specifications of RFC-7636.');
+            $this->assertEquals('The code_verifier contains illegal characters', $e->getMessage());
         }
     }
 
@@ -1724,7 +1724,7 @@ class AuthCodeGrantTest extends TestCase
             /* @var StubResponseType $response */
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
-            $this->assertEquals($e->getHint(), 'Check the `code_verifier` parameter');
+            $this->assertEquals('The code_verifier is missing', $e->getMessage());
         }
     }
 
@@ -1771,7 +1771,7 @@ class AuthCodeGrantTest extends TestCase
 
         $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
         $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
-        $authCodeRepository->method('persistNewAuthCode')->willThrowException(OAuthServerException::serverError('something bad happened'));
+        $authCodeRepository->method('persistNewAuthCode')->willThrowException(OAuthServerException::serverError());
 
         $grant = new AuthCodeGrant(
             $authCodeRepository,
@@ -1907,7 +1907,7 @@ class AuthCodeGrantTest extends TestCase
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
-        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willThrowException(OAuthServerException::serverError('something bad happened'));
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willThrowException(OAuthServerException::serverError());
 
         $grant = new AuthCodeGrant(
             $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -310,7 +310,7 @@ class ImplicitGrantTest extends TestCase
         /** @var AccessTokenRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject $accessTokenRepositoryMock */
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
-        $accessTokenRepositoryMock->method('persistNewAccessToken')->willThrowException(OAuthServerException::serverError('something bad happened'));
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willThrowException(OAuthServerException::serverError());
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
         $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -327,7 +327,7 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(8);
+        $this->expectExceptionCode(10);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }
@@ -375,7 +375,7 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(8);
+        $this->expectExceptionCode(10);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }
@@ -420,7 +420,7 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(8);
+        $this->expectExceptionCode(10);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }
@@ -466,7 +466,7 @@ class RefreshTokenGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(8);
+        $this->expectExceptionCode(10);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }

--- a/tests/Middleware/AuthorizationServerMiddlewareTest.php
+++ b/tests/Middleware/AuthorizationServerMiddlewareTest.php
@@ -110,7 +110,7 @@ class AuthorizationServerMiddlewareTest extends TestCase
 
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals(
-            'http://foo/bar?error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
+            'http://foo/bar?error=invalid_scope&error_description=test&message=test',
             $response->getHeader('location')[0]
         );
     }
@@ -122,7 +122,7 @@ class AuthorizationServerMiddlewareTest extends TestCase
 
         $this->assertEquals(302, $response->getStatusCode());
         $this->assertEquals(
-            'http://foo/bar#error=invalid_scope&error_description=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed&hint=Check+the+%60test%60+scope&message=The+requested+scope+is+invalid%2C+unknown%2C+or+malformed',
+            'http://foo/bar#error=invalid_scope&error_description=test&message=test',
             $response->getHeader('location')[0]
         );
     }

--- a/tests/ResourceServerTest.php
+++ b/tests/ResourceServerTest.php
@@ -21,7 +21,7 @@ class ResourceServerTest extends TestCase
         try {
             $server->validateAuthenticatedRequest(ServerRequestFactory::fromGlobals());
         } catch (OAuthServerException $e) {
-            $this->assertEquals('Missing "Authorization" header', $e->getHint());
+            $this->assertEquals('Missing "Authorization" header', $e->getMessage());
         }
     }
 }

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -191,7 +191,7 @@ class BearerResponseTypeTest extends TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals(
                 'Access token could not be verified',
-                $e->getHint()
+                $e->getMessage()
             );
         }
     }
@@ -236,7 +236,7 @@ class BearerResponseTypeTest extends TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals(
                 'Access token has been revoked',
-                $e->getHint()
+                $e->getMessage()
             );
         }
     }
@@ -259,7 +259,7 @@ class BearerResponseTypeTest extends TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals(
                 'The JWT string must have two dots',
-                $e->getHint()
+                $e->getMessage()
             );
         }
     }
@@ -282,7 +282,7 @@ class BearerResponseTypeTest extends TestCase
         } catch (OAuthServerException $e) {
             $this->assertEquals(
                 'Error while decoding from JSON',
-                $e->getHint()
+                $e->getMessage()
             );
         }
     }


### PR DESCRIPTION
This PR removes the hints from the OAuthException class and instead, provides more useful error messages in the default exception error message.