### PR TITLE
Fix inconsistent `persistDeviceCode` usage

### DIFF
--- a/examples/src/Repositories/DeviceCodeRepository.php
+++ b/examples/src/Repositories/DeviceCodeRepository.php
@@ -53,7 +53,6 @@ class DeviceCodeRepository implements DeviceCodeRepositoryInterface
     public function persistLastPolledAt(DeviceCodeEntityInterface $deviceCodeEntity): void
     {
         $lastPolledAt = $deviceCodeEntity->getLastPolledAt();
-        $approved = $deviceCodeEntity->getUserApproved();
 
         // Some logic to persist "last polled at" datetime of the given device code entity to a database
     }

--- a/examples/src/Repositories/DeviceCodeRepository.php
+++ b/examples/src/Repositories/DeviceCodeRepository.php
@@ -39,6 +39,28 @@ class DeviceCodeRepository implements DeviceCodeRepositoryInterface
     /**
      * {@inheritdoc}
      */
+    public function persistUser(DeviceCodeEntityInterface $deviceCodeEntity): void
+    {
+        $user = $deviceCodeEntity->getUserIdentifier();
+        $approved = $deviceCodeEntity->getUserApproved();
+
+        // Some logic to persist user ID and approval status of the given device code entity to a database
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persistLastPolledAt(DeviceCodeEntityInterface $deviceCodeEntity): void
+    {
+        $lastPolledAt = $deviceCodeEntity->getLastPolledAt();
+        $approved = $deviceCodeEntity->getUserApproved();
+
+        // Some logic to persist "last polled at" datetime of the given device code entity to a database
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getDeviceCodeEntityByDeviceCode($deviceCode): ?DeviceCodeEntityInterface
     {
         $clientEntity = new ClientEntity();

--- a/src/Grant/DeviceCodeGrant.php
+++ b/src/Grant/DeviceCodeGrant.php
@@ -124,7 +124,7 @@ class DeviceCodeGrant extends AbstractGrant
         $deviceCode->setUserIdentifier($userId);
         $deviceCode->setUserApproved($userApproved);
 
-        $this->deviceCodeRepository->persistDeviceCode($deviceCode);
+        $this->deviceCodeRepository->persistUser($deviceCode);
     }
 
     /**
@@ -141,7 +141,7 @@ class DeviceCodeGrant extends AbstractGrant
         $deviceCodeEntity = $this->validateDeviceCode($request, $client);
 
         $deviceCodeEntity->setLastPolledAt(new DateTimeImmutable());
-        $this->deviceCodeRepository->persistDeviceCode($deviceCodeEntity);
+        $this->deviceCodeRepository->persistLastPolledAt($deviceCodeEntity);
 
         // If device code has no user associated, respond with pending
         if (is_null($deviceCodeEntity->getUserIdentifier())) {

--- a/src/Repositories/DeviceCodeRepositoryInterface.php
+++ b/src/Repositories/DeviceCodeRepositoryInterface.php
@@ -30,6 +30,16 @@ interface DeviceCodeRepositoryInterface extends RepositoryInterface
     public function persistDeviceCode(DeviceCodeEntityInterface $deviceCodeEntity): void;
 
     /**
+     * Persists user ID and approval status of the given device code entity to permanent storage.
+     */
+    public function persistUser(DeviceCodeEntityInterface $deviceCodeEntity): void;
+
+    /**
+     * Persists "last polled at" datetime of the given device code entity to permanent storage.
+     */
+    public function persistLastPolledAt(DeviceCodeEntityInterface $deviceCodeEntity): void;
+
+    /**
      * Get a device code entity.
      */
     public function getDeviceCodeEntityByDeviceCode(


### PR DESCRIPTION
On "Device Authorization" grant, the `\League\OAuth2\Server\Repositories\DeviceCodeRepositoryInterface::persistDeviceCode()` method has been used 3 times with 3 different purposes:

1. For persisting the new device code (when requesting a device code)
2. For updating the "User ID" and "User Approved" (when completing the device auth request)
3. For updating "Last polled at" (when responding to access token request)

This makes the implementation of this method too hard, as we have to manually determine that for which purpose this method has been called!

You may check the workaround I had to use to be able to implement this on Laravel Passport [here](https://github.com/laravel/passport/pull/1750/files#diff-6e818e6b65c5a62ab3fa3491233829405e09bd3510a8392a04d091b305be6b6fR25-R49).

This PR adds 2 new methods to fix this:
- `\League\OAuth2\Server\Repositories\DeviceCodeRepositoryInterface::persistUser()`
- `\League\OAuth2\Server\Repositories\DeviceCodeRepositoryInterface::persistLastPolledAt()`