### PR TITLE
Prevent warning when malformed redirect URI is provided

### DIFF
--- a/src/RedirectUriValidators/RedirectUriValidator.php
+++ b/src/RedirectUriValidators/RedirectUriValidator.php
@@ -61,6 +61,10 @@ class RedirectUriValidator implements RedirectUriValidatorInterface
     {
         $parsedUrl = \parse_url($redirectUri);
 
+        if ($parsedUrl === false) {
+            return false;
+        }
+
         return $parsedUrl['scheme'] === 'http'
             && (\in_array($parsedUrl['host'], ['127.0.0.1', '[::1]'], true));
     }

--- a/tests/RedirectUriValidators/RedirectUriValidatorTest.php
+++ b/tests/RedirectUriValidators/RedirectUriValidatorTest.php
@@ -72,4 +72,16 @@ class RedirectUriValidatorTest extends TestCase
             'Loopback redirect URI can change the port number'
         );
     }
+
+    public function testMalformedUri()
+    {
+        $validator = new RedirectUriValidator('http://127.0.0.1:8443/endpoint');
+
+        $malformedUri = 'malformed://';
+
+        $this->assertFalse(
+            $validator->validateRedirectUri($malformedUri),
+            'Malformed URI is rejected'
+        );
+    }
 }


### PR DESCRIPTION
The `RedirectUriValidator` does not account for the fact that `parse_url()` may return `false`, when a consumer provides a malformed URL. The validator will attempt to retrieve the scheme from the parsed URL which at that point will be set to false causing a warning to be emitted (in my case immediately triggering a HTTP 500 response because of error handling).

This PR aims to fix this by checking if the parsed URL is false, in which case the validator exits early.