### PR TITLE
Make validateAuthorizationCode protected

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -186,7 +186,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
      * @param ClientEntityInterface  $client
      * @param ServerRequestInterface $request
      */
-    private function validateAuthorizationCode(
+    protected function validateAuthorizationCode(
         $authCodePayload,
         ClientEntityInterface $client,
         ServerRequestInterface $request


### PR DESCRIPTION
By making this method protected, developer can override checks. For example more complex redirect_uri validation checks require you to override huge amount code, when only overriding this function would be enough.