### PR TITLE
Pass user id from old refresh token to finalizeScopes()

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -69,7 +69,7 @@ class RefreshTokenGrant extends AbstractGrant
             }
         }
 
-        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client);
+        $scopes = $this->scopeRepository->finalizeScopes($scopes, $this->getIdentifier(), $client, $oldRefreshToken['user_id'] ?? null);
 
         // Expire old tokens
         $this->accessTokenRepository->revokeAccessToken($oldRefreshToken['access_token_id']);

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -564,7 +564,7 @@ class RefreshTokenGrantTest extends TestCase
         $scopeRepositoryMock
             ->expects(self::once())
             ->method('finalizeScopes')
-            ->with($scopes, $grant->getIdentifier(), $client)
+            ->with($scopes, $grant->getIdentifier(), $client, '123', null)
             ->willReturn($finalizedScopes);
 
         $accessTokenRepositoryMock


### PR DESCRIPTION
We need the user ID in our `finalizeScopes()` implementation to adjust the selection of scopes. As of version 9.0, the `finalizeScopes()` method is also called for the `RefreshTokenGrant`, but the user ID is not currently passed to the `finalizeScopes()` method. Since the user ID is in the old refresh token, it can be passed from there.