### PR TITLE
Change query delimiter sign to question mark

### DIFF
--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -36,7 +36,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
      * @param DateInterval $accessTokenTTL
      * @param string       $queryDelimiter
      */
-    public function __construct(DateInterval $accessTokenTTL, $queryDelimiter = '#')
+    public function __construct(DateInterval $accessTokenTTL, $queryDelimiter = '?')
     {
         $this->accessTokenTTL = $accessTokenTTL;
         $this->queryDelimiter = $queryDelimiter;


### PR DESCRIPTION
Hey there!
I've testing implicit grant type and find out maybe query delimiter default value is wrong.
so when I tried to get token in query string I came across this this URL:
```
http://localhost:5000/third-party#access_token=eyJ0...&state=u4J2...
```
which is not accessible from Illuminate\Support\Facades\Http\Request object.
so I think if query delimiter default value is changed, every thing will be fine
```
http://localhost:5000/third-party?access_token=eyJ0...&state=u4J2...
```