### PR TITLE
Deny access if user is not authenticated

### DIFF
--- a/src/Grant/AbstractAuthorizeGrant.php
+++ b/src/Grant/AbstractAuthorizeGrant.php
@@ -35,4 +35,14 @@ abstract class AbstractAuthorizeGrant extends AbstractGrant
     {
         return new AuthorizationRequest();
     }
+
+    /**
+     * Get the client redirect URI.
+     */
+    protected function getClientRedirectUri(AuthorizationRequestInterface $authorizationRequest): string
+    {
+        return is_array($authorizationRequest->getClient()->getRedirectUri())
+            ? $authorizationRequest->getClient()->getRedirectUri()[0]
+            : $authorizationRequest->getClient()->getRedirectUri();
+    }
 }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -398,8 +398,8 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
             is_null($authorizationRequest->getUser())
-                ? 'The user denied the request'
-                : 'The user is not authenticated.',
+                ? 'The user is not authenticated.'
+                : 'The user denied the request',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -397,9 +397,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
-            is_null($authorizationRequest->getUser())
-                ? 'The user is not authenticated.'
-                : 'The user denied the request',
+            'The user denied the request',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -395,22 +395,11 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             return $response;
         }
 
-        // The user is not authenticated, redirect them back with an error
-        if (is_null($authorizationRequest->getUser())) {
-            throw OAuthServerException::accessDenied(
-                'The user is not authenticated.',
-                $this->makeRedirectUri(
-                    $finalRedirectUri,
-                    [
-                        'state' => $authorizationRequest->getState(),
-                    ]
-                )
-            );
-        }
-
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
-            'The user denied the request',
+            is_null($authorizationRequest->getUser())
+                ? 'The user denied the request'
+                : 'The user is not authenticated.',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -408,14 +408,4 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             )
         );
     }
-
-    /**
-     * Get the client redirect URI if not set in the request.
-     */
-    private function getClientRedirectUri(AuthorizationRequestInterface $authorizationRequest): string
-    {
-        return is_array($authorizationRequest->getClient()->getRedirectUri())
-                ? $authorizationRequest->getClient()->getRedirectUri()[0]
-                : $authorizationRequest->getClient()->getRedirectUri();
-    }
 }

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -192,8 +192,8 @@ class ImplicitGrant extends AbstractAuthorizeGrant
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
             is_null($authorizationRequest->getUser())
-                ? 'The user denied the request'
-                : 'The user is not authenticated.',
+                ? 'The user is not authenticated.'
+                : 'The user denied the request',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -202,14 +202,4 @@ class ImplicitGrant extends AbstractAuthorizeGrant
             )
         );
     }
-
-    /**
-     * Get the client redirect URI if not set in the request.
-     */
-    private function getClientRedirectUri(AuthorizationRequestInterface $authorizationRequest): string
-    {
-        return is_array($authorizationRequest->getClient()->getRedirectUri())
-            ? $authorizationRequest->getClient()->getRedirectUri()[0]
-            : $authorizationRequest->getClient()->getRedirectUri();
-    }
 }

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -189,22 +189,11 @@ class ImplicitGrant extends AbstractAuthorizeGrant
             return $response;
         }
 
-        // The user is not authenticated, redirect them back with an error
-        if (is_null($authorizationRequest->getUser())) {
-            throw OAuthServerException::accessDenied(
-                'The user is not authenticated.',
-                $this->makeRedirectUri(
-                    $finalRedirectUri,
-                    [
-                        'state' => $authorizationRequest->getState(),
-                    ]
-                )
-            );
-        }
-
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
-            'The user denied the request',
+            is_null($authorizationRequest->getUser())
+                ? 'The user denied the request'
+                : 'The user is not authenticated.',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -191,9 +191,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
 
         // The user denied the client, redirect them back with an error
         throw OAuthServerException::accessDenied(
-            is_null($authorizationRequest->getUser())
-                ? 'The user is not authenticated.'
-                : 'The user denied the request',
+            'The user denied the request',
             $this->makeRedirectUri(
                 $finalRedirectUri,
                 [

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -2186,6 +2186,14 @@ class AuthCodeGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequestNoUser(): void
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(true);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+
         $grant = new AuthCodeGrant(
             $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
@@ -2194,7 +2202,29 @@ class AuthCodeGrantTest extends TestCase
 
         $this->expectException(LogicException::class);
 
-        $grant->completeAuthorizationRequest(new AuthorizationRequest());
+        $grant->completeAuthorizationRequest($authRequest);
+    }
+
+    public function testCompleteAuthorizationRequestDeniedNoUser(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri('http://foo/bar');
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(false);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(9);
+
+        $grant->completeAuthorizationRequest($authRequest);
     }
 
     public function testPublicClientAuthCodeRequestRejectedWhenCodeChallengeRequiredButNotGiven(): void

--- a/tests/Grant/ImplicitGrantTest.php
+++ b/tests/Grant/ImplicitGrantTest.php
@@ -395,10 +395,36 @@ class ImplicitGrantTest extends TestCase
 
     public function testCompleteAuthorizationRequestNoUser(): void
     {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(true);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+
         $grant = new ImplicitGrant(new DateInterval('PT10M'));
 
         $this->expectException(LogicException::class);
 
-        $grant->completeAuthorizationRequest(new AuthorizationRequest());
+        $grant->completeAuthorizationRequest($authRequest);
+    }
+
+    public function testCompleteAuthorizationRequestDeniedNoUser(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri('https://foo/bar');
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(false);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+
+        $grant = new ImplicitGrant(new DateInterval('PT10M'));
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(9);
+
+        $grant->completeAuthorizationRequest($authRequest);
     }
 }


### PR DESCRIPTION
Setting the `user` instance has been forced on `AuthCodeGrant::completeAuthorizationRequest()` method, but it is not necessary when Authorization request is denied!

On Laravel Passport we support [`prompt=none` when redirecting for authorization](https://laravel.com/docs/11.x/passport#requesting-tokens-redirecting-for-authorization). Currently, we have to create the error response manually when user is not authenticated.

Here is the related code on Laravel Passport: 

https://github.com/laravel/passport/blob/8ea1dd41745c89769fd8c4b207c4739eea707e95/src/Http/Controllers/AuthorizationController.php#L181-L204

After this PR we are able to simply do:

```php
if (! is_null($user)) {
    $authRequest->setUser(new User($user->getAuthIdentifier()));
}

$authRequest->setAuthorizationApproved(false);

return $this->withErrorHandling(function () use ($authRequest) {
    return $this->convertResponse(
        $this->server->completeAuthorizationRequest($authRequest, new Psr7Response)
    );
});
```