### PR TITLE
Add issued at property for access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Changed additional attribute added from `oauth_user_id` to the more appropriately named `oauth_owner_id` which can encompass either the user ID or client ID (PR #XXX) 
 
+### Fixed
+- If the same access token is requested twice, the issued at time will now be identical (PR #XXX)
+
 ## [9.2.0] - released 2025-02-15
 ### Added
 - Added a new function to the provided ClientTrait, `supportsGrantType` to allow the auth server to issue the response `unauthorized_client` when applicable (PR #1420)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,9 +7,9 @@ parameters:
         - 
             message: '#Deprecated since v5.5, please use {@see self::withValidationConstraints\(\)} instead#'
             reportUnmatched: false
-	-
-	    message: '#Parameter #1 $issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
-	    reportUnmatched: false
-	-
-	    message: '#Parameter #1 $notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
-	    reportUnmatched: false
+        -
+            message: '#Parameter #1 $issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            reportUnmatched: false
+        -
+            message: '#Parameter #1 $notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            reportUnmatched: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,8 +8,8 @@ parameters:
             message: '#Deprecated since v5.5, please use {@see self::withValidationConstraints\(\)} instead#'
             reportUnmatched: false
         -
-            message: '#Parameter #1 \$issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            message: '#Parameter \#1 \$issuedAt of method Lcobucci\\JWT\\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable\|null given.#'
             reportUnmatched: false
         -
-            message: '#Parameter #1 \$notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            message: '#Parameter \#1 \$notBefore of method Lcobucci\\JWT\\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable\|null given.#'
             reportUnmatched: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,8 +8,8 @@ parameters:
             message: '#Deprecated since v5.5, please use {@see self::withValidationConstraints\(\)} instead#'
             reportUnmatched: false
         -
-            message: '#Parameter #1 $issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            message: '#Parameter #1 \$issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
             reportUnmatched: false
         -
-            message: '#Parameter #1 $notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+            message: '#Parameter #1 \$notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
             reportUnmatched: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,3 +7,9 @@ parameters:
         - 
             message: '#Deprecated since v5.5, please use {@see self::withValidationConstraints\(\)} instead#'
             reportUnmatched: false
+	-
+	    message: '#Parameter #1 $issuedAt of method Lcobucci\JWT\Builder::issuedAt\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+	    reportUnmatched: false
+	-
+	    message: '#Parameter #1 $notBefore of method Lcobucci\JWT\Builder::canOnlyBeUsedAfter\(\) expects DateTimeImmutable, DateTimeImmutable|null given.#'
+	    reportUnmatched: false

--- a/src/Entities/AccessTokenEntityInterface.php
+++ b/src/Entities/AccessTokenEntityInterface.php
@@ -28,7 +28,7 @@ interface AccessTokenEntityInterface extends TokenInterface
     public function setIssuedAt(DateTimeImmutable $issuedAt): void;
 
     /**
-     * Get the issued at datetime value. 
+     * Get the issued at datetime value.
      */
     public function getIssuedAt(): ?DateTimeImmutable;
 

--- a/src/Entities/AccessTokenEntityInterface.php
+++ b/src/Entities/AccessTokenEntityInterface.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace League\OAuth2\Server\Entities;
 
+use DateTimeImmutable;
 use League\OAuth2\Server\CryptKeyInterface;
 
 interface AccessTokenEntityInterface extends TokenInterface
@@ -20,6 +21,16 @@ interface AccessTokenEntityInterface extends TokenInterface
      * Set a private key used to encrypt the access token.
      */
     public function setPrivateKey(CryptKeyInterface $privateKey): void;
+
+    /**
+     * Set a datetime value for the issued at value.
+     */
+    public function setIssuedAt(DateTimeImmutable $issuedAt): void;
+
+    /**
+     * Get the issued at datetime value. 
+     */
+    public function getIssuedAt(): ?DateTimeImmutable;
 
     /**
      * Generate a string representation of the access token.

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -24,9 +24,9 @@ use RuntimeException;
 
 trait AccessTokenTrait
 {
-    private CryptKeyInterface $privateKey;
-
     private Configuration $jwtConfiguration;
+    private CryptKeyInterface $privateKey;
+    private ?DateTimeImmutable $issuedAt = null;
 
     /**
      * Set the private key used to encrypt this access token.
@@ -34,6 +34,22 @@ trait AccessTokenTrait
     public function setPrivateKey(CryptKeyInterface $privateKey): void
     {
         $this->privateKey = $privateKey;
+    }
+
+    /**
+     * Set the datetime value the access token was issued at.
+     */
+    public function setIssuedAt(DateTimeImmutable $issuedAt): void
+    {
+        $this->issuedAt = $issuedAt;
+    }
+
+    /**
+     * Get the datetime value the access token was issued at.
+     */
+    public function getIssuedAt(): ?DateTimeImmutable
+    {
+        return $this->issuedAt;
     }
 
     /**
@@ -61,11 +77,15 @@ trait AccessTokenTrait
     {
         $this->initJwtConfiguration();
 
+        if ($this->getIssuedAt() === null) {
+            $this->setIssuedAt(new DateTimeImmutable());
+        }
+
         return $this->jwtConfiguration->builder()
             ->permittedFor($this->getClient()->getIdentifier())
             ->identifiedBy($this->getIdentifier())
-            ->issuedAt(new DateTimeImmutable())
-            ->canOnlyBeUsedAfter(new DateTimeImmutable())
+            ->issuedAt($this->getIssuedAt())
+            ->canOnlyBeUsedAfter($this->getIssuedAt())
             ->expiresAt($this->getExpiryDateTime())
             ->relatedTo($this->getSubjectIdentifier())
             ->withClaim('scopes', $this->getScopes())


### PR DESCRIPTION
This fixes issue #1389 by adding an issued at property to the access token so that if the access token is issued twice, it will give the same date time stamp