### PR TITLE
Update Laravel example to work when configuration is cached

### DIFF
--- a/v5-security-improvements.md
+++ b/v5-security-improvements.md
@@ -20,7 +20,7 @@ You will notice in your server logs a message like this:
 
 To supress this notice once you have instantiated an instance of `\League\OAuth2\Server\AuthorizationServer` you should call the `setEncryptionKey()` method passing in at least 32 bytes of random data.
 
-You can generate this using `base64_encode(random_bytes(32))`. Alternatively if you're using a framework such as Laravel which has a encryption key already generated you can pass in that (in the case of Laravel use `env('APP_KEY')`).
+You can generate this using `base64_encode(random_bytes(32))`. Alternatively if you're using a framework such as Laravel which has a encryption key already generated you can pass in that (in the case of Laravel use `config('app.key')`).
 
 For example:
 


### PR DESCRIPTION
The Laravel example of reading the application key doesn't work in a production setting where the configuration cache is used. All calls to `env()` return null then and `config()` should be used instead.

<img src="https://user-images.githubusercontent.com/25909128/146749519-0ced3b17-4f35-40de-9c0a-4a4f7cd6efd3.png" width="500px">

Using `config('app.key')` always works, cached or not. Of course a Laravel developer already knows this so the risk of it causing an actual problem is very low, but I think any Laravel example should follow Laravel conventions.

Laravel documentation about this
https://laravel.com/docs/8.x/deployment#optimizing-configuration-loading
