### PR TITLE
[gh-pages] Add Resonance Framework Integration

### DIFF
--- a/framework-integrations.md
+++ b/framework-integrations.md
@@ -12,6 +12,7 @@ permalink: /framework-integrations/
 * [Laravel Passport (Official)](https://laravel.com/docs/passport)
 * [Nette Framework](https://github.com/lookyman/nette-oauth2-server)
 * [Phalcon Framework](https://github.com/tegaphilip/padlock)
+* [Resonance](https://resonance.distantmagic.com/docs/features/security/oauth2)
 * Slim (or any PSR7-supporting framework) - See the examples in this repository
 * [Symfony](https://github.com/thephpleague/oauth2-server-bundle)
 


### PR DESCRIPTION
I integrated oauth2-server into the Resonance Framework (https://resonance.distantmagic.com/docs/features/security/oauth2/). 

This pull request adds a link to that documentation page (inserted in alphabetical order).

Thank you for the OAuth2 Server library. If you want me to change anything in this PR I will be happy to do so.