### PR TITLE
Fixes for Deprecation Notices in Test Suite

### DIFF
--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -14,7 +14,8 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           fetch-depth: 0
-
+      - name: Fix git safe.directory in container
+        run: mkdir -p /home/runner/work/_temp/_github_home && printf "[safe]\n\tdirectory = /github/workspace" > /home/runner/work/_temp/_github_home/.gitconfig
       - name: "Backwards Compatibility Check"
         uses: docker://nyholm/roave-bc-check-ga
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix deprecation notices for PHP 8.x (PR #1329)
 
 ## [8.4.0] - released 2023-02-15
 ### Added

--- a/examples/public/client_credentials.php
+++ b/examples/public/client_credentials.php
@@ -53,20 +53,16 @@ $app = new App([
 ]);
 
 $app->post('/access_token', function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
-
     /* @var \League\OAuth2\Server\AuthorizationServer $server */
     $server = $app->getContainer()->get(AuthorizationServer::class);
 
     try {
-
         // Try to respond to the request
         return $server->respondToAccessTokenRequest($request, $response);
     } catch (OAuthServerException $exception) {
-
         // All instances of OAuthServerException can be formatted into a HTTP response
         return $exception->generateHttpResponse($response);
     } catch (\Exception $exception) {
-
         // Unknown exception
         $body = new Stream('php://temp', 'r+');
         $body->write($exception->getMessage());

--- a/examples/public/password.php
+++ b/examples/public/password.php
@@ -17,7 +17,6 @@ include __DIR__ . '/../vendor/autoload.php';
 $app = new App([
     // Add the authorization server to the DI container
     AuthorizationServer::class => function () {
-
         // Setup the authorization server
         $server = new AuthorizationServer(
             new ClientRepository(),                 // instance of ClientRepositoryInterface
@@ -46,20 +45,16 @@ $app = new App([
 $app->post(
     '/access_token',
     function (ServerRequestInterface $request, ResponseInterface $response) use ($app) {
-
         /* @var \League\OAuth2\Server\AuthorizationServer $server */
         $server = $app->getContainer()->get(AuthorizationServer::class);
 
         try {
-
             // Try to respond to the access token request
             return $server->respondToAccessTokenRequest($request, $response);
         } catch (OAuthServerException $exception) {
-
             // All instances of OAuthServerException can be converted to a PSR-7 response
             return $exception->generateHttpResponse($response);
         } catch (\Exception $exception) {
-
             // Catch unexpected exceptions
             $body = $response->getBody();
             $body->write($exception->getMessage());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="true"
-         stopOnFailure="true" stopOnIncomplete="false" stopOnSkipped="false" bootstrap="tests/Bootstrap.php">
+<phpunit
+        colors="true"
+        convertDeprecationsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        stopOnError="true"
+        stopOnFailure="true"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        bootstrap="tests/Bootstrap.php"
+>
     <testsuites>
         <testsuite name="Tests">
             <directory>./tests/</directory>

--- a/src/Entities/Traits/ClientTrait.php
+++ b/src/Entities/Traits/ClientTrait.php
@@ -30,6 +30,7 @@ trait ClientTrait
      * Get the client's name.
      *
      * @return string
+     *
      * @codeCoverageIgnore
      */
     public function getName()

--- a/src/Entities/Traits/ScopeTrait.php
+++ b/src/Entities/Traits/ScopeTrait.php
@@ -16,6 +16,7 @@ trait ScopeTrait
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIdentifier();

--- a/src/RequestAccessTokenEvent.php
+++ b/src/RequestAccessTokenEvent.php
@@ -31,6 +31,7 @@ class RequestAccessTokenEvent extends RequestEvent
 
     /**
      * @return AccessTokenEntityInterface
+     *
      * @codeCoverageIgnore
      */
     public function getAccessToken()

--- a/src/RequestEvent.php
+++ b/src/RequestEvent.php
@@ -40,6 +40,7 @@ class RequestEvent extends Event
 
     /**
      * @return ServerRequestInterface
+     *
      * @codeCoverageIgnore
      */
     public function getRequest()

--- a/src/RequestRefreshTokenEvent.php
+++ b/src/RequestRefreshTokenEvent.php
@@ -31,6 +31,7 @@ class RequestRefreshTokenEvent extends RequestEvent
 
     /**
      * @return RefreshTokenEntityInterface
+     *
      * @codeCoverageIgnore
      */
     public function getRefreshToken()

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -245,9 +245,12 @@ class AuthorizationServerTest extends TestCase
 
         $server->enableGrantType($grant);
 
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -32,6 +32,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class AuthorizationServerTest extends TestCase
 {
     const DEFAULT_SCOPE = 'basic';
+    const REDIRECT_URI = 'https://foo/bar';
 
     public function setUp(): void
     {
@@ -86,7 +87,7 @@ class AuthorizationServerTest extends TestCase
         $client = new ClientEntity();
 
         $client->setConfidential();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $clientRepository = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepository->method('getClientEntity')->willReturn($client);
@@ -246,7 +247,7 @@ class AuthorizationServerTest extends TestCase
         $server->enableGrantType($grant);
 
         $client = new ClientEntity();
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
@@ -263,7 +264,7 @@ class AuthorizationServerTest extends TestCase
     public function testValidateAuthorizationRequest()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL);
+
 if (!@include_once __DIR__ . '/../vendor/autoload.php') {
     $message = <<<MSG
 You must set up the project dependencies, run the following commands:

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-error_reporting(E_ALL);
+\error_reporting(E_ALL);
 
 if (!@include_once __DIR__ . '/../vendor/autoload.php') {
     $message = <<<MSG

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -31,6 +31,7 @@ use PHPUnit\Framework\TestCase;
 class AuthCodeGrantTest extends TestCase
 {
     const DEFAULT_SCOPE = 'basic';
+    const REDIRECT_URI = 'https://foo/bar';
 
     /**
      * @var CryptTraitStub
@@ -85,7 +86,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequest()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
@@ -115,7 +116,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'response_type' => 'code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
             ]
         );
 
@@ -125,7 +126,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestRedirectUriArray()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri(['http://foo/bar']);
+        $client->setRedirectUri([self::REDIRECT_URI]);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -154,7 +155,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'response_type' => 'code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
             ]
         );
 
@@ -164,7 +165,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestWithoutRedirectUri()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
@@ -206,7 +207,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestCodeChallenge()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -235,7 +236,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'response_type'  => 'code',
                 'client_id'      => 'foo',
-                'redirect_uri'   => 'http://foo/bar',
+                'redirect_uri'   => self::REDIRECT_URI,
                 'code_challenge' => self::CODE_CHALLENGE,
             ]
         );
@@ -246,7 +247,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestCodeChallengeInvalidLengthTooShort()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -261,7 +262,7 @@ class AuthCodeGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type'  => 'code',
             'client_id'      => 'foo',
-            'redirect_uri'   => 'http://foo/bar',
+            'redirect_uri'   => self::REDIRECT_URI,
             'code_challenge' => \str_repeat('A', 42),
         ]);
 
@@ -273,7 +274,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestCodeChallengeInvalidLengthTooLong()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -288,7 +289,7 @@ class AuthCodeGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type'  => 'code',
             'client_id'      => 'foo',
-            'redirect_uri'   => 'http://foo/bar',
+            'redirect_uri'   => self::REDIRECT_URI,
             'code_challenge' => \str_repeat('A', 129),
         ]);
 
@@ -300,7 +301,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestCodeChallengeInvalidCharacters()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -315,7 +316,7 @@ class AuthCodeGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type' => 'code',
             'client_id' => 'foo',
-            'redirect_uri' => 'http://foo/bar',
+            'redirect_uri' => self::REDIRECT_URI,
             'code_challenge' => \str_repeat('A', 42) . '!',
         ]);
 
@@ -371,7 +372,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestBadRedirectUriString()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -397,7 +398,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestBadRedirectUriArray()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri(['http://foo/bar']);
+        $client->setRedirectUri([self::REDIRECT_URI]);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -423,7 +424,7 @@ class AuthCodeGrantTest extends TestCase
     public function testValidateAuthorizationRequestInvalidCodeChallengeMethod()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -444,7 +445,7 @@ class AuthCodeGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type' => 'code',
             'client_id' => 'foo',
-            'redirect_uri' => 'http://foo/bar',
+            'redirect_uri' => self::REDIRECT_URI,
             'code_challenge' => 'foobar',
             'code_challenge_method' => 'foo',
         ]);
@@ -458,7 +459,7 @@ class AuthCodeGrantTest extends TestCase
     public function testCompleteAuthorizationRequest()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
@@ -482,7 +483,7 @@ class AuthCodeGrantTest extends TestCase
     public function testCompleteAuthorizationRequestDenied()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(false);
@@ -510,7 +511,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -552,7 +553,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -561,7 +562,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -578,7 +579,7 @@ class AuthCodeGrantTest extends TestCase
     public function testRespondToAccessTokenRequestUsingHttpBasicAuth()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setIdentifier('foo');
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -618,7 +619,7 @@ class AuthCodeGrantTest extends TestCase
             [],
             [
                 'grant_type'   => 'authorization_code',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -627,7 +628,7 @@ class AuthCodeGrantTest extends TestCase
                             'expire_time'  => \time() + 3600,
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -645,7 +646,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -686,7 +687,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -695,7 +696,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -713,7 +714,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -754,7 +755,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -763,7 +764,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -781,7 +782,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -824,7 +825,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => self::CODE_VERIFIER,
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -834,7 +835,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => self::CODE_VERIFIER,
                             'code_challenge_method' => 'plain',
                         ]
@@ -854,7 +855,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -897,7 +898,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => self::CODE_VERIFIER,
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -907,7 +908,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => self::CODE_CHALLENGE,
                             'code_challenge_method' => 'S256',
                         ]
@@ -927,7 +928,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -970,7 +971,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => self::CODE_VERIFIER,
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -980,7 +981,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -999,7 +1000,7 @@ class AuthCodeGrantTest extends TestCase
         $client = new ClientEntity();
         $client->setIdentifier('foo');
         $client->setConfidential();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -1029,7 +1030,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1078,7 +1079,7 @@ class AuthCodeGrantTest extends TestCase
                             'auth_code_id'          => \uniqid(),
                             'expire_time'           => \time() + 3600,
                             'client_id'             => 'foo',
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1094,7 +1095,7 @@ class AuthCodeGrantTest extends TestCase
     public function testRespondToAccessTokenRequestMissingCode()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1125,7 +1126,7 @@ class AuthCodeGrantTest extends TestCase
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
                 'client_secret' => 'bar',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
             ]
         );
 
@@ -1139,7 +1140,7 @@ class AuthCodeGrantTest extends TestCase
     public function testRespondToAccessTokenRequestWithRefreshTokenInsteadOfAuthCode()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1165,7 +1166,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1192,7 +1193,7 @@ class AuthCodeGrantTest extends TestCase
     public function testRespondToAccessTokenRequestWithAuthCodeNotAString()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1218,7 +1219,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => ['not', 'a', 'string'],
             ]
         );
@@ -1230,7 +1231,7 @@ class AuthCodeGrantTest extends TestCase
     public function testRespondToAccessTokenRequestExpiredCode()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1256,7 +1257,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1265,7 +1266,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1284,7 +1285,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1320,7 +1321,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1329,7 +1330,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1348,7 +1349,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1381,7 +1382,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1390,7 +1391,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'bar',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1409,7 +1410,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1442,7 +1443,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => 'sdfsfsd',
             ]
         );
@@ -1459,7 +1460,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1501,7 +1502,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => self::CODE_VERIFIER,
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -1511,7 +1512,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => 'foobar',
                             'code_challenge_method' => 'plain',
                         ]
@@ -1532,7 +1533,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1574,7 +1575,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => 'nope',
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -1584,7 +1585,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => 'foobar',
                             'code_challenge_method' => 'S256',
                         ]
@@ -1605,7 +1606,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1647,7 +1648,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => 'dqX7C-RbqjHYtytmhGTigKdZCXfxq-+xbsk9_GxUcaE', // Malformed code. Contains `+`.
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -1657,7 +1658,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => self::CODE_CHALLENGE,
                             'code_challenge_method' => 'S256',
                         ]
@@ -1678,7 +1679,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1720,7 +1721,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'    => 'authorization_code',
                 'client_id'     => 'foo',
-                'redirect_uri'  => 'http://foo/bar',
+                'redirect_uri'  => self::REDIRECT_URI,
                 'code_verifier' => 'dqX7C-RbqjHY', // Malformed code. Invalid length.
                 'code'          => $this->cryptStub->doEncrypt(
                     \json_encode(
@@ -1730,7 +1731,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => 'R7T1y1HPNFvs1WDCrx4lfoBS6KD2c71pr8OHvULjvv8',
                             'code_challenge_method' => 'S256',
                         ]
@@ -1751,7 +1752,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -1793,7 +1794,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1802,7 +1803,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'             => 'foo',
                             'user_id'               => 123,
                             'scopes'                => ['foo'],
-                            'redirect_uri'          => 'http://foo/bar',
+                            'redirect_uri'          => self::REDIRECT_URI,
                             'code_challenge'        => 'foobar',
                             'code_challenge_method' => 'plain',
                         ]
@@ -1822,7 +1823,7 @@ class AuthCodeGrantTest extends TestCase
     public function testAuthCodeRepositoryUniqueConstraintCheck()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
@@ -1908,7 +1909,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -1959,7 +1960,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -1968,7 +1969,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -1986,7 +1987,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -2027,7 +2028,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -2036,7 +2037,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -2057,7 +2058,7 @@ class AuthCodeGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('foo');
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -2098,7 +2099,7 @@ class AuthCodeGrantTest extends TestCase
             [
                 'grant_type'   => 'authorization_code',
                 'client_id'    => 'foo',
-                'redirect_uri' => 'http://foo/bar',
+                'redirect_uri' => self::REDIRECT_URI,
                 'code'         => $this->cryptStub->doEncrypt(
                     \json_encode(
                         [
@@ -2107,7 +2108,7 @@ class AuthCodeGrantTest extends TestCase
                             'client_id'    => 'foo',
                             'user_id'      => 123,
                             'scopes'       => ['foo'],
-                            'redirect_uri' => 'http://foo/bar',
+                            'redirect_uri' => self::REDIRECT_URI,
                         ]
                     )
                 ),
@@ -2140,7 +2141,7 @@ class AuthCodeGrantTest extends TestCase
     public function testPublicClientAuthCodeRequestRejectedWhenCodeChallengeRequiredButNotGiven()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
@@ -2162,7 +2163,7 @@ class AuthCodeGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type' => 'code',
             'client_id'     => 'foo',
-            'redirect_uri'  => 'http://foo/bar',
+            'redirect_uri'  => self::REDIRECT_URI,
         ]);
 
         $this->expectException(OAuthServerException::class);
@@ -2174,7 +2175,7 @@ class AuthCodeGrantTest extends TestCase
     public function testUseValidRedirectUriIfScopeCheckFails()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri(['http://foo/bar', 'http://bar/foo']);
+        $client->setRedirectUri([self::REDIRECT_URI, 'http://bar/foo']);
         $client->setConfidential();
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -457,9 +457,12 @@ class AuthCodeGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequest()
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
@@ -478,9 +481,12 @@ class AuthCodeGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequestDenied()
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(false);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
@@ -1815,9 +1821,12 @@ class AuthCodeGrantTest extends TestCase
 
     public function testAuthCodeRepositoryUniqueConstraintCheck()
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 class ImplicitGrantTest extends TestCase
 {
     const DEFAULT_SCOPE = 'basic';
+    const REDIRECT_URI = 'https://foo/bar';
 
     /**
      * CryptTrait stub
@@ -79,7 +80,7 @@ class ImplicitGrantTest extends TestCase
     public function testValidateAuthorizationRequest()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -95,7 +96,7 @@ class ImplicitGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type' => 'code',
             'client_id'     => 'foo',
-            'redirect_uri'  => 'http://foo/bar',
+            'redirect_uri'  => self::REDIRECT_URI,
         ]);
 
         $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
@@ -104,7 +105,7 @@ class ImplicitGrantTest extends TestCase
     public function testValidateAuthorizationRequestRedirectUriArray()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri(['http://foo/bar']);
+        $client->setRedirectUri([self::REDIRECT_URI]);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -120,7 +121,7 @@ class ImplicitGrantTest extends TestCase
         $request = (new ServerRequest())->withQueryParams([
             'response_type' => 'code',
             'client_id' => 'foo',
-            'redirect_uri' => 'http://foo/bar',
+            'redirect_uri' => self::REDIRECT_URI,
         ]);
 
         $this->assertInstanceOf(AuthorizationRequest::class, $grant->validateAuthorizationRequest($request));
@@ -163,7 +164,7 @@ class ImplicitGrantTest extends TestCase
     public function testValidateAuthorizationRequestBadRedirectUriString()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('http://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -185,7 +186,7 @@ class ImplicitGrantTest extends TestCase
     public function testValidateAuthorizationRequestBadRedirectUriArray()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri(['http://foo/bar']);
+        $client->setRedirectUri([self::REDIRECT_URI]);
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
@@ -208,7 +209,7 @@ class ImplicitGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('identifier');
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
@@ -237,7 +238,7 @@ class ImplicitGrantTest extends TestCase
     public function testCompleteAuthorizationRequestDenied()
     {
         $client = new ClientEntity();
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(false);
@@ -267,7 +268,7 @@ class ImplicitGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('identifier');
-        $client->setRedirectUri('https://foo/bar');
+        $client->setRedirectUri(self::REDIRECT_URI);
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -208,6 +208,7 @@ class ImplicitGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('identifier');
+        $client->setRedirectUri('https://foo/bar');
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);
@@ -235,9 +236,12 @@ class ImplicitGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequestDenied()
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(false);
-        $authRequest->setClient(new ClientEntity());
+        $authRequest->setClient($client);
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
@@ -263,6 +267,7 @@ class ImplicitGrantTest extends TestCase
     {
         $client = new ClientEntity();
         $client->setIdentifier('identifier');
+        $client->setRedirectUri('https://foo/bar');
 
         $authRequest = new AuthorizationRequest();
         $authRequest->setAuthorizationApproved(true);

--- a/tests/Stubs/ScopeEntity.php
+++ b/tests/Stubs/ScopeEntity.php
@@ -9,6 +9,7 @@ class ScopeEntity implements ScopeEntityInterface
 {
     use EntityTrait;
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->getIdentifier();


### PR DESCRIPTION
This fixes deprecation notices for PHP 8.x that appear in the test suite