### PR TITLE
Fix `code_challenge` error is not redirecting

### DIFF
--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -347,6 +347,16 @@ class OAuthServerException extends Exception
     }
 
     /**
+     * Set the Redirect URI used for redirecting.
+     */
+    public function withRedirectUri(string $redirectUri): static
+    {
+        $this->redirectUri = $redirectUri;
+
+        return $this;
+    }
+
+    /**
      * Returns the HTTP status code to send when the exceptions is output.
      */
     public function getHttpStatusCode(): int


### PR DESCRIPTION
Fixes #1039

On authorization request of "Authorization Code" flow, after client is verified and redirect URI is finalized, the client expects the error response to be redirected back to the URI with "state" parameter set if provided.

This PR fixes a bug where `code_challenge` or `code_challenge_method` parameters are invalid and the server responses with error 400 instead of redirecting to URI with `error` and `state` parameters.