### PR TITLE
Update additional attribute name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed additional attribute added from `oauth_user_id` to the more appropriately named `oauth_owner_id` which can encompass either the user ID or client ID (PR #XXX) 
+
 ## [9.2.0] - released 2025-02-15
 ### Added
 - Added a new function to the provided ClientTrait, `supportsGrantType` to allow the auth server to issue the response `unauthorized_client` when applicable (PR #1420)

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -42,9 +42,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
 
     private Configuration $jwtConfiguration;
 
-    public function __construct(private AccessTokenRepositoryInterface $accessTokenRepository, private ?DateInterval $jwtValidAtDateLeeway = null)
-    {
-    }
+    public function __construct(private AccessTokenRepositoryInterface $accessTokenRepository, private ?DateInterval $jwtValidAtDateLeeway = null) {}
 
     /**
      * Set the public key
@@ -130,7 +128,7 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
         return $request
             ->withAttribute('oauth_access_token_id', $claims->get('jti'))
             ->withAttribute('oauth_client_id', $claims->get('aud')[0])
-            ->withAttribute('oauth_user_id', $claims->get('sub'))
+            ->withAttribute('oauth_owner_id', $claims->get('sub'))
             ->withAttribute('oauth_scopes', $claims->get('scopes'));
     }
 }


### PR DESCRIPTION
This is the start of changes that will be encompassed in v10 around the additional attributed added after a successful validation. In v9 the sub claim was changed so that the client ID or user ID is always listed. This means that sometimes, the "oauth_user_id" field may contain a client ID. 

v10 will change the name of this to more accurately reflect its content. Long term, we will also fix the issues around the usage of the aud claim