### PR TITLE
Add switch to prevent revoking of refresh tokens.

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -82,7 +82,7 @@ class AuthorizationServer implements EmitterAwareInterface
     /**
      * @var bool
      */
-    private $revokeRefreshTokens;
+    private $revokeRefreshTokens = true;
 
     /**
      * New server instance.
@@ -93,7 +93,6 @@ class AuthorizationServer implements EmitterAwareInterface
      * @param CryptKey|string                $privateKey
      * @param string|Key                     $encryptionKey
      * @param null|ResponseTypeInterface     $responseType
-     * @param bool                           $revokeRefreshTokens
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,
@@ -101,8 +100,7 @@ class AuthorizationServer implements EmitterAwareInterface
         ScopeRepositoryInterface $scopeRepository,
         $privateKey,
         $encryptionKey,
-        ResponseTypeInterface $responseType = null,
-        bool $revokeRefreshTokens = true
+        ResponseTypeInterface $responseType = null
     ) {
         $this->clientRepository = $clientRepository;
         $this->accessTokenRepository = $accessTokenRepository;
@@ -122,7 +120,6 @@ class AuthorizationServer implements EmitterAwareInterface
         }
 
         $this->responseType = $responseType;
-        $this->revokeRefreshTokens = $revokeRefreshTokens;
     }
 
     /**
@@ -241,5 +238,15 @@ class AuthorizationServer implements EmitterAwareInterface
     public function setDefaultScope($defaultScope)
     {
         $this->defaultScope = $defaultScope;
+    }
+
+    /**
+     * Sets wether to revoke refresh tokens or not (for all grant types).
+     *
+     * @param bool $revokeRefreshTokens
+     */
+    public function setRevokeRefreshTokens(bool $revokeRefreshTokens): void
+    {
+        $this->revokeRefreshTokens = $revokeRefreshTokens;
     }
 }

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -80,6 +80,11 @@ class AuthorizationServer implements EmitterAwareInterface
     private $defaultScope = '';
 
     /**
+     * @var bool
+     */
+    private $revokeRefreshTokens;
+
+    /**
      * New server instance.
      *
      * @param ClientRepositoryInterface      $clientRepository
@@ -88,6 +93,7 @@ class AuthorizationServer implements EmitterAwareInterface
      * @param CryptKey|string                $privateKey
      * @param string|Key                     $encryptionKey
      * @param null|ResponseTypeInterface     $responseType
+     * @param bool                           $revokeRefreshTokens
      */
     public function __construct(
         ClientRepositoryInterface $clientRepository,
@@ -95,7 +101,8 @@ class AuthorizationServer implements EmitterAwareInterface
         ScopeRepositoryInterface $scopeRepository,
         $privateKey,
         $encryptionKey,
-        ResponseTypeInterface $responseType = null
+        ResponseTypeInterface $responseType = null,
+        bool $revokeRefreshTokens = true
     ) {
         $this->clientRepository = $clientRepository;
         $this->accessTokenRepository = $accessTokenRepository;
@@ -115,6 +122,7 @@ class AuthorizationServer implements EmitterAwareInterface
         }
 
         $this->responseType = $responseType;
+        $this->revokeRefreshTokens = $revokeRefreshTokens;
     }
 
     /**
@@ -136,6 +144,7 @@ class AuthorizationServer implements EmitterAwareInterface
         $grantType->setPrivateKey($this->privateKey);
         $grantType->setEmitter($this->getEmitter());
         $grantType->setEncryptionKey($this->encryptionKey);
+        $grantType->setRevokeRefreshTokens($this->revokeRefreshTokens);
 
         $this->enabledGrantTypes[$grantType->getIdentifier()] = $grantType;
         $this->grantTypeAccessTokenTTL[$grantType->getIdentifier()] = $accessTokenTTL;

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -93,6 +93,11 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected $defaultScope;
 
     /**
+     * @var bool
+     */
+    protected $revokeRefreshTokens;
+
+    /**
      * @param ClientRepositoryInterface $clientRepository
      */
     public function setClientRepository(ClientRepositoryInterface $clientRepository)
@@ -167,6 +172,14 @@ abstract class AbstractGrant implements GrantTypeInterface
     }
 
     /**
+     * @param bool $revokeRefreshTokens
+     */
+    public function setRevokeRefreshTokens(bool $revokeRefreshTokens)
+    {
+        $this->revokeRefreshTokens = $revokeRefreshTokens;
+    }
+
+    /**
      * Validate the client.
      *
      * @param ServerRequestInterface $request
@@ -177,7 +190,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      */
     protected function validateClient(ServerRequestInterface $request)
     {
-        list($clientId, $clientSecret) = $this->getClientCredentials($request);
+        [$clientId, $clientSecret] = $this->getClientCredentials($request);
 
         if ($this->clientRepository->validateClient($clientId, $clientSecret, $this->getIdentifier()) === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::CLIENT_AUTHENTICATION_FAILED, $request));
@@ -234,7 +247,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      */
     protected function getClientCredentials(ServerRequestInterface $request)
     {
-        list($basicAuthUser, $basicAuthPassword) = $this->getBasicAuthCredentials($request);
+        [$basicAuthUser, $basicAuthPassword] = $this->getBasicAuthCredentials($request);
 
         $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
 

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -141,11 +141,4 @@ interface GrantTypeInterface extends EmitterAwareInterface
      * @param string|Key|null $key
      */
     public function setEncryptionKey($key = null);
-
-    /**
-     * Enables ability to prevent refresh tokens from being revoked.
-     *
-     * @param bool $revokeRefreshTokens
-     */
-    public function setRevokeRefreshTokens(bool $revokeRefreshTokens);
 }

--- a/src/Grant/GrantTypeInterface.php
+++ b/src/Grant/GrantTypeInterface.php
@@ -141,4 +141,11 @@ interface GrantTypeInterface extends EmitterAwareInterface
      * @param string|Key|null $key
      */
     public function setEncryptionKey($key = null);
+
+    /**
+     * Enables ability to prevent refresh tokens from being revoked.
+     *
+     * @param bool $revokeRefreshTokens
+     */
+    public function setRevokeRefreshTokens(bool $revokeRefreshTokens);
 }

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -79,7 +79,7 @@ class RefreshTokenGrant extends AbstractGrant
             $refreshToken = $this->issueRefreshToken($accessToken);
 
             if ($refreshToken !== null) {
-            $this->getEmitter()->emit(new RequestRefreshTokenEvent(RequestEvent::REFRESH_TOKEN_ISSUED, $request, $refreshToken));
+                $this->getEmitter()->emit(new RequestRefreshTokenEvent(RequestEvent::REFRESH_TOKEN_ISSUED, $request, $refreshToken));
                 $responseType->setRefreshToken($refreshToken);
             }
         }

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -63,7 +63,9 @@ class RefreshTokenGrant extends AbstractGrant
 
         // Expire old tokens
         $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
-        $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
+        if ($this->revokeRefreshTokens) {
+            $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
+        }
 
         // Issue and persist new access token
         $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $oldRefreshToken['user_id'], $scopes);
@@ -71,11 +73,13 @@ class RefreshTokenGrant extends AbstractGrant
         $responseType->setAccessToken($accessToken);
 
         // Issue and persist new refresh token if given
-        $refreshToken = $this->issueRefreshToken($accessToken);
+        if ($this->revokeRefreshTokens) {
+            $refreshToken = $this->issueRefreshToken($accessToken);
 
-        if ($refreshToken !== null) {
-            $this->getEmitter()->emit(new RequestEvent(RequestEvent::REFRESH_TOKEN_ISSUED, $request));
-            $responseType->setRefreshToken($refreshToken);
+            if ($refreshToken !== null) {
+                $this->getEmitter()->emit(new RequestEvent(RequestEvent::REFRESH_TOKEN_ISSUED, $request));
+                $responseType->setRefreshToken($refreshToken);
+            }
         }
 
         return $responseType;

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -18,6 +18,7 @@ use LeagueTests\Stubs\CryptTraitStub;
 use LeagueTests\Stubs\RefreshTokenEntity;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
 class RefreshTokenGrantTest extends TestCase
@@ -468,5 +469,119 @@ class RefreshTokenGrantTest extends TestCase
         $this->expectExceptionCode(8);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
+    }
+
+    public function testRevokedRefreshToken()
+    {
+        $refreshTokenId = 'foo';
+
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeEntity = new ScopeEntity();
+        $scopeEntity->setIdentifier('foo');
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
+        $accessTokenRepositoryMock->expects($this->once())->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('isRefreshTokenRevoked')
+             ->will($this->onConsecutiveCalls(false, true));
+        $refreshTokenRepositoryMock->expects($this->once())->method('revokeRefreshToken')->with($this->equalTo($refreshTokenId));
+
+        $oldRefreshToken = $this->cryptStub->doEncrypt(
+            \json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => $refreshTokenId,
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => \time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = (new ServerRequest())->withParsedBody([
+            'client_id'     => 'foo',
+            'client_secret' => 'bar',
+            'refresh_token' => $oldRefreshToken,
+            'scope'         => ['foo'],
+        ]);
+
+        $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+        $grant->setRevokeRefreshTokens(true);
+        $grant->respondToAccessTokenRequest($serverRequest, new StubResponseType(), new DateInterval('PT5M'));
+
+        Assert::assertTrue($refreshTokenRepositoryMock->isRefreshTokenRevoked($refreshTokenId));
+    }
+
+    public function testUnrevokedRefreshToken()
+    {
+        $refreshTokenId = 'foo';
+
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri('http://foo/bar');
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeEntity = new ScopeEntity();
+        $scopeEntity->setIdentifier('foo');
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
+        $accessTokenRepositoryMock->expects($this->once())->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('isRefreshTokenRevoked')->willReturn(false);
+        $refreshTokenRepositoryMock->expects($this->never())->method('revokeRefreshToken');
+
+        $oldRefreshToken = $this->cryptStub->doEncrypt(
+            \json_encode(
+                [
+                    'client_id'        => 'foo',
+                    'refresh_token_id' => $refreshTokenId,
+                    'access_token_id'  => 'abcdef',
+                    'scopes'           => ['foo'],
+                    'user_id'          => 123,
+                    'expire_time'      => \time() + 3600,
+                ]
+            )
+        );
+
+        $serverRequest = (new ServerRequest())->withParsedBody([
+            'client_id'     => 'foo',
+            'client_secret' => 'bar',
+            'refresh_token' => $oldRefreshToken,
+            'scope'         => ['foo'],
+        ]);
+
+        $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+        $grant->respondToAccessTokenRequest($serverRequest, new StubResponseType(), new DateInterval('PT5M'));
+
+        Assert::assertFalse($refreshTokenRepositoryMock->isRefreshTokenRevoked($refreshTokenId));
     }
 }

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -68,6 +68,7 @@ class RefreshTokenGrantTest extends TestCase
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+        $grant->setRevokeRefreshTokens(true);
 
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             \json_encode(
@@ -181,6 +182,7 @@ class RefreshTokenGrantTest extends TestCase
         $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+        $grant->setRevokeRefreshTokens(true);
 
         $oldRefreshToken = $this->cryptStub->doEncrypt(
             \json_encode(


### PR DESCRIPTION
Hi,
Recently we (my colleagues and i) came across a specific use case in our software which uses oauth2-server where we needed to prevent refresh tokens to be revoked after requesting a new access token. We looked at the ouath rfc and read that this behaviour is allowed according to the spec. I've gone ahead and implemented the change in this pull request. See below for references to the specific information on refresh tokens in the rfc.

According to [section 1.5](https://tools.ietf.org/html/rfc6749#section-1.5), issuing a new refresh token is optional (see step H).
Also according to [section 4.1](https://tools.ietf.org/html/rfc6749#section-4.1) which describes the authorization code grant type, the refresh token is optional (see step E).
Finally according to [section 6](https://tools.ietf.org/html/rfc6749#section-6) (Refreshing an Access token), in the last paragraph it states that the server MAY issue a new refresh token.
And also states that the server MAY revoke the old refresh token.

Hoping someone can take a look at this, any suggestions and/or feedback, would be much appreciated! 
