### PR TITLE
Update isAuthCodeRevoked() documentation to make it more clear

### DIFF
--- a/repository-interface-auth-code.md
+++ b/repository-interface-auth-code.md
@@ -34,4 +34,4 @@ This method is called when an authorization code is exchanged for an access toke
 
 ## isAuthCodeRevoked() : boolean
 
-This method is called before an authorization code is exchanged for an access token by the authorization server. Return `true` if the auth code has been manually revoked before it expired. If the auth code is still valid return `false`.
+This method is called before an authorization code is exchanged for an access token by the authorization server. Return `true` if the auth code is invalid and `false` if the auth code is still valid.


### PR DESCRIPTION
The current documentation explicitly states that isAuthCodeRevoked() should return 'true' if the auth code has been revoked and 'false' if it is still valid, but 'true' is the correct return value for all incorrect auth codes (revoked, expired, fabricated, ...), not just manually revoked ones, as can be seen in Laravel Passport ([AuthCodeRepository Line 47](https://github.com/laravel/passport/blob/951fe86b260adeb2485cfc251cbfa2fc9d7fe45a/src/Bridge/AuthCodeRepository.php#L47)).