### PR TITLE
Bug: GrantTypeInterface not respected

### DIFF
--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -21,11 +21,13 @@ use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
 use LeagueTests\Stubs\AccessTokenEntity;
 use LeagueTests\Stubs\AuthCodeEntity;
 use LeagueTests\Stubs\ClientEntity;
+use LeagueTests\Stubs\GrantType;
 use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class AuthorizationServerTest extends TestCase
 {
@@ -37,6 +39,23 @@ class AuthorizationServerTest extends TestCase
         \chmod(__DIR__ . '/Stubs/private.key', 0600);
         \chmod(__DIR__ . '/Stubs/public.key', 0600);
         \chmod(__DIR__ . '/Stubs/private.key.crlf', 0600);
+    }
+
+    public function testGrantTypeGetsEnabled()
+    {
+        $server = new AuthorizationServer(
+            $this->getMockBuilder(ClientRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/private.key',
+            \base64_encode(\random_bytes(36)),
+            new StubResponseType()
+        );
+
+        $server->enableGrantType(new GrantType(), new DateInterval('PT1M'));
+
+        $authRequest = $server->validateAuthorizationRequest($this->createMock(ServerRequestInterface::class));
+        $this->assertSame(GrantType::class, $authRequest->getGrantTypeId());
     }
 
     public function testRespondToRequestInvalidGrantType()

--- a/tests/Stubs/GrantType.php
+++ b/tests/Stubs/GrantType.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LeagueTests\Stubs;
+
+use DateInterval;
+use League\Event\EmitterInterface;
+use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\Grant\GrantTypeInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class GrantType implements GrantTypeInterface
+{
+    private $emitter;
+
+    public function setEmitter(EmitterInterface $emitter = null)
+    {
+        $this->emitter = $emitter;
+
+        return $this;
+    }
+
+    public function getEmitter()
+    {
+        return $this->emitter;
+    }
+
+    public function setRefreshTokenTTL(DateInterval $refreshTokenTTL)
+    {
+    }
+
+    public function getIdentifier()
+    {
+        return 'grant_type_identifier';
+    }
+
+    public function respondToAccessTokenRequest(
+        ServerRequestInterface $request,
+        ResponseTypeInterface $responseType,
+        DateInterval $accessTokenTTL
+    ) {
+        return $responseType;
+    }
+
+    public function canRespondToAuthorizationRequest(ServerRequestInterface $request)
+    {
+        return true;
+    }
+
+    public function validateAuthorizationRequest(ServerRequestInterface $request)
+    {
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setGrantTypeId(self::class);
+
+        return $authRequest;
+    }
+
+    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    {
+    }
+
+    public function canRespondToAccessTokenRequest(ServerRequestInterface $request)
+    {
+        return true;
+    }
+
+    public function setClientRepository(ClientRepositoryInterface $clientRepository)
+    {
+    }
+
+    public function setAccessTokenRepository(AccessTokenRepositoryInterface $accessTokenRepository)
+    {
+    }
+
+    public function setScopeRepository(ScopeRepositoryInterface $scopeRepository)
+    {
+    }
+
+    public function setDefaultScope($scope)
+    {
+    }
+
+    public function setPrivateKey(CryptKey $privateKey)
+    {
+    }
+
+    public function setEncryptionKey($key = null)
+    {
+    }
+}


### PR DESCRIPTION
when enabling a grant type via `enableGrantType` the provided type `GrantTypeInterface` is not respected (`$grantType->revokeRefreshTokens($this->revokeRefreshTokens);`). 
A non-existent method will be called.

I just added unit test to test against a custom grant type