### PR TITLE
Remove Message Response from Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The authorization server can now finalize scopes when a client uses a refresh token (PR #1094)
 - An AuthorizationRequestInterface to make it easier to extend the AuthorizationRequest (PR #1110)
 
-### Fixed (v9)
-- If a refresh token has expired, been revoked, cannot be decrypted, or does not belong to the correct client, the server will now issue an `invalid_grant` error and a HTTP 400 response. In previous versions the server incorrectly issued an `invalid_request` and HTTP 401 response (PR #1042) (PR #1082)
-
 ### Changed (v9)
 - Authorization Request objects are now created through the factory method, `createAuthorizationRequest()` (PR #1111)
 - Changed parameters for `finalizeScopes()` to allow a reference to an auth code ID (PR #1112)
 
+### Removed (v9)
+- Removed message property from OAuthException HTTP response. Now just use error_description as per the OAuth 2 spec (PR #XXXX)
+
+### Fixed (v9)
+- If a refresh token has expired, been revoked, cannot be decrypted, or does not belong to the correct client, the server will now issue an `invalid_grant` error and a HTTP 400 response. In previous versions the server incorrectly issued an `invalid_request` and HTTP 401 response (PR #1042) (PR #1082)
 
 ## [8.2.3] - released 2020-12-02
 ### Added

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -80,15 +80,7 @@ class OAuthServerException extends Exception
      */
     public function getPayload()
     {
-        $payload = $this->payload;
-
-        // The "message" property is deprecated and replaced by "error_description"
-        // TODO: remove "message" property
-        if (isset($payload['error_description']) && !isset($payload['message'])) {
-            $payload['message'] = $payload['error_description'];
-        }
-
-        return $payload;
+        return $this->payload;
     }
 
     /**

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -47,6 +47,11 @@ class OAuthServerException extends Exception
     private $serverRequest;
 
     /**
+     * @var string
+     */
+    private $state;
+
+    /**
      * Throw a new exception.
      *
      * @param string      $message        Error message
@@ -55,19 +60,24 @@ class OAuthServerException extends Exception
      * @param int         $httpStatusCode HTTP status code to send (default = 400)
      * @param null|string $hint           A helper hint
      * @param null|string $redirectUri    A HTTP URI to redirect the user back to
+     * @param null|string $state          The state parameter from the original request
      * @param Throwable   $previous       Previous exception
      */
-    public function __construct($message, $code, $errorType, $httpStatusCode = 400, $hint = null, $redirectUri = null, Throwable $previous = null)
+    public function __construct($message, $code, $errorType, $httpStatusCode = 400, $hint = null, $redirectUri = null, $state = null, Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
+
         $this->httpStatusCode = $httpStatusCode;
         $this->errorType = $errorType;
         $this->hint = $hint;
+        $this->state = $state;
         $this->redirectUri = $redirectUri;
         $this->payload = [
             'error'             => $errorType,
             'error_description' => $message,
+            'state'             => $state,
         ];
+
         if ($hint !== null) {
             $this->payload['hint'] = $hint;
         }


### PR DESCRIPTION
In previous versions of the server, we used to write error descriptions in a "message" parameter on the JSON payload instead of an "error_description" parameter.

This was changed in recent versions but the message parameter was left in for backwards compatibility. This PR removes this BC hack.