### PR TITLE
Fix inconsistent var

### DIFF
--- a/src/Entities/Traits/EntityTrait.php
+++ b/src/Entities/Traits/EntityTrait.php
@@ -12,7 +12,7 @@ namespace League\OAuth2\Server\Entities\Traits;
 trait EntityTrait
 {
     /**
-     * @var string
+     * @var mixed
      */
     protected $identifier;
 


### PR DESCRIPTION
Fix inconsistent ```@var``` based on ```@param``` and ```@return``` in the same class