### PR TITLE
Respond with helpful and spec complient error on invalid user credentials

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -189,7 +189,7 @@ class OAuthServerException extends Exception
      */
     public static function invalidCredentials()
     {
-        return new static('The user credentials were incorrect.', 6, 'invalid_credentials', 401);
+        return new static('The user credentials were incorrect.', 6, 'invalid_grant', 400);
     }
 
     /**

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -106,7 +106,7 @@ class PasswordGrant extends AbstractGrant
         if ($user instanceof UserEntityInterface === false) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
 
-            throw OAuthServerException::invalidGrant();
+            throw OAuthServerException::invalidCredentials();
         }
 
         return $user;

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -137,4 +137,11 @@ class OAuthServerExceptionTest extends TestCase
 
         $this->assertSame('https://example.com/error', $exceptionWithRedirect->getRedirectUri());
     }
+
+    public function testInvalidCredentialsIsInvalidGrant()
+    {
+        $exception = OAuthServerException::invalidCredentials();
+
+        $this->assertSame('invalid_grant', $exception->getErrorType());
+    }
 }

--- a/tests/Grant/PasswordGrantTest.php
+++ b/tests/Grant/PasswordGrantTest.php
@@ -211,7 +211,7 @@ class PasswordGrantTest extends TestCase
         $responseType = new StubResponseType();
 
         $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-        $this->expectExceptionCode(10);
+        $this->expectExceptionCode(6);
 
         $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
     }


### PR DESCRIPTION
See #967 #1175 #1093

This PR tries to solve the non helpful error message if a user types in wrong credentials in a a much smaller scope then done in #1093 and hopefully can be merged and released much faster.

In #967 the error type should be `invalid_grant` (instead of `invalid_credentials`) and the HTTP status code should be `400` instead of `401` but this also had changed the error message from `The user credentials were incorrect.` into `The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.` which is not user friendly at all.

Instead of calling `invalidGrant()` (as done in #967) this PR calls `invalidCredentials()` but modifies the logic of `invalidCredentials()` to return `invalid_grant` with `400`.

Interestingly `invalidCredentials()` wasn't used anymore since #967.

TODOs
- [ ] Update tests