### PR TITLE
Use key as string without a temporary file

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -77,7 +77,10 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             \class_exists(StrictValidAt::class)
                 ? new StrictValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get())))
                 : new ValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get()))),
-            new SignedWith(new Sha256(), $this->publicKey->getKey())
+            new SignedWith(
+                new Sha256(),
+                InMemory::plainText($this->publicKey->getKeyContents(), $this->publicKey->getPassPhrase() ?? ''),
+            )
         );
     }
 

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -79,7 +79,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
                 : new ValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get()))),
             new SignedWith(
                 new Sha256(),
-                InMemory::plainText($this->publicKey->getKeyContents(), $this->publicKey->getPassPhrase() ?? ''),
+                InMemory::plainText($this->publicKey->getKeyContents(), $this->publicKey->getPassPhrase() ?? '')
             )
         );
     }

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -13,7 +13,6 @@ use DateTimeZone;
 use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\Constraint\StrictValidAt;

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -78,7 +78,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             \class_exists(StrictValidAt::class)
                 ? new StrictValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get())))
                 : new ValidAt(new SystemClock(new DateTimeZone(\date_default_timezone_get()))),
-            new SignedWith(new Sha256(), LocalFileReference::file($this->publicKey->getKeyPath()))
+            new SignedWith(new Sha256(), $this->publicKey->getKey())
         );
     }
 

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -54,7 +54,7 @@ class CryptKey
             $this->keyPath = '';
             // There's no file, so no need for permission check.
             $keyPermissionsCheck = false;
-        } else if (\is_file($keyPath)) {
+        } elseif (\is_file($keyPath)) {
             if (\strpos($keyPath, self::FILE_PREFIX) !== 0) {
                 $keyPath = self::FILE_PREFIX . $keyPath;
             }
@@ -66,11 +66,11 @@ class CryptKey
             $this->keyPath = $keyPath;
             $this->key = LocalFileReference::file($this->keyPath, $this->passPhrase ?? '');
             if (!$this->isValidKey($contents, $this->passPhrase ?? '')) {
-               throw new LogicException('Unable to read key from file ' . $keyPath);
+                throw new LogicException('Unable to read key from file ' . $keyPath);
             }
         }
         else {
-           throw new LogicException('Unable to read key from file ' . $keyPath);
+            throw new LogicException('Unable to read key from file ' . $keyPath);
         }
 
         if ($keyPermissionsCheck === true) {

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -49,11 +49,11 @@ class CryptKey
         $this->passPhrase = $passPhrase;
 
         if (\strpos($keyPath, self::FILE_PREFIX) !== 0 && $this->isValidKey($keyPath, $this->passPhrase ?? '')) {
-          $contents = $keyPath;
-          $this->key = InMemory::plainText($keyPath, $this->passPhrase ?? '');
-          $this->keyPath = '';
-          // There's no file, so no need for permission check.
-          $keyPermissionsCheck = false;
+            $contents = $keyPath;
+            $this->key = InMemory::plainText($keyPath, $this->passPhrase ?? '');
+            $this->keyPath = '';
+            // There's no file, so no need for permission check.
+            $keyPermissionsCheck = false;
         } else if (\is_file($keyPath)) {
             if (\strpos($keyPath, self::FILE_PREFIX) !== 0) {
                 $keyPath = self::FILE_PREFIX . $keyPath;
@@ -66,11 +66,12 @@ class CryptKey
             $this->keyPath = $keyPath;
             $this->key = LocalFileReference::file($this->keyPath, $this->passPhrase ?? '');
             if (!$this->isValidKey($contents, $this->passPhrase ?? '')) {
-              throw new LogicException('Unable to read key from file ' . $keyPath);
+               throw new LogicException('Unable to read key from file ' . $keyPath);
             }
         }
-        else
+        else {
            throw new LogicException('Unable to read key from file ' . $keyPath);
+        }
 
         if ($keyPermissionsCheck === true) {
             // Verify the permissions of the key

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -68,8 +68,7 @@ class CryptKey
             if (!$this->isValidKey($contents, $this->passPhrase ?? '')) {
                 throw new LogicException('Unable to read key from file ' . $keyPath);
             }
-        }
-        else {
+        } else {
             throw new LogicException('Unable to read key from file ' . $keyPath);
         }
 

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -14,7 +14,6 @@ namespace League\OAuth2\Server;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
-
 use LogicException;
 
 class CryptKey

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -11,9 +11,6 @@
 
 namespace League\OAuth2\Server;
 
-use Lcobucci\JWT\Signer\Key;
-use Lcobucci\JWT\Signer\Key\InMemory;
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use LogicException;
 
 class CryptKey
@@ -25,9 +22,9 @@ class CryptKey
     private const FILE_PREFIX = 'file://';
 
     /**
-     * @var Key
+     * @var string Key contents
      */
-    protected $key;
+    protected $keyContents;
 
     /**
      * @var string
@@ -49,8 +46,7 @@ class CryptKey
         $this->passPhrase = $passPhrase;
 
         if (\strpos($keyPath, self::FILE_PREFIX) !== 0 && $this->isValidKey($keyPath, $this->passPhrase ?? '')) {
-            $contents = $keyPath;
-            $this->key = InMemory::plainText($keyPath, $this->passPhrase ?? '');
+            $this->keyContents = $keyPath;
             $this->keyPath = '';
             // There's no file, so no need for permission check.
             $keyPermissionsCheck = false;
@@ -62,10 +58,9 @@ class CryptKey
             if (!\is_readable($keyPath)) {
                 throw new LogicException(\sprintf('Key path "%s" does not exist or is not readable', $keyPath));
             }
-            $contents = \file_get_contents($keyPath);
+            $this->keyContents = \file_get_contents($keyPath);
             $this->keyPath = $keyPath;
-            $this->key = LocalFileReference::file($this->keyPath, $this->passPhrase ?? '');
-            if (!$this->isValidKey($contents, $this->passPhrase ?? '')) {
+            if (!$this->isValidKey($this->keyContents, $this->passPhrase ?? '')) {
                 throw new LogicException('Unable to read key from file ' . $keyPath);
             }
         } else {
@@ -89,13 +84,13 @@ class CryptKey
     }
 
     /**
-     * Get key
+     * Get key contents
      *
-     * @return Key
+     * @return string Key contents
      */
-    public function getKey(): Key
+    public function getKeyContents(): string
     {
-        return $this->key;
+        return $this->keyContents;
     }
 
     /**

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -45,7 +45,7 @@ trait AccessTokenTrait
     {
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
-            $this->privateKey->getKey(),
+            InMemory::plainText($this->privateKey->getKeyContents(), $this->privateKey->getPassPhrase() ?? ''),
             InMemory::plainText('')
         );
     }

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,7 @@ trait AccessTokenTrait
     {
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
-            LocalFileReference::file($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase() ?? ''),
+            $this->privateKey->getKey(),
             InMemory::plainText('')
         );
     }

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -12,7 +12,6 @@ namespace League\OAuth2\Server\Entities\Traits;
 use DateTimeImmutable;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token;
 use League\OAuth2\Server\CryptKey;

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -35,7 +35,7 @@ class CryptKeyTest extends TestCase
 
         $this->assertEquals(
             $keyContent,
-            $key->getKey()->contents()
+            $key->getKeyContents()
         );
 
         $keyContent = \file_get_contents(__DIR__ . '/../Stubs/private.key.crlf');
@@ -48,7 +48,7 @@ class CryptKeyTest extends TestCase
 
         $this->assertEquals(
             $keyContent,
-            $key->getKey()->contents()
+            $key->getKeyContents()
         );
     }
 

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -23,7 +23,7 @@ class CryptKeyTest extends TestCase
         $this->assertEquals('secret', $key->getPassPhrase());
     }
 
-    public function testKeyFileCreation()
+    public function testKeyString()
     {
         $keyContent = \file_get_contents(__DIR__ . '/../Stubs/public.key');
 
@@ -33,7 +33,10 @@ class CryptKeyTest extends TestCase
 
         $key = new CryptKey($keyContent);
 
-        $this->assertEquals(self::generateKeyPath($keyContent), $key->getKeyPath());
+        $this->assertEquals(
+            $keyContent,
+            $key->getKey()->contents()
+        );
 
         $keyContent = \file_get_contents(__DIR__ . '/../Stubs/private.key.crlf');
 
@@ -43,7 +46,10 @@ class CryptKeyTest extends TestCase
 
         $key = new CryptKey($keyContent);
 
-        $this->assertEquals(self::generateKeyPath($keyContent), $key->getKeyPath());
+        $this->assertEquals(
+            $keyContent,
+            $key->getKey()->contents()
+        );
     }
 
     public function testUnsupportedKeyType()
@@ -83,9 +89,8 @@ class CryptKeyTest extends TestCase
             \openssl_pkey_export($res, $keyContent, 'mystrongpassword');
 
             $key = new CryptKey($keyContent, 'mystrongpassword');
-            $path = self::generateKeyPath($keyContent);
 
-            $this->assertEquals($path, $key->getKeyPath());
+            $this->assertEquals('', $key->getKeyPath());
             $this->assertEquals('mystrongpassword', $key->getPassPhrase());
         } catch (\Throwable $e) {
             $this->fail('The EC key was not created');
@@ -109,9 +114,8 @@ class CryptKeyTest extends TestCase
             \openssl_pkey_export($res, $keyContent, 'mystrongpassword');
 
             $key = new CryptKey($keyContent, 'mystrongpassword');
-            $path = self::generateKeyPath($keyContent);
 
-            $this->assertEquals($path, $key->getKeyPath());
+            $this->assertEquals('', $key->getKeyPath());
             $this->assertEquals('mystrongpassword', $key->getPassPhrase());
         } catch (\Throwable $e) {
             $this->fail('The RSA key was not created');


### PR DESCRIPTION
- Addresses thephpleague/oauth2-server#1007
- This allows you to use a private key from a string without writing to a temporary file.  For security reasons, I'd rather not have the key written to disk on the server.