### PR TITLE
Parse request parameters

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,7 +3,3 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
-        -
-          message: '#Call to an undefined method League\\OAuth2\\Server\\ResponseTypes\\ResponseTypeInterface::getAccessToken\(\)\.#'
-          path: tests/Grant/ClientCredentialsGrantTest.php 

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -43,13 +43,13 @@ class CryptKey implements CryptKeyInterface
 
     public function __construct(string $keyPath, protected ?string $passPhrase = null, bool $keyPermissionsCheck = true)
     {
-        if (strpos($keyPath, self::FILE_PREFIX) !== 0 && $this->isValidKey($keyPath, $this->passPhrase ?? '')) {
+        if (!str_starts_with($keyPath, self::FILE_PREFIX) && $this->isValidKey($keyPath, $this->passPhrase ?? '')) {
             $this->keyContents = $keyPath;
             $this->keyPath = '';
             // There's no file, so no need for permission check.
             $keyPermissionsCheck = false;
         } elseif (is_file($keyPath)) {
-            if (strpos($keyPath, self::FILE_PREFIX) !== 0) {
+            if (!str_starts_with($keyPath, self::FILE_PREFIX)) {
                 $keyPath = self::FILE_PREFIX . $keyPath;
             }
 

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -269,9 +269,9 @@ class OAuthServerException extends Exception
 
         if ($this->redirectUri !== null) {
             if ($useFragment === true) {
-                $this->redirectUri .= (strstr($this->redirectUri, '#') === false) ? '#' : '&';
+                $this->redirectUri .= (!str_contains($this->redirectUri, '#')) ? '#' : '&';
             } else {
-                $this->redirectUri .= (strstr($this->redirectUri, '?') === false) ? '?' : '&';
+                $this->redirectUri .= (!str_contains($this->redirectUri, '?')) ? '?' : '&';
             }
 
             return $response->withStatus(302)->withHeader('Location', $this->redirectUri . http_build_query($payload));
@@ -310,7 +310,7 @@ class OAuthServerException extends Exception
         // include the "WWW-Authenticate" response header field
         // matching the authentication scheme used by the client.
         if ($this->errorType === 'invalid_client' && $this->requestHasAuthorizationHeader()) {
-            $authScheme = strpos($this->serverRequest->getHeader('Authorization')[0], 'Bearer') === 0 ? 'Bearer' : 'Basic';
+            $authScheme = str_starts_with($this->serverRequest->getHeader('Authorization')[0], 'Bearer') ? 'Bearer' : 'Basic';
 
             $headers['WWW-Authenticate'] = $authScheme . ' realm="OAuth"';
         }

--- a/src/Grant/AbstractAuthorizeGrant.php
+++ b/src/Grant/AbstractAuthorizeGrant.php
@@ -18,16 +18,15 @@ use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 
 use function http_build_query;
-use function strstr;
 
 abstract class AbstractAuthorizeGrant extends AbstractGrant
 {
     /**
-     * @param mixed[] $params
+     * @param array<array-key,mixed> $params
      */
     public function makeRedirectUri(string $uri, array $params = [], string $queryDelimiter = '?'): string
     {
-        $uri .= (strstr($uri, $queryDelimiter) === false) ? $queryDelimiter : '&';
+        $uri .= str_contains($uri, $queryDelimiter) ? '&' : $queryDelimiter;
 
         return $uri . http_build_query($params);
     }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -49,10 +49,8 @@ use function array_key_exists;
 use function base64_decode;
 use function bin2hex;
 use function explode;
-use function is_null;
 use function is_string;
 use function random_bytes;
-use function strpos;
 use function substr;
 use function trim;
 
@@ -129,9 +127,9 @@ abstract class AbstractGrant implements GrantTypeInterface
     /**
      * Set the private key
      */
-    public function setPrivateKey(CryptKeyInterface $key): void
+    public function setPrivateKey(CryptKeyInterface $privateKey): void
     {
-        $this->privateKey = $key;
+        $this->privateKey = $privateKey;
     }
 
     public function setDefaultScope(string $scope): void
@@ -139,9 +137,9 @@ abstract class AbstractGrant implements GrantTypeInterface
         $this->defaultScope = $scope;
     }
 
-    public function revokeRefreshTokens(bool $revokeRefreshTokens): void
+    public function revokeRefreshTokens(bool $willRevoke): void
     {
-        $this->revokeRefreshTokens = $revokeRefreshTokens;
+        $this->revokeRefreshTokens = $willRevoke;
     }
 
     /**
@@ -161,13 +159,9 @@ abstract class AbstractGrant implements GrantTypeInterface
         $client = $this->getClientEntityOrFail($clientId, $request);
 
         // If a redirect URI is provided ensure it matches what is pre-registered
-        $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
+        $redirectUri = $this->getRequestParameter('redirect_uri', $request);
 
         if ($redirectUri !== null) {
-            if (!is_string($redirectUri)) {
-                throw OAuthServerException::invalidRequest('redirect_uri');
-            }
-
             $this->validateRedirectUri($redirectUri, $client, $request);
         }
 
@@ -183,6 +177,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      * doesn't actually enforce non-null returns/exception-on-no-client so
      * getClientEntity might return null. By contrast, this method will
      * always either return a ClientEntityInterface or throw.
+     * @throws OAuthServerException
      */
     protected function getClientEntityOrFail(string $clientId, ServerRequestInterface $request): ClientEntityInterface
     {
@@ -200,7 +195,8 @@ abstract class AbstractGrant implements GrantTypeInterface
      * Gets the client credentials from the request from the request body or
      * the Http Basic Authorization header
      *
-     * @return mixed[]
+     * @return array{0:non-empty-string,1:string}
+     * @throws OAuthServerException
      */
     protected function getClientCredentials(ServerRequestInterface $request): array
     {
@@ -208,17 +204,13 @@ abstract class AbstractGrant implements GrantTypeInterface
 
         $clientId = $this->getRequestParameter('client_id', $request, $basicAuthUser);
 
-        if (is_null($clientId)) {
+        if ($clientId === null) {
             throw OAuthServerException::invalidRequest('client_id');
         }
 
         $clientSecret = $this->getRequestParameter('client_secret', $request, $basicAuthPassword);
 
-        if ($clientSecret !== null && !is_string($clientSecret)) {
-            throw OAuthServerException::invalidRequest('client_secret');
-        }
-
-        return [$clientId, $clientSecret];
+        return [$clientId, $clientSecret ?? ''];
     }
 
     /**
@@ -279,19 +271,43 @@ abstract class AbstractGrant implements GrantTypeInterface
      */
     private function convertScopesQueryStringToArray(string $scopes): array
     {
-        return array_filter(explode(self::SCOPE_DELIMITER_STRING, trim($scopes)), function ($scope) {
-            return $scope !== '';
-        });
+        return array_filter(explode(self::SCOPE_DELIMITER_STRING, trim($scopes)), static fn($scope) => $scope !== '');
+    }
+
+    /**
+     * Parse request parameter.
+     * @param array<array-key, mixed> $request
+     * @return non-empty-string|null
+     * @throws OAuthServerException
+     */
+    private static function parseParam(string $parameter, array $request, ?string $default = null): ?string
+    {
+        $value = $request[$parameter] ?? '';
+        if (is_scalar($value)) {
+            $value = trim((string)$value);
+        } else {
+            throw OAuthServerException::invalidRequest($parameter);
+        }
+
+        if ($value === '') {
+            $value = $default === null ? null : trim($default);
+            if ($value === '') {
+                $value = null;
+            }
+        }
+
+        return $value;
     }
 
     /**
      * Retrieve request parameter.
+     *
+     * @return non-empty-string|null
+     * @throws OAuthServerException
      */
-    protected function getRequestParameter(string $parameter, ServerRequestInterface $request, mixed $default = null): mixed
+    protected function getRequestParameter(string $parameter, ServerRequestInterface $request, ?string $default = null): ?string
     {
-        $requestParameters = (array) $request->getParsedBody();
-
-        return $requestParameters[$parameter] ?? $default;
+        return self::parseParam($parameter, (array) $request->getParsedBody(), $default);
     }
 
     /**
@@ -301,7 +317,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      * not exist, or is otherwise an invalid HTTP Basic header, return
      * [null, null].
      *
-     * @return string[]|null[]
+     * @return array{0:non-empty-string,1:string}|array{0:null,1:null}
      */
     protected function getBasicAuthCredentials(ServerRequestInterface $request): array
     {
@@ -310,7 +326,7 @@ abstract class AbstractGrant implements GrantTypeInterface
         }
 
         $header = $request->getHeader('Authorization')[0];
-        if (strpos($header, 'Basic ') !== 0) {
+        if (!str_starts_with($header, 'Basic ')) {
             return [null, null];
         }
 
@@ -320,35 +336,47 @@ abstract class AbstractGrant implements GrantTypeInterface
             return [null, null];
         }
 
-        if (strpos($decoded, ':') === false) {
+        if (!str_contains($decoded, ':')) {
             return [null, null]; // HTTP Basic header without colon isn't valid
         }
 
-        return explode(':', $decoded, 2);
+        [$username, $password] = explode(':', $decoded, 2);
+
+        if ($username === '') {
+            return [null, null];
+        }
+
+        return [$username, $password];
     }
 
     /**
      * Retrieve query string parameter.
+     * @return non-empty-string|null
+     * @throws OAuthServerException
      */
-    protected function getQueryStringParameter(string $parameter, ServerRequestInterface $request, mixed $default = null): mixed
+    protected function getQueryStringParameter(string $parameter, ServerRequestInterface $request, ?string $default = null): ?string
     {
-        return isset($request->getQueryParams()[$parameter]) ? $request->getQueryParams()[$parameter] : $default;
+        return self::parseParam($parameter, $request->getQueryParams(), $default);
     }
 
     /**
      * Retrieve cookie parameter.
+     * @return non-empty-string|null
+     * @throws OAuthServerException
      */
-    protected function getCookieParameter(string $parameter, ServerRequestInterface $request, mixed $default = null): mixed
+    protected function getCookieParameter(string $parameter, ServerRequestInterface $request, ?string $default = null): ?string
     {
-        return isset($request->getCookieParams()[$parameter]) ? $request->getCookieParams()[$parameter] : $default;
+        return self::parseParam($parameter, $request->getCookieParams(), $default);
     }
 
     /**
      * Retrieve server parameter.
+     * @return non-empty-string|null
+     * @throws OAuthServerException
      */
-    protected function getServerParameter(string $parameter, ServerRequestInterface $request, mixed $default = null): mixed
+    protected function getServerParameter(string $parameter, ServerRequestInterface $request, ?string $default = null): ?string
     {
-        return isset($request->getServerParams()[$parameter]) ? $request->getServerParams()[$parameter] : $default;
+        return self::parseParam($parameter, $request->getServerParams(), $default);
     }
 
     /**

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -41,7 +41,6 @@ use function hash_algos;
 use function implode;
 use function in_array;
 use function is_array;
-use function is_string;
 use function json_decode;
 use function json_encode;
 use function preg_match;
@@ -106,9 +105,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             $this->validateClient($request);
         }
 
-        $encryptedAuthCode = $this->getRequestParameter('code', $request, null);
+        $encryptedAuthCode = $this->getRequestParameter('code', $request);
 
-        if (!is_string($encryptedAuthCode)) {
+        if ($encryptedAuthCode === null) {
             throw OAuthServerException::invalidRequest('code');
         }
 
@@ -128,7 +127,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             throw OAuthServerException::invalidRequest('code', 'Cannot decrypt the authorization code', $e);
         }
 
-        $codeVerifier = $this->getRequestParameter('code_verifier', $request, null);
+        $codeVerifier = $this->getRequestParameter('code_verifier', $request);
 
         // If a code challenge isn't present but a code verifier is, reject the request to block PKCE downgrade attack
         if (!isset($authCodePayload->code_challenge) && $codeVerifier !== null) {
@@ -219,7 +218,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         }
 
         // The redirect URI is required in this request
-        $redirectUri = $this->getRequestParameter('redirect_uri', $request, null);
+        $redirectUri = $this->getRequestParameter('redirect_uri', $request);
         if ($authCodePayload->redirect_uri !== '' && $redirectUri === null) {
             throw OAuthServerException::invalidRequest('redirect_uri');
         }

--- a/src/Grant/DeviceCodeGrant.php
+++ b/src/Grant/DeviceCodeGrant.php
@@ -304,7 +304,7 @@ class DeviceCodeGrant extends AbstractGrant
 
             return $userCode;
             // @codeCoverageIgnoreStart
-        } catch (TypeError|Error $e) {
+        } catch (TypeError | Error $e) {
             throw OAuthServerException::serverError('An unexpected error has occurred', $e);
         } catch (Exception $e) {
             // If you get this message, the CSPRNG failed hard.

--- a/src/Grant/DeviceCodeGrant.php
+++ b/src/Grant/DeviceCodeGrant.php
@@ -304,9 +304,7 @@ class DeviceCodeGrant extends AbstractGrant
 
             return $userCode;
             // @codeCoverageIgnoreStart
-        } catch (TypeError $e) {
-            throw OAuthServerException::serverError('An unexpected error has occurred', $e);
-        } catch (Error $e) {
+        } catch (TypeError|Error $e) {
             throw OAuthServerException::serverError('An unexpected error has occurred', $e);
         } catch (Exception $e) {
             // If you get this message, the CSPRNG failed hard.

--- a/src/Grant/PasswordGrant.php
+++ b/src/Grant/PasswordGrant.php
@@ -26,8 +26,6 @@ use League\OAuth2\Server\RequestRefreshTokenEvent;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function is_string;
-
 /**
  * Password grant class.
  */
@@ -84,17 +82,11 @@ class PasswordGrant extends AbstractGrant
      */
     protected function validateUser(ServerRequestInterface $request, ClientEntityInterface $client): UserEntityInterface
     {
-        $username = $this->getRequestParameter('username', $request);
+        $username = $this->getRequestParameter('username', $request)
+            ?? throw OAuthServerException::invalidRequest('username');
 
-        if (!is_string($username)) {
-            throw OAuthServerException::invalidRequest('username');
-        }
-
-        $password = $this->getRequestParameter('password', $request);
-
-        if (!is_string($password)) {
-            throw OAuthServerException::invalidRequest('password');
-        }
+        $password = $this->getRequestParameter('password', $request)
+            ?? throw OAuthServerException::invalidRequest('password');
 
         $user = $this->userRepository->getUserEntityByUserCredentials(
             $username,

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -26,7 +26,6 @@ use Psr\Http\Message\ServerRequestInterface;
 
 use function implode;
 use function in_array;
-use function is_string;
 use function json_decode;
 use function time;
 
@@ -103,11 +102,8 @@ class RefreshTokenGrant extends AbstractGrant
      */
     protected function validateOldRefreshToken(ServerRequestInterface $request, string $clientId): array
     {
-        $encryptedRefreshToken = $this->getRequestParameter('refresh_token', $request);
-
-        if (!is_string($encryptedRefreshToken)) {
-            throw OAuthServerException::invalidRequest('refresh_token');
-        }
+        $encryptedRefreshToken = $this->getRequestParameter('refresh_token', $request)
+            ?? throw OAuthServerException::invalidRequest('refresh_token');
 
         // Validate refresh token
         try {

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -73,7 +73,7 @@ class BearerTokenResponse extends AbstractResponseType
      * AuthorizationServer::getResponseType() to pull in your version of
      * this class rather than the default.
      *
-     * @return mixed[]
+     * @return array<array-key,mixed>
      */
     protected function getExtraParams(AccessTokenEntityInterface $accessToken): array
     {

--- a/src/ResponseTypes/DeviceCodeResponse.php
+++ b/src/ResponseTypes/DeviceCodeResponse.php
@@ -84,7 +84,7 @@ class DeviceCodeResponse extends AbstractResponseType
      * AuthorizationServer::getResponseType() to pull in your version of
      * this class rather than the default.
      *
-     * @return mixed[]
+     * @return array<array-key,mixed>
      */
     protected function getExtraParams(DeviceCodeEntityInterface $deviceCode): array
     {

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -123,7 +123,7 @@ class OAuthServerExceptionTest extends TestCase
         $previous = new Exception('This is the previous');
         $exceptionWithPrevious = OAuthServerException::accessDenied(null, null, $previous);
 
-        $previousMessage = $exceptionWithPrevious->getPrevious() !== null ? $exceptionWithPrevious->getPrevious()->getMessage() : null;
+        $previousMessage = $exceptionWithPrevious->getPrevious()?->getMessage();
 
         self::assertSame('This is the previous', $previousMessage);
     }

--- a/tests/Grant/ClientCredentialsGrantTest.php
+++ b/tests/Grant/ClientCredentialsGrantTest.php
@@ -59,6 +59,8 @@ class ClientCredentialsGrantTest extends TestCase
         ]);
 
         $responseType = new StubResponseType();
+
+        /** @var StubResponseType $response */
         $response = $grant->respondToAccessTokenRequest($serverRequest, $responseType, new DateInterval('PT5M'));
 
         self::assertNotEmpty($response->getAccessToken()->getIdentifier());

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -23,6 +23,7 @@ use LeagueTests\Stubs\ScopeEntity;
 use LeagueTests\Stubs\StubResponseType;
 use LeagueTests\Stubs\UserEntity;
 use LogicException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class ImplicitGrantTest extends TestCase
@@ -282,7 +283,7 @@ class ImplicitGrantTest extends TestCase
         $accessToken->setClient($client);
         $accessToken->setUserIdentifier('userId');
 
-        /** @var AccessTokenRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject $accessTokenRepositoryMock */
+        /** @var AccessTokenRepositoryInterface|MockObject $accessTokenRepositoryMock */
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
 
@@ -321,7 +322,7 @@ class ImplicitGrantTest extends TestCase
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
-        /** @var AccessTokenRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject $accessTokenRepositoryMock */
+        /** @var AccessTokenRepositoryInterface|MockObject $accessTokenRepositoryMock */
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willThrowException(OAuthServerException::serverError('something bad happened'));
@@ -353,7 +354,7 @@ class ImplicitGrantTest extends TestCase
         $authRequest->setGrantTypeId('authorization_code');
         $authRequest->setUser(new UserEntity());
 
-        /** @var AccessTokenRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject $accessTokenRepositoryMock */
+        /** @var AccessTokenRepositoryInterface|MockObject $accessTokenRepositoryMock */
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willThrowException(UniqueTokenIdentifierConstraintViolationException::create());

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -595,7 +595,7 @@ class RefreshTokenGrantTest extends TestCase
            'client_id'     => 'foo',
            'client_secret' => 'bar',
            'refresh_token' => $encryptedOldRefreshToken,
-           'scope'         =>  ['foo', 'bar'],
+           'scope'         =>  'foo bar',
         ]);
 
         $responseType = new StubResponseType();
@@ -654,7 +654,7 @@ class RefreshTokenGrantTest extends TestCase
             'client_id'     => 'foo',
             'client_secret' => 'bar',
             'refresh_token' => $encryptedOldRefreshToken,
-            'scope'         => ['foo'],
+            'scope'         => 'foo',
         ]);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
@@ -719,7 +719,7 @@ class RefreshTokenGrantTest extends TestCase
             'client_id'     => 'foo',
             'client_secret' => 'bar',
             'refresh_token' => $encryptedOldRefreshToken,
-            'scope'         => ['foo'],
+            'scope'         => 'foo',
         ]);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);

--- a/tests/Stubs/StubResponseType.php
+++ b/tests/Stubs/StubResponseType.php
@@ -35,7 +35,7 @@ class StubResponseType extends AbstractResponseType
     }
 
     /**
-     * @throws \League\OAuth2\Server\Exception\OAuthServerException
+     * @throws OAuthServerException
      */
     public function validateAccessToken(ServerRequestInterface $request): ServerRequestInterface
     {


### PR DESCRIPTION
@Sephster I have implemented my proposal.

- Params parsed to non-empty string
- Scalar params cast to string
- Empty string treats as null
- Non-scalar params throws invalidRequest
- Remove string checks
- Null checks have been shorten to null-coalesce operator

I will be glad if it helps.