### PR TITLE
Fix compatibility with lcobucci/jwt ^4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use InMemory::empty() instead of InMemory::plainText('') to avoid new empty string exception thrown by lcobucci/jwt (PR #1282)
 
 ## [8.3.4] - released 2022-04-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use InMemory::empty() instead of InMemory::plainText('') to avoid new empty string exception thrown by lcobucci/jwt (PR #1282)
+- Use string 'empty' instead of InMemory::plainText('') to avoid new empty string exception thrown by lcobucci/jwt (PR #1282)
 
 ## [8.3.4] - released 2022-04-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Use string 'empty' instead of InMemory::plainText('') to avoid new empty string exception thrown by lcobucci/jwt (PR #1282)
+- Use InMemory::plainText('empty', 'empty') instead of InMemory::plainText('') to avoid [new empty string exception](https://github.com/lcobucci/jwt/pull/833) thrown by lcobucci/jwt (PR #1282)
 
 ## [8.3.4] - released 2022-04-07
 ### Fixed

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -70,7 +70,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     {
         $this->jwtConfiguration = Configuration::forSymmetricSigner(
             new Sha256(),
-            InMemory::empty()
+            InMemory::plainText('empty', 'empty')
         );
 
         $this->jwtConfiguration->setValidationConstraints(

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -70,7 +70,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     {
         $this->jwtConfiguration = Configuration::forSymmetricSigner(
             new Sha256(),
-            InMemory::plainText('')
+            InMemory::empty()
         );
 
         $this->jwtConfiguration->setValidationConstraints(

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,7 @@ trait AccessTokenTrait
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
             InMemory::plainText($this->privateKey->getKeyContents(), $this->privateKey->getPassPhrase() ?? ''),
-            InMemory::plainText('')
+            InMemory::plainText('empty', 'empty')
         );
     }
 

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,7 @@ trait AccessTokenTrait
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
             InMemory::plainText($this->privateKey->getKeyContents(), $this->privateKey->getPassPhrase() ?? ''),
-            InMemory::empty()
+            InMemory::plainText('empty', 'empty')
         );
     }
 

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -46,7 +46,7 @@ trait AccessTokenTrait
         $this->jwtConfiguration = Configuration::forAsymmetricSigner(
             new Sha256(),
             InMemory::plainText($this->privateKey->getKeyContents(), $this->privateKey->getPassPhrase() ?? ''),
-            InMemory::plainText('empty', 'empty')
+            InMemory::empty()
         );
     }
 


### PR DESCRIPTION
Hey, 
Here is a forward compatibility layer for lcobucci ^4.2 and specifically this change https://github.com/lcobucci/jwt/pull/833 which forbids creating `InMemory` keys with empty strings.
Spotted in https://github.com/thephpleague/oauth2-server-bundle/runs/6077089570?check_suite_focus=true