### PR TITLE
Validate key with openssl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "lcobucci/jwt": "^3.4 || ~4.0.0",
         "psr/http-message": "^1.0.1",
         "defuse/php-encryption": "^2.2.1",
-        "ext-json": "*",
-        "phpseclib/phpseclib": "~3.0"
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.13",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "lcobucci/jwt": "^3.4 || ~4.0.0",
         "psr/http-message": "^1.0.1",
         "defuse/php-encryption": "^2.2.1",
-        "ext-json": "*"
+        "ext-json": "*",
+        "phpseclib/phpseclib": "~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.13",

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -41,7 +41,7 @@ class CryptKey
         $this->keyPath = $keyPath;
         $this->passPhrase = $passPhrase;
 
-        if (is_file($this->keyPath) && !$this->isFilePath()) {
+        if (\is_file($this->keyPath) && !$this->isFilePath()) {
             $this->keyPath = self::FILE_PREFIX . $this->keyPath;
         }
 
@@ -50,7 +50,7 @@ class CryptKey
                 throw new LogicException(\sprintf('Key path "%s" does not exist or is not readable', $this->keyPath));
             }
 
-            $contents = file_get_contents($this->keyPath);
+            $contents = \file_get_contents($this->keyPath);
         } else {
             $contents = $keyPath;
         }
@@ -60,7 +60,7 @@ class CryptKey
                 $this->keyPath = $this->saveKeyToFile($keyPath);
             }
         } else {
-            throw new LogicException('Unable to read key' . ($this->isFilePath() ? " from file $keyPath" : '' ));
+            throw new LogicException('Unable to read key' . ($this->isFilePath() ? " from file $keyPath" : ''));
         }
 
         if ($keyPermissionsCheck === true) {
@@ -122,13 +122,17 @@ class CryptKey
     {
         try {
             RSA::load($contents, $passPhrase);
+
             return true;
-        } catch (NoKeyLoadedException $e) {}
+        } catch (NoKeyLoadedException $e) {
+        }
 
         try {
             EC::load($contents, $passPhrase);
+
             return true;
-        } catch (NoKeyLoadedException $e) {}
+        } catch (NoKeyLoadedException $e) {
+        }
 
         return false;
     }

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -90,7 +90,7 @@ class CryptKey
         $tmpDir = \sys_get_temp_dir();
         $keyPath = $tmpDir . '/' . \sha1($key) . '.key';
 
-        if (\is_readable($keyPath)) {
+        if (\file_exists($keyPath)) {
             return self::FILE_PREFIX . $keyPath;
         }
 

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -19,6 +19,10 @@ use RuntimeException;
 
 class CryptKey
 {
+    /** @deprecated left for backward compatibility check */
+    const RSA_KEY_PATTERN =
+        '/^(-----BEGIN (RSA )?(PUBLIC|PRIVATE) KEY-----)\R.*(-----END (RSA )?(PUBLIC|PRIVATE) KEY-----)\R?$/s';
+
     private const FILE_PREFIX = 'file://';
 
     /**

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -121,13 +121,13 @@ class CryptKey
      */
     private function isValidKey($contents, $passPhrase)
     {
-        $pkey = openssl_pkey_get_private($contents, $passPhrase) ?: openssl_pkey_get_public($contents);
+        $pkey = \openssl_pkey_get_private($contents, $passPhrase) ?: \openssl_pkey_get_public($contents);
         if ($pkey === false) {
             return false;
         }
-        $details = openssl_pkey_get_details($pkey);
+        $details = \openssl_pkey_get_details($pkey);
 
-        return $details !== false && in_array(
+        return $details !== false && \in_array(
             $details['type'] ?? -1,
             [OPENSSL_KEYTYPE_RSA, OPENSSL_KEYTYPE_EC],
             true

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -33,10 +33,7 @@ class CryptKeyTest extends TestCase
 
         $key = new CryptKey($keyContent);
 
-        $this->assertEquals(
-            'file://' . \sys_get_temp_dir() . '/' . \sha1($keyContent) . '.key',
-            $key->getKeyPath()
-        );
+        $this->assertEquals(self::generateKeyPath($keyContent), $key->getKeyPath());
 
         $keyContent = \file_get_contents(__DIR__ . '/../Stubs/private.key.crlf');
 
@@ -46,10 +43,7 @@ class CryptKeyTest extends TestCase
 
         $key = new CryptKey($keyContent);
 
-        $this->assertEquals(
-            'file://' . \sys_get_temp_dir() . '/' . \sha1($keyContent) . '.key',
-            $key->getKeyPath()
-        );
+        $this->assertEquals(self::generateKeyPath($keyContent), $key->getKeyPath());
     }
 
     public function testUnsupportedKeyType()
@@ -65,13 +59,13 @@ class CryptKeyTest extends TestCase
                 'private_key_type' => OPENSSL_KEYTYPE_DSA,
             ]);
             // Get private key
-            \openssl_pkey_export($res, $privkey, 'mystrongpassword');
-            $path = 'file://' . \sys_get_temp_dir() . '/' . \sha1($privkey) . '.key';
+            \openssl_pkey_export($res, $keyContent, 'mystrongpassword');
+            $path = self::generateKeyPath($keyContent);
 
-            new CryptKey($privkey, 'mystrongpassword');
+            new CryptKey($keyContent, 'mystrongpassword');
         } finally {
             if (isset($path)) {
-                @unlink($path);
+                @\unlink($path);
             }
         }
     }
@@ -86,19 +80,18 @@ class CryptKeyTest extends TestCase
                 'private_key_type' => OPENSSL_KEYTYPE_EC,
             ]);
             // Get private key
-            \openssl_pkey_export($res, $privkey, 'mystrongpassword');
+            \openssl_pkey_export($res, $keyContent, 'mystrongpassword');
 
-            $key = new CryptKey($privkey, 'mystrongpassword');
-            $path = 'file://' . \sys_get_temp_dir() . '/' . \sha1($privkey) . '.key';
+            $key = new CryptKey($keyContent, 'mystrongpassword');
+            $path = self::generateKeyPath($keyContent);
 
             $this->assertEquals($path, $key->getKeyPath());
             $this->assertEquals('mystrongpassword', $key->getPassPhrase());
-
         } catch (\Throwable $e) {
             $this->fail('The EC key was not created');
         } finally {
             if (isset($path)) {
-                @unlink($path);
+                @\unlink($path);
             }
         }
     }
@@ -113,10 +106,10 @@ class CryptKeyTest extends TestCase
                  'private_key_type' => OPENSSL_KEYTYPE_RSA,
             ]);
             // Get private key
-            \openssl_pkey_export($res, $privkey, 'mystrongpassword');
+            \openssl_pkey_export($res, $keyContent, 'mystrongpassword');
 
-            $key = new CryptKey($privkey, 'mystrongpassword');
-            $path = 'file://' . \sys_get_temp_dir() . '/' . \sha1($privkey) . '.key';
+            $key = new CryptKey($keyContent, 'mystrongpassword');
+            $path = self::generateKeyPath($keyContent);
 
             $this->assertEquals($path, $key->getKeyPath());
             $this->assertEquals('mystrongpassword', $key->getPassPhrase());
@@ -124,8 +117,18 @@ class CryptKeyTest extends TestCase
             $this->fail('The RSA key was not created');
         } finally {
             if (isset($path)) {
-                @unlink($path);
+                @\unlink($path);
             }
         }
+    }
+
+    /**
+     * @param string $keyContent
+     *
+     * @return string
+     */
+    private static function generateKeyPath($keyContent)
+    {
+        return 'file://' . \sys_get_temp_dir() . '/' . \sha1($keyContent) . '.key';
     }
 }

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -51,19 +51,4 @@ class CryptKeyTest extends TestCase
             $key->getKeyPath()
         );
     }
-
-    /**
-     * Test whether we get a RuntimeException if a PCRE error is encountered.
-     *
-     * @link https://www.php.net/manual/en/function.preg-last-error.php
-     */
-    public function testPcreErrorExceptions()
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/^PCRE error/');
-
-        new class('foobar foobar foobar') extends CryptKey {
-            const RSA_KEY_PATTERN = '/(?:\D+|<\d+>)*[!?]/';
-        };
-    }
 }


### PR DESCRIPTION
Added key validation using phpseclib. RSA and EC keys are supported. In the future, I would like to make separate types for Public and Private keys to check this aspect as well.

Fixes #1214

