### PR TITLE
Allow configuring the JWT builder when generating a token

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -86,11 +86,6 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
 
     /**
      * Configure the request instance.
-     *
-     * @param ServerRequestInterface $request
-     * @param Plain                  $token
-     *
-     * @return ServerRequestInterface
      */
     protected function withRequest(ServerRequestInterface $request, Plain $token): ServerRequestInterface
     {

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -14,6 +14,7 @@ use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
@@ -90,6 +91,19 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     }
 
     /**
+     * Configure the request instance.
+     *
+     * @param ServerRequestInterface $request
+     * @param Plain $token
+     *
+     * @return ServerRequestInterface
+     */
+    protected function withRequest(ServerRequestInterface $request, Plain $token): ServerRequestInterface
+    {
+        return $request;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function validateAuthorization(ServerRequestInterface $request)
@@ -124,11 +138,11 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
         }
 
         // Return the request with additional attributes
-        return $request
+        return $this->withRequest($request
             ->withAttribute('oauth_access_token_id', $claims->get('jti'))
             ->withAttribute('oauth_client_id', $this->convertSingleRecordAudToString($claims->get('aud')))
             ->withAttribute('oauth_user_id', $claims->get('sub'))
-            ->withAttribute('oauth_scopes', $claims->get('scopes'));
+            ->withAttribute('oauth_scopes', $claims->get('scopes')), $token);
     }
 
     /**

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -19,7 +19,6 @@ use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Exception;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
-use Lcobucci\JWT\Token\Plain;
 use Lcobucci\JWT\UnencryptedToken;
 use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
@@ -85,9 +84,9 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
     }
 
     /**
-     * Configure the request instance.
+     * Configure the validated authorization request instance.
      */
-    protected function withRequest(ServerRequestInterface $request, Plain $token): ServerRequestInterface
+    protected function withValidatedRequest(ServerRequestInterface $request, UnencryptedToken $token): ServerRequestInterface
     {
         return $request;
     }
@@ -135,7 +134,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
         }
 
         // Return the request with additional attributes
-        return $this->withRequest($request
+        return $this->withValidatedRequest($request
             ->withAttribute('oauth_access_token_id', $claims->get('jti'))
             ->withAttribute('oauth_client_id', $claims->get('aud')[0])
             ->withAttribute('oauth_user_id', $claims->get('sub'))

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -88,7 +88,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
      * Configure the request instance.
      *
      * @param ServerRequestInterface $request
-     * @param Plain $token
+     * @param Plain                  $token
      *
      * @return ServerRequestInterface
      */

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -13,6 +13,7 @@ use DateTimeImmutable;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
+use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Token;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
@@ -51,6 +52,16 @@ trait AccessTokenTrait
     }
 
     /**
+     * Configure the JWT builder instance.
+     *
+     * @return Builder
+     */
+    protected function withBuilder(Builder $builder)
+    {
+        return $builder;
+    }
+
+    /**
      * Generate a JWT from the access token
      *
      * @return Token
@@ -59,14 +70,16 @@ trait AccessTokenTrait
     {
         $this->initJwtConfiguration();
 
-        return $this->jwtConfiguration->builder()
+        $builder = $this->jwtConfiguration->builder()
             ->permittedFor($this->getClient()->getIdentifier())
             ->identifiedBy($this->getIdentifier())
             ->issuedAt(new DateTimeImmutable())
             ->canOnlyBeUsedAfter(new DateTimeImmutable())
             ->expiresAt($this->getExpiryDateTime())
             ->relatedTo((string) $this->getUserIdentifier())
-            ->withClaim('scopes', $this->getScopes())
+            ->withClaim('scopes', $this->getScopes());
+
+        return $this->withBuilder($builder)
             ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
     }
 

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -57,10 +57,8 @@ trait AccessTokenTrait
 
     /**
      * Configure the JWT builder instance.
-     *
-     * @return Builder
      */
-    protected function withBuilder(Builder $builder)
+    protected function withBuilder(Builder $builder): Builder
     {
         return $builder;
     }

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -70,16 +70,14 @@ trait AccessTokenTrait
     {
         $this->initJwtConfiguration();
 
-        $builder = $this->jwtConfiguration->builder()
+        return $this->withBuilder($this->jwtConfiguration->builder()
             ->permittedFor($this->getClient()->getIdentifier())
             ->identifiedBy($this->getIdentifier())
             ->issuedAt(new DateTimeImmutable())
             ->canOnlyBeUsedAfter(new DateTimeImmutable())
             ->expiresAt($this->getExpiryDateTime())
             ->relatedTo($this->getSubjectIdentifier())
-            ->withClaim('scopes', $this->getScopes());
-
-        return $this->withBuilder($builder)
+            ->withClaim('scopes', $this->getScopes()))
             ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
     }
 

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -58,7 +58,7 @@ trait AccessTokenTrait
     /**
      * Configure the JWT builder instance.
      */
-    protected function withBuilder(Builder $builder): Builder
+    protected function withJwtBuilder(Builder $builder): Builder
     {
         return $builder;
     }
@@ -70,7 +70,7 @@ trait AccessTokenTrait
     {
         $this->initJwtConfiguration();
 
-        return $this->withBuilder($this->jwtConfiguration->builder()
+        return $this->withJwtBuilder($this->jwtConfiguration->builder()
             ->permittedFor($this->getClient()->getIdentifier())
             ->identifiedBy($this->getIdentifier())
             ->issuedAt(new DateTimeImmutable())

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -10,10 +10,10 @@
 namespace League\OAuth2\Server\Entities\Traits;
 
 use DateTimeImmutable;
+use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
-use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Token;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Entities\ClientEntityInterface;


### PR DESCRIPTION
Fixes #885 
Closes #851 
Closes #1122 
Related to #1434

Currently we have to override the whole `convertToJWT` method to configure JWT (e.g. to add additional claims). This PR makes it possible to override the new `withJwtBuilder` method instead:

```php
// \League\OAuth2\Server\Entities\Traits\AccessTokenTrait

use Lcobucci\JWT\Builder;

/**
 * Configure the JWT builder instance.
 */
protected function withJwtBuilder(Builder $builder)
{
    return $builder->withClaim('foo', 'bar');
}
```

Update: This PR also adds `withValidatedRequest` method to the bearer token validator that makes it possible to configure the request and append additional attributes:

```php
// \League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator

use Lcobucci\JWT\UnencryptedToken;
use Psr\Http\Message\ServerRequestInterface;

/**
 * Configure the validated authorization request instance.
 */
protected function withValidatedRequest(ServerRequestInterface $request, UnencryptedToken $token): ServerRequestInterface
{
    return $request->withAttribute('oauth_foo', $token->claims()->get('foo'));
}
```