### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [8.1, 8.2, 8.3, 8.4]
         composer-stability: [prefer-lowest, prefer-stable]
         operating-system:
           - ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3, 8.4]
         os: [ubuntu-22.04]
         stability: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://oauth2.thephpleague.com/",
     "license": "MIT",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-openssl": "*",
         "league/event": "^3.0",
         "league/uri": "^7.0",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,4 +33,5 @@
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
     <rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
     <rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion" />
+    <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
 </ruleset>

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -33,7 +33,7 @@ class OAuthServerException extends Exception
     /**
      * Throw a new exception.
      */
-    final public function __construct(string $message, int $code, private string $errorType, private int $httpStatusCode = 400, private ?string $hint = null, private ?string $redirectUri = null, Throwable $previous = null)
+    final public function __construct(string $message, int $code, private string $errorType, private int $httpStatusCode = 400, private ?string $hint = null, private ?string $redirectUri = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->payload = [
@@ -88,7 +88,7 @@ class OAuthServerException extends Exception
     /**
      * Invalid request error.
      */
-    public static function invalidRequest(string $parameter, ?string $hint = null, Throwable $previous = null): static
+    public static function invalidRequest(string $parameter, ?string $hint = null, ?Throwable $previous = null): static
     {
         $errorMessage = 'The request is missing a required parameter, includes an invalid parameter value, ' .
             'includes a parameter more than once, or is otherwise malformed.';
@@ -141,7 +141,7 @@ class OAuthServerException extends Exception
      *
      * @codeCoverageIgnore
      */
-    public static function serverError(string $hint, Throwable $previous = null): static
+    public static function serverError(string $hint, ?Throwable $previous = null): static
     {
         return new static(
             'The authorization server encountered an unexpected condition which prevented it from fulfilling'
@@ -158,7 +158,7 @@ class OAuthServerException extends Exception
     /**
      * Invalid refresh token.
      */
-    public static function invalidRefreshToken(?string $hint = null, Throwable $previous = null): static
+    public static function invalidRefreshToken(?string $hint = null, ?Throwable $previous = null): static
     {
         return new static('The refresh token is invalid.', 8, 'invalid_grant', 400, $hint, null, $previous);
     }
@@ -166,7 +166,7 @@ class OAuthServerException extends Exception
     /**
      * Access denied.
      */
-    public static function accessDenied(?string $hint = null, ?string $redirectUri = null, Throwable $previous = null): static
+    public static function accessDenied(?string $hint = null, ?string $redirectUri = null, ?Throwable $previous = null): static
     {
         return new static(
             'The resource owner or authorization server denied the request.',
@@ -207,7 +207,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function expiredToken(?string $hint = null, Throwable $previous = null): static
+    public static function expiredToken(?string $hint = null, ?Throwable $previous = null): static
     {
         $errorMessage = 'The `device_code` has expired and the device ' .
                         'authorization session has concluded.';
@@ -215,7 +215,7 @@ class OAuthServerException extends Exception
         return new static($errorMessage, 11, 'expired_token', 400, $hint, null, $previous);
     }
 
-    public static function authorizationPending(string $hint = '', Throwable $previous = null): static
+    public static function authorizationPending(string $hint = '', ?Throwable $previous = null): static
     {
         return new static(
             'The authorization request is still pending as the end user ' .
@@ -236,7 +236,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function slowDown(string $hint = '', Throwable $previous = null): static
+    public static function slowDown(string $hint = '', ?Throwable $previous = null): static
     {
         return new static(
             'The authorization request is still pending and polling should ' .

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -243,7 +243,7 @@ abstract class AbstractGrant implements GrantTypeInterface
      *
      * @return ScopeEntityInterface[]
      */
-    public function validateScopes(string|array|null $scopes, string $redirectUri = null): array
+    public function validateScopes(string|array|null $scopes, ?string $redirectUri = null): array
     {
         if ($scopes === null) {
             $scopes = [];

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -22,19 +22,15 @@ class ResourceServer
 {
     private CryptKeyInterface $publicKey;
 
-    private ?AuthorizationValidatorInterface $authorizationValidator = null;
-
     public function __construct(
         private AccessTokenRepositoryInterface $accessTokenRepository,
         CryptKeyInterface|string $publicKey,
-        AuthorizationValidatorInterface $authorizationValidator = null
+        private ?AuthorizationValidatorInterface $authorizationValidator = null
     ) {
         if ($publicKey instanceof CryptKeyInterface === false) {
             $publicKey = new CryptKey($publicKey);
         }
         $this->publicKey = $publicKey;
-
-        $this->authorizationValidator = $authorizationValidator;
     }
 
     protected function getAuthorizationValidator(): AuthorizationValidatorInterface


### PR DESCRIPTION
Code changes are related to a deprecation of implicitly nullable parameter declarations in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated. It has been done automatically by the `phpcbf` executable using the added PHPCS rule.