### PR TITLE
Added exception chaining in BearerTokenValidator

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -108,7 +108,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             $constraints = $this->jwtConfiguration->validationConstraints();
             $this->jwtConfiguration->validator()->assert($token, ...$constraints);
         } catch (RequiredConstraintsViolated $exception) {
-            throw OAuthServerException::accessDenied('Access token could not be verified');
+            throw OAuthServerException::accessDenied('Access token could not be verified', null, $exception);
         }
 
         $claims = $token->claims();


### PR DESCRIPTION
Added exception chaining for RequiredConstraintsViolated in `\League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator::validateAuthorization()`.

This helps with logging the exception (similar to line 103).