### PR TITLE
PHP version requirement (readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The latest version of this package supports the following versions of PHP:
 * PHP 7.3
 * PHP 7.4
 * PHP 8.0
+* PHP 8.1
 
 The `openssl` and `json` extensions are also required.
 


### PR DESCRIPTION
It is unclear which PHP versions are supported.

https://oauth2.thephpleague.com/requirements/:
> The following versions of PHP are supported:
> PHP 7.2
> PHP 7.3
> PHP 7.4

https://github.com/thephpleague/oauth2-server/blob/master/README.md:
> The latest version of this package supports the following versions of PHP:
> PHP 7.2
> PHP 7.3
> PHP 7.4
> PHP 8.0

https://github.com/thephpleague/oauth2-server/blob/master/composer.json:
> "require": {
>     "php": "^7.2 || ^8.0",

I assume we support both PHP 8.0 and 8.1. Maybe it would be a good idea to update that.