### PR TITLE
Tweaked version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,15 @@
     "homepage": "https://oauth2.thephpleague.com/",
     "license": "MIT",
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "^8.0",
         "ext-openssl": "*",
         "league/event": "^2.2",
         "league/uri": "^6.7",
-        "lcobucci/jwt": "^4.3.0 || ^5.0.0",
+        "lcobucci/jwt": "^4.3 || ^5.0",
         "psr/http-message": "^1.0.1",
-        "defuse/php-encryption": "^2.3.0",
+        "defuse/php-encryption": "^2.3",
         "ext-json": "*",
-        "lcobucci/clock": "^2.2.0 || ^3.1.0"
+        "lcobucci/clock": "^2.2 || ^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.6",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/http-message": "^1.0.1",
         "defuse/php-encryption": "^2.3",
         "ext-json": "*",
-        "lcobucci/clock": "^2.2 || ^3.1"
+        "lcobucci/clock": "^2.2 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6.6",


### PR DESCRIPTION
The important change is the PHP version. It is too late to apply an upper-bound in a major release series - composer will just go and get v8.4.1 instead of v8.5.0 which is definitely worse. ;)