### PR TITLE
Make Basic Auth Case Insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Basic authorization is now case insensitive (PR #XXX)
+- Basic authorization is now case insensitive (PR #1403)
 
 ## [9.0.0-RC1] - released 2024-03-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Basic authorization is now case insensitive (PR #XXX)
 
 ## [9.0.0-RC1] - released 2024-03-27
 ### Added

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -310,7 +310,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         }
 
         $header = $request->getHeader('Authorization')[0];
-        if (strpos($header, 'Basic ') !== 0) {
+        if (stripos($header, 'Basic ') !== 0) {
             return [null, null];
         }
 

--- a/tests/Grant/AbstractGrantTest.php
+++ b/tests/Grant/AbstractGrantTest.php
@@ -70,6 +70,19 @@ class AbstractGrantTest extends TestCase
         self::assertSame([null, null], $basicAuthMethod->invoke($grantMock, $serverRequest));
     }
 
+    public function testHttpBasicCaseInsensitive(): void
+    {
+        /** @var AbstractGrant $grantMock */
+        $grantMock = $this->getMockForAbstractClass(AbstractGrant::class);
+        $abstractGrantReflection = new ReflectionClass($grantMock);
+
+        $serverRequest = (new ServerRequest())->withHeader('Authorization', 'bAsIc ' . base64_encode('Open:Sesame'));
+        $basicAuthMethod = $abstractGrantReflection->getMethod('getBasicAuthCredentials');
+        $basicAuthMethod->setAccessible(true);
+
+        self::assertSame(['Open', 'Sesame'], $basicAuthMethod->invoke($grantMock, $serverRequest));
+    }
+
     public function testHttpBasicNotBase64(): void
     {
         /** @var AbstractGrant $grantMock */


### PR DESCRIPTION
Allows the word Basic to be case insensitive when retrieving basic auth credentials. Reported in issue #1399 