### PR TITLE
Split the `AccessTokenTrait::convertToJWT()` function so that the token can be customized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `getJwtBuilder()` function was added to the `AccessTokenTrait` to allow customization of the access token (PR #1382)
 
 ## [8.5.4] - released 2023-08-25
 ### Added

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -10,6 +10,7 @@
 namespace League\OAuth2\Server\Entities\Traits;
 
 use DateTimeImmutable;
+use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
@@ -51,11 +52,11 @@ trait AccessTokenTrait
     }
 
     /**
-     * Generate a JWT from the access token
+     * Get the JWT builder and apply default claims
      *
-     * @return Token
+     * @return Builder
      */
-    private function convertToJWT()
+    private function getJwtBuilder()
     {
         $this->initJwtConfiguration();
 
@@ -66,7 +67,17 @@ trait AccessTokenTrait
             ->canOnlyBeUsedAfter(new DateTimeImmutable())
             ->expiresAt($this->getExpiryDateTime())
             ->relatedTo((string) $this->getUserIdentifier())
-            ->withClaim('scopes', $this->getScopes())
+            ->withClaim('scopes', $this->getScopes());
+    }
+
+    /**
+     * Generate a JWT from the access token
+     *
+     * @return Token
+     */
+    private function convertToJWT()
+    {
+        return $this->getJwtBuilder()
             ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
     }
 


### PR DESCRIPTION
Split the `\League\OAuth2\Server\Entities\Traits\AccessTokenTrait::convertToJWT()` function into two separate functions so that implementing classes can customize the token. E.g.

```php
class AccessToken implements AccessTokenEntityInterface
{
// ...
    use AccessTokenTrait {
        getJwtBuilder as traitGetJwtBuilder;
    }
// ...
    private function getJwtBuilder()
    {
        $builder = $this->traitGetJwtBuilder();

        $builder->withClaim('my_custom_claim', 'custom claim value');

        return $builder;
    }
```