### PR TITLE
Fix the issue when client id is a number but in the refresh token it'…

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -106,7 +106,7 @@ class RefreshTokenGrant extends AbstractGrant
         }
 
         $refreshTokenData = \json_decode($refreshToken, true);
-        if ($refreshTokenData['client_id'] !== $clientId) {
+        if ((string) $refreshTokenData['client_id'] != (string) $clientId) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::REFRESH_TOKEN_CLIENT_FAILED, $request));
             throw OAuthServerException::invalidRefreshToken('Token is not linked to client');
         }


### PR DESCRIPTION
In case if `$refreshTokenData['client_id'] = 22` and `$clientId = "22"` it breaks. This is not an edge case. I faced this issue in Laravel 5.6, that uses Zend Framework to handle the request.