### PR TITLE
Update the Param Type on the Validate Scopes Method

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -294,8 +294,8 @@ abstract class AbstractGrant implements GrantTypeInterface
     /**
      * Validate scopes in the request.
      *
-     * @param string|array $scopes
-     * @param string       $redirectUri
+     * @param string|array|null $scopes
+     * @param string            $redirectUri
      *
      * @throws OAuthServerException
      *


### PR DESCRIPTION
`validateScopes` does accept and handle `null` values.

Hit this while writing a new grant type and PHPStan complained. Since `validateScopes` does handle `null` appropriately, just updating the type in PHPDoc