### PR TITLE
Fix PHP 8 Test Runner

### DIFF
--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -54,9 +54,6 @@ class CryptKeyTest extends TestCase
 
     public function testUnsupportedKeyType()
     {
-        if (\str_starts_with(\phpversion(), '8.0')) {
-            $this->markTestSkipped('Cannot generate key on PHP 8.0 runner. Investigating');
-        }
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Unable to read key');
 


### PR DESCRIPTION
This PR reinstates some tests that were skipped by the PHP 8.0 test runner due to an open SSL compat issue on the host OS