### PR TITLE
Remove Key Leak 8.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [8.4.2] - released 2023-07-xx
+### Security
+- If a key string is provided to the CryptKey constructor with an invalid
+  passphrase, the LogicException message generated will contain the given key.
+  The key is no longer leaked via this exception (PR #1353)
+
 ## [8.4.1] - released 2023-03-22
 ### Fixed
 - Fix deprecation notices for PHP 8.x (PR #1329)

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -64,7 +64,7 @@ class CryptKey
                 throw new LogicException('Unable to read key from file ' . $keyPath);
             }
         } else {
-            throw new LogicException('Unable to read key from file ' . $keyPath);
+            throw new LogicException('Invalid key supplied');
         }
 
         if ($keyPermissionsCheck === true) {

--- a/tests/Utils/CryptKeyTest.php
+++ b/tests/Utils/CryptKeyTest.php
@@ -55,7 +55,7 @@ class CryptKeyTest extends TestCase
     public function testUnsupportedKeyType()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Unable to read key');
+        $this->expectExceptionMessage('Invalid key supplied');
 
         try {
             // Create the keypair


### PR DESCRIPTION
Could we consider a 8.4.x branch for security updates, so this can be maintained separately?

Running into issues with Snyk with oauth2-server-bundle, and am bound to PHP 7.x.
I'm porting over a commit from this PR: https://github.com/thephpleague/oauth2-server/pull/1353