### PR TITLE
Pass along previous exception

### DIFF
--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -113,7 +113,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             $constraints = $this->jwtConfiguration->validationConstraints();
             $this->jwtConfiguration->validator()->assert($token, ...$constraints);
         } catch (RequiredConstraintsViolated $exception) {
-            throw OAuthServerException::accessDenied('Access token could not be verified');
+            throw OAuthServerException::accessDenied('Access token could not be verified', null, $exception);
         }
 
         $claims = $token->claims();


### PR DESCRIPTION
The current message is ambiguous on it's own. Supplementing the exception with the previously caught exception helps debug _which_ constraint was violated.