### PR TITLE
Fix wrong cmd to gen private key with passphrase

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -31,7 +31,7 @@ openssl genrsa -out private.key 2048
 If you want to provide a passphrase for your private key run this command instead:
 
 ~~~ shell
-openssl genrsa -passout pass:_passphrase_ -out private.key 2048
+openssl genrsa -aes128 -passout pass:_passphrase_ -out private.key 2048
 ~~~
 
 then extract the public key from the private key:


### PR DESCRIPTION
To generate a private key with passphrase an encryption must be specified `-aes128`. Otherwise a key without passphrase will be created and no error will occur. The stupid thing is that the PHP code does not throw an error if you specify a passphrase for a private key without passphrase. Therefore no one notices the error.