### PR TITLE
Use thephpleague/oauth2-server-bundle for the Symfony integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ We use [Github Actions](https://github.com/features/actions), [Scrutinizer](http
 * [Laravel Passport](https://github.com/laravel/passport)
 * [OAuth 2 Server for CakePHP 3](https://github.com/uafrica/oauth-server)
 * [OAuth 2 Server for Mezzio](https://github.com/mezzio/mezzio-authentication-oauth2)
-* [Trikoder OAuth 2 Bundle (Symfony)](https://github.com/trikoder/oauth2-bundle)
+* [OAuth 2 Server Bundle (Symfony)](https://github.com/thephpleague/oauth2-server-bundle)
 * [Heimdall for CodeIgniter 4](https://github.com/ezralazuardy/heimdall)
 
 ## Changelog


### PR DESCRIPTION
Hey,
The bundle has been tagged now and it already integrates the same features as the Trikoder bundle which is not actively maintained anymore.

I'm not sure if the content of https://oauth2.thephpleague.com/framework-integrations comes from this repo so it may need an update as well.

Fixes https://github.com/thephpleague/oauth2-server-bundle/issues/54