### PR TITLE
Separation of token parsing and validation

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -12,12 +12,9 @@ namespace League\OAuth2\Server\AuthorizationValidators;
 use DateTimeZone;
 use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Encoding\CannotDecodeContent;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
-use Lcobucci\JWT\Token\InvalidTokenStructure;
-use Lcobucci\JWT\Token\UnsupportedHeaderFound;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\Constraint\ValidAt;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -95,18 +92,18 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
         $jwt = \trim((string) \preg_replace('/^(?:\s+)?Bearer\s/', '', $header[0]));
 
         try {
-            // Attempt to parse and validate the JWT
+            // Attempt to parse the JWT
             $token = $this->jwtConfiguration->parser()->parse($jwt);
-
-            $constraints = $this->jwtConfiguration->validationConstraints();
-
-            try {
-                $this->jwtConfiguration->validator()->assert($token, ...$constraints);
-            } catch (RequiredConstraintsViolated $exception) {
-                throw OAuthServerException::accessDenied('Access token could not be verified');
-            }
-        } catch (CannotDecodeContent | InvalidTokenStructure | UnsupportedHeaderFound $exception) {
+        } catch (\Lcobucci\JWT\Exception $exception) {
             throw OAuthServerException::accessDenied($exception->getMessage(), null, $exception);
+        }
+
+        try {
+            // Attempt to validate the JWT
+            $constraints = $this->jwtConfiguration->validationConstraints();
+            $this->jwtConfiguration->validator()->assert($token, ...$constraints);
+        } catch (RequiredConstraintsViolated $exception) {
+            throw OAuthServerException::accessDenied('Access token could not be verified');
         }
 
         $claims = $token->claims();

--- a/tests/ResponseTypes/BearerResponseTypeTest.php
+++ b/tests/ResponseTypes/BearerResponseTypeTest.php
@@ -166,7 +166,7 @@ class BearerResponseTypeTest extends TestCase
         $accessToken = new AccessTokenEntity();
         $accessToken->setIdentifier('abcdef');
         $accessToken->setUserIdentifier(123);
-        $accessToken->setExpiryDateTime((new DateTimeImmutable())->add(new DateInterval('PT1H')));
+        $accessToken->setExpiryDateTime((new DateTimeImmutable())->sub(new DateInterval('PT1H')));
         $accessToken->setClient($client);
         $accessToken->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
 
@@ -184,7 +184,7 @@ class BearerResponseTypeTest extends TestCase
         $authorizationValidator = new BearerTokenValidator($accessTokenRepositoryMock);
         $authorizationValidator->setPublicKey(new CryptKey('file://' . __DIR__ . '/../Stubs/public.key'));
 
-        $request = (new ServerRequest())->withHeader('authorization', \sprintf('Bearer %s', $json->access_token . 'foo'));
+        $request = (new ServerRequest())->withHeader('authorization', \sprintf('Bearer %s', $json->access_token));
 
         try {
             $authorizationValidator->validateAuthorization($request);


### PR DESCRIPTION
Fixes #1197

Test `testDetermineAccessTokenInHeaderInvalidJWT` asserts only on validation error. Parse errors will be catched by test `testDetermineAccessTokenInHeaderInvalidToken`.