### PR TITLE
RefreshTokenGrant: add option whether to revoke refreshed access tokens

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -85,6 +85,11 @@ class AuthorizationServer implements EmitterAwareInterface
     private $revokeRefreshTokens = true;
 
     /**
+     * @var bool
+     */
+    private $revokeRefreshedAccessTokens = true;
+
+    /**
      * New server instance.
      *
      * @param ClientRepositoryInterface      $clientRepository
@@ -142,6 +147,7 @@ class AuthorizationServer implements EmitterAwareInterface
         $grantType->setEmitter($this->getEmitter());
         $grantType->setEncryptionKey($this->encryptionKey);
         $grantType->revokeRefreshTokens($this->revokeRefreshTokens);
+        $grantType->revokeRefreshedAccessTokens($this->revokeRefreshedAccessTokens);
 
         $this->enabledGrantTypes[$grantType->getIdentifier()] = $grantType;
         $this->grantTypeAccessTokenTTL[$grantType->getIdentifier()] = $accessTokenTTL;
@@ -248,5 +254,15 @@ class AuthorizationServer implements EmitterAwareInterface
     public function revokeRefreshTokens(bool $revokeRefreshTokens): void
     {
         $this->revokeRefreshTokens = $revokeRefreshTokens;
+    }
+
+    /**
+     * Sets whether to revoke access tokens after they were refreshed or not (for all grant types).
+     *
+     * @param bool $revokeRefreshedAccessTokens
+     */
+    public function revokeRefreshedAccessTokens(bool $revokeRefreshedAccessTokens): void
+    {
+        $this->revokeRefreshedAccessTokens = $revokeRefreshedAccessTokens;
     }
 }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -99,6 +99,11 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected $revokeRefreshTokens;
 
     /**
+     * @var bool
+     */
+    protected $revokeRefreshedAccessTokens;
+
+    /**
      * @param ClientRepositoryInterface $clientRepository
      */
     public function setClientRepository(ClientRepositoryInterface $clientRepository)
@@ -178,6 +183,14 @@ abstract class AbstractGrant implements GrantTypeInterface
     public function revokeRefreshTokens(bool $revokeRefreshTokens)
     {
         $this->revokeRefreshTokens = $revokeRefreshTokens;
+    }
+
+    /**
+     * @param bool $revokeRefreshedAccessTokens
+     */
+    public function revokeRefreshedAccessTokens(bool $revokeRefreshedAccessTokens)
+    {
+        $this->revokeRefreshedAccessTokens = $revokeRefreshedAccessTokens;
     }
 
     /**

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -64,7 +64,9 @@ class RefreshTokenGrant extends AbstractGrant
         }
 
         // Expire old tokens
-        $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
+        if ($this->revokeRefreshedAccessTokens) {
+            $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);
+        }
         if ($this->revokeRefreshTokens) {
             $this->refreshTokenRepository->revokeRefreshToken($oldRefreshToken['refresh_token_id']);
         }

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -699,5 +699,4 @@ class RefreshTokenGrantTest extends TestCase
 
         Assert::assertFalse($accessTokenRepositoryMock->isAccessTokenRevoked($accessTokenId));
     }
-
 }


### PR DESCRIPTION
Currently, the `RefreshTokenGrant` immediately revokes an access token when it gets refreshed.

The [RFC Section 6](https://www.rfc-editor.org/rfc/rfc6749#section-6) makes no mention that this should happen. 

The current behavior sometimes causes issues: Some clients assume the old access token is still valid because it has not reached its expiration date yet. Also, there are race conditions with simultaneous requests when one client refreshes the token and the other client still uses the old, non-expired token.

This PR adds an option `revokeRefreshedAccessTokens` to configure revoking old access token after refreshing. It defaults to `true`, wich is the current behaviour. 

Also see #1347