### PR TITLE
Added auth_code event

### DIFF
--- a/src/AuthCodeEvent.php
+++ b/src/AuthCodeEvent.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+namespace League\OAuth2\Server;
+
+use League\Event\Event;
+use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
+
+class AuthCodeEvent extends Event
+{
+    const AUTH_CODE_ISSUED = 'auth_code.issued';
+
+    /**
+     * @var AuthCodeEntityInterface
+     */
+    private $authCode;
+
+    public function __construct(AuthCodeEntityInterface $authCode)
+    {
+        parent::__construct(self::AUTH_CODE_ISSUED);
+        $this->authCode = $authCode;
+    }
+
+    /**
+     * @return AuthCodeEntityInterface
+     *
+     * @codeCoverageIgnore
+     */
+    public function getAuthCode()
+    {
+        return $this->authCode;
+    }
+}

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -15,6 +15,7 @@ use DateTimeImmutable;
 use Error;
 use Exception;
 use League\Event\EmitterAwareTrait;
+use League\OAuth2\Server\AuthCodeEvent;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
@@ -507,6 +508,8 @@ abstract class AbstractGrant implements GrantTypeInterface
         foreach ($scopes as $scope) {
             $authCode->addScope($scope);
         }
+
+        $this->getEmitter()->emit(new AuthCodeEvent($authCode));
 
         while ($maxGenerationAttempts-- > 0) {
             $authCode->setIdentifier($this->generateUniqueIdentifier());


### PR DESCRIPTION
Like events are emitted (#1211) when the access and refresh tokens are created, I've added an event when the auth_code is created.

Using this event, I am able to add state to the auth_code, which I need to generate the correct access token, later