### PR TITLE
Fix key files permission on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.2, 8.3]
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest, windows-latest]
         stability: [prefer-lowest, prefer-stable]
 
     runs-on: ${{ matrix.os }}
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, sodium, zip
           coverage: pcov
 
       - name: Install dependencies

--- a/src/CryptKey.php
+++ b/src/CryptKey.php
@@ -72,7 +72,7 @@ class CryptKey implements CryptKeyInterface
             throw new LogicException('Invalid key supplied');
         }
 
-        if ($keyPermissionsCheck === true) {
+        if ($keyPermissionsCheck === true && PHP_OS_FAMILY !== 'Windows') {
             // Verify the permissions of the key
             $keyPathPerms = decoct(fileperms($this->keyPath) & 0777);
             if (in_array($keyPathPerms, ['400', '440', '600', '640', '660'], true) === false) {

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -50,6 +50,15 @@ class AuthorizationServerTest extends TestCase
         chmod(__DIR__ . '/Stubs/private.key.crlf', 0600);
     }
 
+    public function testKeyPermissions(): void
+    {
+        $permission = PHP_OS_FAMILY === 'Windows' ? '666' : '600';
+
+        self::assertSame($permission, decoct(fileperms(__DIR__ . '/Stubs/private.key') & 0777));
+        self::assertSame($permission, decoct(fileperms(__DIR__ . '/Stubs/public.key') & 0777));
+        self::assertSame($permission, decoct(fileperms(__DIR__ . '/Stubs/private.key.crlf') & 0777));
+    }
+
     public function testGrantTypeGetsEnabled(): void
     {
         $server = new AuthorizationServer(


### PR DESCRIPTION
Closes #901 
Related to laravel/passport#1789

This PR adds windows tests and fixes the permission check on Windows. The possible file permissions on Windows are '666' and '444'.