### PR TITLE
Remove the encrypted payload from AuthCode and RefreshToken

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -48,7 +48,7 @@ class AuthorizationServer implements EmitterAwareInterface
 
     protected ResponseTypeInterface $responseType;
 
-    private string|Key $encryptionKey;
+    private Key|string|null $encryptionKey;
 
     private string $defaultScope = '';
 
@@ -62,7 +62,7 @@ class AuthorizationServer implements EmitterAwareInterface
         private AccessTokenRepositoryInterface $accessTokenRepository,
         private ScopeRepositoryInterface $scopeRepository,
         CryptKeyInterface|string $privateKey,
-        Key|string $encryptionKey,
+        Key|string|null $encryptionKey,
         ResponseTypeInterface|null $responseType = null
     ) {
         if ($privateKey instanceof CryptKeyInterface === false) {

--- a/src/CryptTrait.php
+++ b/src/CryptTrait.php
@@ -87,4 +87,13 @@ trait CryptTrait
     {
         $this->encryptionKey = $key;
     }
+
+    /**
+     * Has Encryption key been set
+     * @return bool True if encryption key has been set
+     */
+    public function canUseCrypt() : bool
+    {
+        return !empty($this->encryptionKey);
+    }
 }

--- a/src/Entities/AuthCodeEntityInterface.php
+++ b/src/Entities/AuthCodeEntityInterface.php
@@ -14,7 +14,15 @@ namespace League\OAuth2\Server\Entities;
 
 interface AuthCodeEntityInterface extends TokenInterface
 {
-    public function getRedirectUri(): string|null;
+    public function getRedirectUri(): ?string;
 
-    public function setRedirectUri(string $uri): void;
+    public function setRedirectUri(?string $uri): void;
+
+    public function setCodeChallenge(?string $codeChallenge): void;
+
+    public function getCodeChallenge(): ?string;
+
+    public function setCodeChallengeMethod(?string $codeChallengeMethod): void;
+
+    public function getCodeChallengeMethod(): ?string;
 }

--- a/src/Entities/RefreshTokenEntityInterface.php
+++ b/src/Entities/RefreshTokenEntityInterface.php
@@ -12,34 +12,8 @@ declare(strict_types=1);
 
 namespace League\OAuth2\Server\Entities;
 
-use DateTimeImmutable;
-
-interface RefreshTokenEntityInterface
+interface RefreshTokenEntityInterface extends TokenInterface
 {
-    /**
-     * Get the token's identifier.
-     *
-     * @return non-empty-string
-     */
-    public function getIdentifier(): string;
-
-    /**
-     * Set the token's identifier.
-     *
-     * @param non-empty-string $identifier
-     */
-    public function setIdentifier(string $identifier): void;
-
-    /**
-     * Get the token's expiry date time.
-     */
-    public function getExpiryDateTime(): DateTimeImmutable;
-
-    /**
-     * Set the date time when the token expires.
-     */
-    public function setExpiryDateTime(DateTimeImmutable $dateTime): void;
-
     /**
      * Set the access token that the refresh token was associated with.
      */

--- a/src/Entities/TokenInterface.php
+++ b/src/Entities/TokenInterface.php
@@ -45,14 +45,14 @@ interface TokenInterface
      *
      * @param non-empty-string $identifier
      */
-    public function setUserIdentifier(string $identifier): void;
+    public function setUserIdentifier(?string $identifier): void;
 
     /**
      * Get the token user's identifier.
      *
      * @return non-empty-string|null
      */
-    public function getUserIdentifier(): string|null;
+    public function getUserIdentifier(): ?string;
 
     /**
      * Get the client that the token was issued to.
@@ -75,4 +75,10 @@ interface TokenInterface
      * @return ScopeEntityInterface[]
      */
     public function getScopes(): array;
+
+    /**
+     * Set the scopes array (doesn't check for duplicates)
+     * @param array scopes
+     */
+    public function setScopes(array $scopes): void;
 }

--- a/src/Entities/Traits/AuthCodeTrait.php
+++ b/src/Entities/Traits/AuthCodeTrait.php
@@ -15,14 +15,44 @@ namespace League\OAuth2\Server\Entities\Traits;
 trait AuthCodeTrait
 {
     protected ?string $redirectUri = null;
+    
+    /**
+     * The code challenge (if provided)
+     */
+    protected ?string $codeChallenge;
 
-    public function getRedirectUri(): string|null
+    /**
+     * The code challenge method (if provided)
+     */
+    protected ?string $codeChallengeMethod;
+
+    public function getRedirectUri(): ?string
     {
         return $this->redirectUri;
     }
 
-    public function setRedirectUri(string $uri): void
+    public function setRedirectUri(?string $uri): void
     {
         $this->redirectUri = $uri;
+    }
+
+    public function getCodeChallenge(): ?string
+    {
+        return $this->codeChallenge ?? null;
+    }
+
+    public function setCodeChallenge(?string $codeChallenge): void
+    {
+        $this->codeChallenge = $codeChallenge;
+    }
+
+    public function getCodeChallengeMethod(): ?string
+    {
+        return $this->codeChallengeMethod ?? null;
+    }
+
+    public function setCodeChallengeMethod(?string $codeChallengeMethod): void
+    {
+        $this->codeChallengeMethod = $codeChallengeMethod;
     }
 }

--- a/src/Entities/Traits/RefreshTokenTrait.php
+++ b/src/Entities/Traits/RefreshTokenTrait.php
@@ -19,8 +19,6 @@ trait RefreshTokenTrait
 {
     protected AccessTokenEntityInterface $accessToken;
 
-    protected DateTimeImmutable $expiryDateTime;
-
     /**
      * {@inheritdoc}
      */
@@ -35,21 +33,5 @@ trait RefreshTokenTrait
     public function getAccessToken(): AccessTokenEntityInterface
     {
         return $this->accessToken;
-    }
-
-    /**
-     * Get the token's expiry date time.
-     */
-    public function getExpiryDateTime(): DateTimeImmutable
-    {
-        return $this->expiryDateTime;
-    }
-
-    /**
-     * Set the date time when the token expires.
-     */
-    public function setExpiryDateTime(DateTimeImmutable $dateTime): void
-    {
-        $this->expiryDateTime = $dateTime;
     }
 }

--- a/src/Entities/Traits/TokenEntityTrait.php
+++ b/src/Entities/Traits/TokenEntityTrait.php
@@ -53,6 +53,15 @@ trait TokenEntityTrait
     }
 
     /**
+     * Set the scopes array (doesn't check for duplicates)
+     * @param array scopes
+     */
+    public function setScopes(array $scopes): void
+    {
+        $this->scopes = $scopes;
+    }
+
+    /**
      * Get the token's expiry date time.
      */
     public function getExpiryDateTime(): DateTimeImmutable
@@ -73,7 +82,7 @@ trait TokenEntityTrait
      *
      * @param non-empty-string $identifier The identifier of the user
      */
-    public function setUserIdentifier(string $identifier): void
+    public function setUserIdentifier(?string $identifier): void
     {
         $this->userIdentifier = $identifier;
     }
@@ -83,7 +92,7 @@ trait TokenEntityTrait
      *
      * @return non-empty-string|null
      */
-    public function getUserIdentifier(): string|null
+    public function getUserIdentifier(): ?string
     {
         return $this->userIdentifier;
     }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -260,10 +260,10 @@ abstract class AbstractGrant implements GrantTypeInterface
                 throw OAuthServerException::invalidScope($scopeItem, $redirectUri);
             }
 
-            $validScopes[] = $scope;
+            $validScopes[$scopeItem] = $scope;
         }
 
-        return $validScopes;
+        return array_values($validScopes);
     }
 
     /**
@@ -444,7 +444,9 @@ abstract class AbstractGrant implements GrantTypeInterface
         ClientEntityInterface $client,
         string $userIdentifier,
         ?string $redirectUri,
-        array $scopes = []
+        array $scopes = [],
+        ?string $codeChallenge = null,
+        ?string $codeChallengeMethod = null
     ): AuthCodeEntityInterface {
         $maxGenerationAttempts = self::MAX_RANDOM_TOKEN_GENERATION_ATTEMPTS;
 
@@ -452,6 +454,8 @@ abstract class AbstractGrant implements GrantTypeInterface
         $authCode->setExpiryDateTime((new DateTimeImmutable())->add($authCodeTTL));
         $authCode->setClient($client);
         $authCode->setUserIdentifier($userIdentifier);
+        $authCode->setCodeChallenge($codeChallenge);
+        $authCode->setCodeChallengeMethod($codeChallengeMethod);
 
         if ($redirectUri !== null) {
             $authCode->setRedirectUri($redirectUri);

--- a/src/Repositories/AccessTokenRepositoryInterface.php
+++ b/src/Repositories/AccessTokenRepositoryInterface.php
@@ -41,4 +41,6 @@ interface AccessTokenRepositoryInterface extends RepositoryInterface
     public function revokeAccessToken(string $tokenId): void;
 
     public function isAccessTokenRevoked(string $tokenId): bool;
+
+    public function getAccessTokenEntity(string $tokenId): ?AccessTokenEntityInterface;
 }

--- a/src/Repositories/AuthCodeRepositoryInterface.php
+++ b/src/Repositories/AuthCodeRepositoryInterface.php
@@ -30,4 +30,10 @@ interface AuthCodeRepositoryInterface extends RepositoryInterface
     public function revokeAuthCode(string $codeId): void;
 
     public function isAuthCodeRevoked(string $codeId): bool;
+
+    /**
+     * Get Auth code entity from repository
+     * @return ?AuthCodeEntityInterface
+     */
+    public function getAuthCodeEntity(string $codeId): ?AuthCodeEntityInterface;
 }

--- a/src/Repositories/RefreshTokenRepositoryInterface.php
+++ b/src/Repositories/RefreshTokenRepositoryInterface.php
@@ -30,4 +30,10 @@ interface RefreshTokenRepositoryInterface extends RepositoryInterface
     public function revokeRefreshToken(string $tokenId): void;
 
     public function isRefreshTokenRevoked(string $tokenId): bool;
+
+    /**
+     * Get Refresh Token entity from repository
+     * @return ?RefreshTokenRepositoryInterface
+     */
+    public function getRefreshTokenEntity(string $tokenId): ?RefreshTokenRepositoryInterface;
 }

--- a/src/ResponseTypes/BearerTokenResponse.php
+++ b/src/ResponseTypes/BearerTokenResponse.php
@@ -35,20 +35,25 @@ class BearerTokenResponse extends AbstractResponseType
         ];
 
         if (isset($this->refreshToken)) {
-            $refreshTokenPayload = json_encode([
-                    'client_id'        => $this->accessToken->getClient()->getIdentifier(),
-                    'refresh_token_id' => $this->refreshToken->getIdentifier(),
-                    'access_token_id'  => $this->accessToken->getIdentifier(),
-                    'scopes'           => $this->accessToken->getScopes(),
-                    'user_id'          => $this->accessToken->getUserIdentifier(),
-                    'expire_time'      => $this->refreshToken->getExpiryDateTime()->getTimestamp(),
-            ]);
+            if ($this->canUseCrypt()) {
+                $refreshTokenPayload = json_encode([
+                        'client_id'        => $this->accessToken->getClient()->getIdentifier(),
+                        'refresh_token_id' => $this->refreshToken->getIdentifier(),
+                        'access_token_id'  => $this->accessToken->getIdentifier(),
+                        'scopes'           => $this->accessToken->getScopes(),
+                        'user_id'          => $this->accessToken->getUserIdentifier(),
+                        'expire_time'      => $this->refreshToken->getExpiryDateTime()->getTimestamp(),
+                ]);
 
-            if ($refreshTokenPayload === false) {
-                throw new LogicException('Error encountered JSON encoding the refresh token payload');
+                if ($refreshTokenPayload === false) {
+                    throw new LogicException('Error encountered JSON encoding the refresh token payload');
+                }
+
+                $responseParams['refresh_token'] = $this->encrypt($refreshTokenPayload);
             }
-
-            $responseParams['refresh_token'] = $this->encrypt($refreshTokenPayload);
+            else {
+                $responseParams['refresh_token'] = $this->refreshToken->getIdentifier();
+            }
         }
 
         $responseParams = json_encode(array_merge($this->getExtraParams($this->accessToken), $responseParams));

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -623,8 +623,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -693,8 +696,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -754,8 +760,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $authCodeGrant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $refreshTokenRepositoryMock,
             new DateInterval('PT10M')
         );
@@ -820,8 +829,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -885,8 +897,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(null);
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $refreshTokenRepositoryMock,
             new DateInterval('PT10M')
         );
@@ -955,9 +970,12 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
-            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
+            $refreshTokenRepositoryMock,
             new DateInterval('PT10M')
         );
 
@@ -1029,8 +1047,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1100,8 +1121,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1163,8 +1187,11 @@ class AuthCodeGrantTest extends TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1213,8 +1240,11 @@ class AuthCodeGrantTest extends TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1264,8 +1294,11 @@ class AuthCodeGrantTest extends TestCase
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1359,13 +1392,20 @@ class AuthCodeGrantTest extends TestCase
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
 
         $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
         $request = new ServerRequest(
@@ -1448,13 +1488,20 @@ class AuthCodeGrantTest extends TestCase
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
         $clientRepositoryMock->method('getClientEntity')->willReturn($client);
 
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
 
         $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
         $request = new ServerRequest(
@@ -1512,7 +1559,11 @@ class AuthCodeGrantTest extends TestCase
 
         $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
         $authCodeRepositoryMock->method('isAuthCodeRevoked')->willReturn(true);
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
 
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        
         $grant = new AuthCodeGrant(
             $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
@@ -1521,6 +1572,7 @@ class AuthCodeGrantTest extends TestCase
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
         $request = new ServerRequest(
@@ -1566,9 +1618,21 @@ class AuthCodeGrantTest extends TestCase
         $client->setRedirectUri(self::REDIRECT_URI);
         $client->setConfidential();
 
+        $client2 = new ClientEntity();
+
+        $client2->setIdentifier('foo');
+        $client2->setRedirectUri(self::REDIRECT_URI);
+        $client2->setConfidential();
+
+        $client3 = new ClientEntity();
+
+        $client3->setIdentifier('bar');
+        $client3->setRedirectUri(self::REDIRECT_URI);
+        $client3->setConfidential();
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
 
-        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client, $client2, $client3);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
@@ -1577,14 +1641,21 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
 
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
         $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
 
         $request = new ServerRequest(
@@ -1695,8 +1766,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1727,7 +1801,7 @@ class AuthCodeGrantTest extends TestCase
             $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
         } catch (OAuthServerException $e) {
             self::assertEquals($e->getErrorType(), 'invalid_request');
-            self::assertEquals($e->getHint(), 'Issue decrypting the authorization code');
+            self::assertEquals($e->getHint(), 'Cannot find authorization code');
         }
     }
 
@@ -1757,8 +1831,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1832,8 +1909,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1907,8 +1987,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -1982,8 +2065,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -2057,8 +2143,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -2158,6 +2247,7 @@ class AuthCodeGrantTest extends TestCase
         $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
         $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
         $authCodeRepository->method('persistNewAuthCode')->willThrowException(OAuthServerException::serverError('something bad happened'));
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());        
 
         $grant = new AuthCodeGrant(
             $authCodeRepository,
@@ -2220,6 +2310,9 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $refreshTokenRepositoryMock
             ->expects(self::exactly(2))
             ->method('persistNewRefreshToken')
@@ -2232,7 +2325,7 @@ class AuthCodeGrantTest extends TestCase
             });
 
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepository,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -2296,8 +2389,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willThrowException(OAuthServerException::serverError('something bad happened'));
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );
@@ -2364,8 +2460,11 @@ class AuthCodeGrantTest extends TestCase
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willThrowException(UniqueTokenIdentifierConstraintViolationException::create());
 
+        $authCodeRepositoryMock = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepositoryMock->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
         $grant = new AuthCodeGrant(
-            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $authCodeRepositoryMock,
             $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
             new DateInterval('PT10M')
         );

--- a/tests/Grant/RefreshTokenGrantTest.php
+++ b/tests/Grant/RefreshTokenGrantTest.php
@@ -62,6 +62,9 @@ class RefreshTokenGrantTest extends TestCase
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
         $accessTokenRepositoryMock->expects(self::once())->method('persistNewAccessToken')->willReturnSelf();
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
@@ -127,7 +130,7 @@ class RefreshTokenGrantTest extends TestCase
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
-        $accessTokenRepositoryMock->expects(self::once())->method('persistNewAccessToken')->willReturnSelf();
+        $accessTokenRepositoryMock->expects(self::never())->method('persistNewAccessToken')->willReturnSelf();
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(null);
@@ -185,6 +188,9 @@ class RefreshTokenGrantTest extends TestCase
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
@@ -248,14 +254,25 @@ class RefreshTokenGrantTest extends TestCase
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
-        $scope = new ScopeEntity();
-        $scope->setIdentifier('foobar');
+        $scope1 = new ScopeEntity();
+        $scope1->setIdentifier('foo');
+
+        $scope2 = new ScopeEntity();
+        $scope2->setIdentifier('bar');
+
+        $scope3 = new ScopeEntity();
+        $scope3->setIdentifier('foobar');
+
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
-        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope);
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope1, $scope2, $scope3);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
@@ -371,19 +388,34 @@ class RefreshTokenGrantTest extends TestCase
         $client->setIdentifier('foo');
         $client->setRedirectUri('http://foo/bar');
 
+        $client2 = new ClientEntity();
+        $client2->setIdentifier('bar');
+        $client2->setRedirectUri('http://foo/bar');
+
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client, $client2);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $scope1 = new ScopeEntity();
+        $scope1->setIdentifier('foo');
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope1);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
 
@@ -427,15 +459,27 @@ class RefreshTokenGrantTest extends TestCase
         $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client, $client);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
+
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $scope1 = new ScopeEntity();
+        $scope1->setIdentifier('foo');
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope1);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
 
@@ -479,16 +523,28 @@ class RefreshTokenGrantTest extends TestCase
         $client->setRedirectUri('http://foo/bar');
 
         $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
-        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client, $client);
         $clientRepositoryMock->method('validateClient')->willReturn(true);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
+
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('isRefreshTokenRevoked')->willReturn(true);
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $scope1 = new ScopeEntity();
+        $scope1->setIdentifier('foo');
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scope1);
 
         $grant = new RefreshTokenGrant($refreshTokenRepositoryMock);
         $grant->setClientRepository($clientRepositoryMock);
         $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
         $grant->setEncryptionKey($this->cryptStub->getKey());
         $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
 
@@ -543,10 +599,13 @@ class RefreshTokenGrantTest extends TestCase
         $barScopeEntity->setIdentifier('bar');
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
-        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($fooScopeEntity, $barScopeEntity);
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($fooScopeEntity, $barScopeEntity, $fooScopeEntity, $barScopeEntity);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
@@ -621,17 +680,21 @@ class RefreshTokenGrantTest extends TestCase
         $scopeEntity->setIdentifier('foo');
 
         $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
-        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity);
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn($scopeEntity, $scopeEntity);
         $scopeRepositoryMock->method('finalizeScopes')->willReturn([$scopeEntity]);
 
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->expects(self::once())->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('isRefreshTokenRevoked')
             ->will(self::onConsecutiveCalls(false, true));
         $refreshTokenRepositoryMock->expects(self::once())->method('revokeRefreshToken')->with(self::equalTo($refreshTokenId));
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
 
         $oldRefreshToken = json_encode(
             [
@@ -696,6 +759,9 @@ class RefreshTokenGrantTest extends TestCase
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessTokenEntity);
         $accessTokenRepositoryMock->expects(self::once())->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
@@ -774,6 +840,9 @@ class RefreshTokenGrantTest extends TestCase
         $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
         $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
         $accessTokenRepositoryMock->expects(self::once())->method('persistNewAccessToken')->willReturnSelf();
+        $ace = new AccessTokenEntity();
+        $ace->setIdentifier("abcdef");
+        $accessTokenRepositoryMock->method('getAccessTokenEntity')->willReturn($ace);
 
         $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
         $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());

--- a/tests/Stubs/RefreshTokenEntity.php
+++ b/tests/Stubs/RefreshTokenEntity.php
@@ -7,9 +7,11 @@ namespace LeagueTests\Stubs;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Entities\Traits\EntityTrait;
 use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class RefreshTokenEntity implements RefreshTokenEntityInterface
 {
     use RefreshTokenTrait;
     use EntityTrait;
+    use TokenEntityTrait;
 }


### PR DESCRIPTION
The Auth Code and Refresh Token information can be stored in the repository and doesn't have to go in the payload. This will reduce auth code and refresh token size, but will require more calls to the repository.

If the user specifies an encryption key, the payload will be attempted to be encrypted or decrypted, else they are returned from the respective repositories.