### PR TITLE
Remove requirement of json extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "lcobucci/jwt": "^4.3 || ^5.0",
         "psr/http-message": "^1.0.1",
         "defuse/php-encryption": "^2.3",
-        "ext-json": "*",
         "lcobucci/clock": "^2.2 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since PHP 8.0, `ext-json` is part of PHP core and cannot be disabled (see https://www.php.net/manual/en/json.installation.php).

I think it can be removed from `composer.json` require section.