### PR TITLE
BC support of Custom Claims

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -118,7 +118,8 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             ->withAttribute('oauth_access_token_id', $claims->get('jti'))
             ->withAttribute('oauth_client_id', $this->convertSingleRecordAudToString($claims->get('aud')))
             ->withAttribute('oauth_user_id', $claims->get('sub'))
-            ->withAttribute('oauth_scopes', $claims->get('scopes'));
+            ->withAttribute('oauth_scopes', $claims->get('scopes'))
+            ->withAttribute('oauth_custom_claims', $this->extractCustomClaims($claims->all()));
     }
 
     /**
@@ -131,5 +132,17 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     private function convertSingleRecordAudToString($aud)
     {
         return \is_array($aud) && \count($aud) === 1 ? $aud[0] : $aud;
+    }
+
+    /**
+     * Extract custom claims
+     *
+     * @param array $claims
+     *
+     * @return array
+     */
+    private function extractCustomClaims($claims)
+    {
+        return \array_diff_key($claims, \array_flip(['jti', 'aud', 'sub', 'scopes', 'iat', 'nbf', 'exp']));
     }
 }

--- a/tests/AuthorizationValidators/BearerTokenValidatorTest.php
+++ b/tests/AuthorizationValidators/BearerTokenValidatorTest.php
@@ -34,6 +34,8 @@ class BearerTokenValidatorTest extends TestCase
             ->expiresAt((new DateTimeImmutable())->add(new DateInterval('PT1H')))
             ->relatedTo('user-id')
             ->withClaim('scopes', 'scope1 scope2 scope3 scope4')
+            ->withClaim('attr1', 'value')
+            ->withClaim('attr2', 42)
             ->getToken(new Sha256(), LocalFileReference::file(__DIR__ . '/../Stubs/private.key'));
 
         $request = (new ServerRequest())->withHeader('authorization', \sprintf('Bearer %s', $validJwt->toString()));
@@ -46,6 +48,7 @@ class BearerTokenValidatorTest extends TestCase
         $this->assertEquals('client-id', $validRequest->getAttribute('oauth_client_id'));
         $this->assertEquals('user-id', $validRequest->getAttribute('oauth_user_id'));
         $this->assertEquals('scope1 scope2 scope3 scope4', $validRequest->getAttribute('oauth_scopes'));
+        $this->assertEquals(['attr1' => 'value', 'attr2' => 42], $validRequest->getAttribute('oauth_custom_claims'));
     }
 
     public function testBearerTokenValidatorRejectsExpiredToken()

--- a/tests/AuthorizationValidators/BearerTokenValidatorTest.php
+++ b/tests/AuthorizationValidators/BearerTokenValidatorTest.php
@@ -41,6 +41,11 @@ class BearerTokenValidatorTest extends TestCase
         $validRequest = $bearerTokenValidator->validateAuthorization($request);
 
         $this->assertArrayHasKey('authorization', $validRequest->getHeaders());
+
+        $this->assertEquals('token-id', $validRequest->getAttribute('oauth_access_token_id'));
+        $this->assertEquals('client-id', $validRequest->getAttribute('oauth_client_id'));
+        $this->assertEquals('user-id', $validRequest->getAttribute('oauth_user_id'));
+        $this->assertEquals('scope1 scope2 scope3 scope4', $validRequest->getAttribute('oauth_scopes'));
     }
 
     public function testBearerTokenValidatorRejectsExpiredToken()


### PR DESCRIPTION
Easy backward compatible way for parsing custom claims for #1120, #1122 and #1183 in the next 8.x release.

## How to use it

For example, if you want to add a role field into JWT, just add `$role` property into your token entity and override `convertToJWT` method from trait for adding `role` claim:

```php
class AccessToken implements AccessTokenEntityInterface
{
    // ...

    private $userRole;

    public function setUserRole($role) { $this->userRole = $role }
    public function getUserRole() { return $this->userRole }

    private function convertToJWT()
    {
        return $this->jwtConfiguration->builder()
            // ...
            ->withClaim('role', $this->getUserRole())
            // ...
    }
}
```

After all fetch user role and fill the property in token repository:

```php
class AccessTokenRepository implements AccessTokenRepositoryInterface
{
    // ...

    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
    {
        $accessToken = new AccessTokenEntity();
        // ...

        if ($userIdentifier !== null) {
            $accessToken->setUserIdentifier($userIdentifier);

            $row = $this->db->query('SELECT role FROM users WHERE id = :id', ['id' => $userIdentifier]);
            $accessToken->setUserRole($row['role']);
        }

        return $accessToken;
    }

    // ...
}
```

And now you can retreive `$request->getAttribute('oauth_custom_claims')` with value like `['role' => 'admin']`.