### PR TITLE
Fix PHP 8.4 deprecation notices

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -27,6 +27,7 @@ enabled:
   - no_unreachable_default_argument_value
   - no_unused_imports
   - no_whitespace_before_comma_in_array
+  - nullable_type_declarations
   - ordered_imports
   - phpdoc_align
   - phpdoc_indent

--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -100,7 +100,7 @@ class AuthorizationServer implements EmitterAwareInterface
         ScopeRepositoryInterface $scopeRepository,
         $privateKey,
         $encryptionKey,
-        ResponseTypeInterface $responseType = null
+        ?ResponseTypeInterface $responseType = null
     ) {
         $this->clientRepository = $clientRepository;
         $this->accessTokenRepository = $accessTokenRepository;
@@ -128,7 +128,7 @@ class AuthorizationServer implements EmitterAwareInterface
      * @param GrantTypeInterface $grantType
      * @param null|DateInterval  $accessTokenTTL
      */
-    public function enableGrantType(GrantTypeInterface $grantType, DateInterval $accessTokenTTL = null)
+    public function enableGrantType(GrantTypeInterface $grantType, ?DateInterval $accessTokenTTL = null)
     {
         if ($accessTokenTTL === null) {
             $accessTokenTTL = new DateInterval('PT1H');

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -52,7 +52,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
      * @param AccessTokenRepositoryInterface $accessTokenRepository
      * @param \DateInterval|null             $jwtValidAtDateLeeway
      */
-    public function __construct(AccessTokenRepositoryInterface $accessTokenRepository, \DateInterval $jwtValidAtDateLeeway = null)
+    public function __construct(AccessTokenRepositoryInterface $accessTokenRepository, ?\DateInterval $jwtValidAtDateLeeway = null)
     {
         $this->accessTokenRepository = $accessTokenRepository;
         $this->jwtValidAtDateLeeway = $jwtValidAtDateLeeway;

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -57,7 +57,7 @@ class OAuthServerException extends Exception
      * @param null|string $redirectUri    A HTTP URI to redirect the user back to
      * @param Throwable   $previous       Previous exception
      */
-    public function __construct($message, $code, $errorType, $httpStatusCode = 400, $hint = null, $redirectUri = null, Throwable $previous = null)
+    public function __construct($message, $code, $errorType, $httpStatusCode = 400, $hint = null, $redirectUri = null, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->httpStatusCode = $httpStatusCode;
@@ -133,7 +133,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function invalidRequest($parameter, $hint = null, Throwable $previous = null)
+    public static function invalidRequest($parameter, $hint = null, ?Throwable $previous = null)
     {
         $errorMessage = 'The request is missing a required parameter, includes an invalid parameter value, ' .
             'includes a parameter more than once, or is otherwise malformed.';
@@ -202,7 +202,7 @@ class OAuthServerException extends Exception
      *
      * @codeCoverageIgnore
      */
-    public static function serverError($hint, Throwable $previous = null)
+    public static function serverError($hint, ?Throwable $previous = null)
     {
         return new static(
             'The authorization server encountered an unexpected condition which prevented it from fulfilling'
@@ -224,7 +224,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function invalidRefreshToken($hint = null, Throwable $previous = null)
+    public static function invalidRefreshToken($hint = null, ?Throwable $previous = null)
     {
         return new static('The refresh token is invalid.', 8, 'invalid_request', 401, $hint, null, $previous);
     }
@@ -238,7 +238,7 @@ class OAuthServerException extends Exception
      *
      * @return static
      */
-    public static function accessDenied($hint = null, $redirectUri = null, Throwable $previous = null)
+    public static function accessDenied($hint = null, $redirectUri = null, ?Throwable $previous = null)
     {
         return new static(
             'The resource owner or authorization server denied the request.',

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -65,7 +65,7 @@ class OAuthServerException extends Exception
         $this->hint = $hint;
         $this->redirectUri = $redirectUri;
         $this->payload = [
-            'error'             => $errorType,
+            'error' => $errorType,
             'error_description' => $message,
         ];
         if ($hint !== null) {

--- a/src/ResourceServer.php
+++ b/src/ResourceServer.php
@@ -42,7 +42,7 @@ class ResourceServer
     public function __construct(
         AccessTokenRepositoryInterface $accessTokenRepository,
         $publicKey,
-        AuthorizationValidatorInterface $authorizationValidator = null
+        ?AuthorizationValidatorInterface $authorizationValidator = null
     ) {
         $this->accessTokenRepository = $accessTokenRepository;
 

--- a/tests/Stubs/GrantType.php
+++ b/tests/Stubs/GrantType.php
@@ -19,7 +19,7 @@ final class GrantType implements GrantTypeInterface
 {
     private $emitter;
 
-    public function setEmitter(EmitterInterface $emitter = null)
+    public function setEmitter(?EmitterInterface $emitter = null)
     {
         $this->emitter = $emitter;
 


### PR DESCRIPTION
- Fixes PHP 8.4 deprecation notices.
- See https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Is it possible to do a patch release on 8.x branch after merge? :-) Thanks!