### PR TITLE
Removes Check Forcing Client ID to be a String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.3.1] - released 2021-06-04
+### Fixed
+- Revert check on clientID. We will no longer require this to be a string (PR #1233)
+
 ## [8.3.0] - released 2021-06-03
 ### Added
 - The server will now validate redirect uris according to rfc8252 (PR #1203)
@@ -541,7 +545,8 @@ Version 5 is a complete code rewrite.
 
 - First major release
 
-[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.3.0...HEAD
+[Unreleased]: https://github.com/thephpleague/oauth2-server/compare/8.3.1...HEAD
+[8.3.1]: https://github.com/thephpleague/oauth2-server/compare/8.3.0...8.3.1
 [8.3.0]: https://github.com/thephpleague/oauth2-server/compare/8.2.4...8.3.0
 [8.2.4]: https://github.com/thephpleague/oauth2-server/compare/8.2.3...8.2.4
 [8.2.3]: https://github.com/thephpleague/oauth2-server/compare/8.2.2...8.2.3

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -256,7 +256,7 @@ abstract class AbstractGrant implements GrantTypeInterface
 
         $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
 
-        if (!\is_string($clientId)) {
+        if (\is_null($clientId)) {
             throw OAuthServerException::invalidRequest('client_id');
         }
 

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -120,7 +120,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
             $this->getServerParameter('PHP_AUTH_USER', $request)
         );
 
-        if (!\is_string($clientId)) {
+        if (\is_null($clientId)) {
             throw OAuthServerException::invalidRequest('client_id');
         }
 

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -89,38 +89,6 @@ class AbstractGrantTest extends TestCase
         $this->assertSame([null, null], $basicAuthMethod->invoke($grantMock, $serverRequest));
     }
 
-    public function testGetClientCredentialsClientIdNotAString()
-    {
-        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-
-        /** @var AbstractGrant $grantMock */
-        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
-        $grantMock->setClientRepository($clientRepositoryMock);
-
-        $abstractGrantReflection = new \ReflectionClass($grantMock);
-
-        $serverRequest = new ServerRequest(
-            [],
-            [],
-            null,
-            'POST',
-            'php://input',
-            [],
-            [],
-            [],
-            [
-                'client_id'     => ['not', 'a', 'string'],
-                'client_secret' => 'client_secret',
-            ]
-        );
-        $getClientCredentialsMethod = $abstractGrantReflection->getMethod('getClientCredentials');
-        $getClientCredentialsMethod->setAccessible(true);
-
-        $this->expectException(\League\OAuth2\Server\Exception\OAuthServerException::class);
-
-        $getClientCredentialsMethod->invoke($grantMock, $serverRequest, true, true);
-    }
-
     public function testGetClientCredentialsClientSecretNotAString()
     {
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();


### PR DESCRIPTION
This PR removes the check forcing the client ID to be a string as this is breaking Laravel Passport which uses integers. It is likely other implementations are affected by this so I am reverting this change.

This should fix issue #1232