### PR TITLE
Change visibility of `AuthCodeGrant::validateAuthorizationCode()` (#1199)

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -185,8 +185,10 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      * @param stdClass               $authCodePayload
      * @param ClientEntityInterface  $client
      * @param ServerRequestInterface $request
+     *
+     * @throws OAuthServerException
      */
-    private function validateAuthorizationCode(
+    protected function validateAuthorizationCode(
         $authCodePayload,
         ClientEntityInterface $client,
         ServerRequestInterface $request


### PR DESCRIPTION
Currently the method is `private`, which means there is no way to alter (extend or change) the validation logic for the auth code, for example in a sub-class of `AuthCode`.

In addition, add a `@throws` tag to the method for `OAuthServerException`.

See #1199 for reference.
