### PR TITLE
Add RFC 8707 resource indicator support

### DIFF
--- a/src/Entities/AudienceRestrictedTokenInterface.php
+++ b/src/Entities/AudienceRestrictedTokenInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+declare(strict_types=1);
+
+namespace League\OAuth2\Server\Entities;
+
+/**
+ * Opt-in extension for token entities that carry RFC 8707 audience
+ * restrictions (the `aud` claim derived from the `resource` request parameter).
+ *
+ * Implementing this interface is optional: {@see TokenInterface} remains the
+ * canonical contract and existing consumer implementations continue to work
+ * without modification. Grants check for this interface via `instanceof` when
+ * propagating resource indicators through the token flow.
+ */
+interface AudienceRestrictedTokenInterface
+{
+    /**
+     * @return list<non-empty-string> The absolute URIs of the audiences this token is bound to.
+     */
+    public function getAudiences(): array;
+
+    /**
+     * @param list<non-empty-string> $audiences
+     */
+    public function setAudiences(array $audiences): void;
+}

--- a/src/Entities/Traits/AccessTokenTrait.php
+++ b/src/Entities/Traits/AccessTokenTrait.php
@@ -18,11 +18,21 @@ use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Lcobucci\JWT\Token;
 use League\OAuth2\Server\CryptKeyInterface;
+use League\OAuth2\Server\Entities\AudienceRestrictedTokenInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use RuntimeException;
 use SensitiveParameter;
 
+/**
+ * Default implementation of the access-token entity contract.
+ *
+ * This trait is aware of {@see AudienceRestrictedTokenInterface} and
+ * degrades gracefully if the composing class does not implement it: when
+ * the class opts in and provides a non-empty audience list, those values
+ * drive the JWT `aud` claim; otherwise the trait falls back to the client
+ * identifier, preserving the historical single-audience behaviour.
+ */
 trait AccessTokenTrait
 {
     private CryptKeyInterface $privateKey;
@@ -64,8 +74,10 @@ trait AccessTokenTrait
     {
         $this->initJwtConfiguration();
 
+        $audiences = $this->resolveAudiences();
+
         return $this->jwtConfiguration->builder()
-            ->permittedFor($this->getClient()->getIdentifier())
+            ->permittedFor(...$audiences)
             ->identifiedBy($this->getIdentifier())
             ->issuedAt(new DateTimeImmutable())
             ->canOnlyBeUsedAfter(new DateTimeImmutable())
@@ -73,6 +85,30 @@ trait AccessTokenTrait
             ->relatedTo($this->getSubjectIdentifier())
             ->withClaim('scopes', $this->getScopes())
             ->getToken($this->jwtConfiguration->signer(), $this->jwtConfiguration->signingKey());
+    }
+
+    /**
+     * Resolve the JWT `aud` claim values. RFC 8707 resource indicators take
+     * precedence when the entity opts in via
+     * {@see \League\OAuth2\Server\Entities\AudienceRestrictedTokenInterface}
+     * and supplies a non-empty audience list; an empty audience list is
+     * treated as "no restriction asserted" and falls back to the client id,
+     * preserving the historical single-audience behaviour for tokens issued
+     * without a `resource` parameter.
+     *
+     * @return non-empty-list<non-empty-string>
+     */
+    private function resolveAudiences(): array
+    {
+        if ($this instanceof AudienceRestrictedTokenInterface) {
+            $audiences = $this->getAudiences();
+
+            if ($audiences !== []) {
+                return $audiences;
+            }
+        }
+
+        return [$this->getClient()->getIdentifier()];
     }
 
     /**

--- a/src/Entities/Traits/AudienceRestrictedTokenTrait.php
+++ b/src/Entities/Traits/AudienceRestrictedTokenTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+declare(strict_types=1);
+
+namespace League\OAuth2\Server\Entities\Traits;
+
+/**
+ * Default in-memory implementation of {@see \League\OAuth2\Server\Entities\AudienceRestrictedTokenInterface}.
+ */
+trait AudienceRestrictedTokenTrait
+{
+    /**
+     * @var list<non-empty-string>
+     */
+    private array $audiences = [];
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public function getAudiences(): array
+    {
+        return $this->audiences;
+    }
+
+    /**
+     * @param list<non-empty-string> $audiences
+     */
+    public function setAudiences(array $audiences): void
+    {
+        $this->audiences = $audiences;
+    }
+}

--- a/src/Exception/OAuthServerException.php
+++ b/src/Exception/OAuthServerException.php
@@ -266,6 +266,25 @@ class OAuthServerException extends Exception
     }
 
     /**
+     * Invalid target error.
+     *
+     * The requested resource is invalid, missing, unknown, or malformed.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc8707#section-2
+     */
+    public static function invalidTarget(?string $hint = null, ?string $redirectUri = null): static
+    {
+        return new static(
+            'The requested resource is invalid, missing, unknown, or malformed.',
+            15,
+            'invalid_target',
+            400,
+            $hint,
+            $redirectUri
+        );
+    }
+
+    /**
      * Generate a HTTP response.
      */
     public function generateHttpResponse(ResponseInterface $response, bool $useFragment = false, int $jsonOptions = 0): ResponseInterface

--- a/src/Grant/AbstractAuthorizeGrant.php
+++ b/src/Grant/AbstractAuthorizeGrant.php
@@ -17,6 +17,8 @@ namespace League\OAuth2\Server\Grant;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
+use League\OAuth2\Server\RequestTypes\ResourceIndicatorAwareInterface;
+use LogicException;
 
 use function http_build_query;
 
@@ -45,5 +47,45 @@ abstract class AbstractAuthorizeGrant extends AbstractGrant
         return is_array($client->getRedirectUri())
             ? $client->getRedirectUri()[0]
             : $client->getRedirectUri();
+    }
+
+    /**
+     * Propagate RFC 8707 `resource` parameters through the authorization
+     * request. The ship-with {@see AuthorizationRequest} implements
+     * {@see ResourceIndicatorAwareInterface}, so the fallback branch only
+     * fires for custom implementations that override
+     * {@see createAuthorizationRequest()} to return a non-aware instance.
+     *
+     * When the client sent a `resource` parameter but the authorization
+     * request implementation cannot carry it, that is a library-level
+     * misconfiguration (the consumer wired up a custom auth-request type
+     * without opting into {@see ResourceIndicatorAwareInterface}), not a
+     * protocol error. A {@see LogicException} is raised to fail fast in
+     * development rather than surfacing an `invalid_target` redirect to the
+     * end-user — mirroring the analogous taxonomy in
+     * {@see AbstractGrant::applyResourceIndicators()}.
+     *
+     * @param list<non-empty-string> $resources
+     *
+     * @throws LogicException When the request implementation cannot accept
+     *                        resource indicators but the client supplied one.
+     */
+    protected function applyResourcesToAuthorizationRequest(
+        AuthorizationRequestInterface $authorizationRequest,
+        array $resources
+    ): void {
+        if ($authorizationRequest instanceof ResourceIndicatorAwareInterface) {
+            $authorizationRequest->setResources($resources);
+
+            return;
+        }
+
+        if ($resources !== []) {
+            throw new LogicException(
+                'The authorization request implementation must implement '
+                . ResourceIndicatorAwareInterface::class
+                . ' to support RFC 8707 resource indicators.'
+            );
+        }
     }
 }

--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -22,6 +22,7 @@ use Exception;
 use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\AudienceRestrictedTokenInterface;
 use League\OAuth2\Server\Entities\AuthCodeEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
@@ -40,6 +41,8 @@ use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\DeviceCodeResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
+use League\Uri\Exceptions\SyntaxError;
+use League\Uri\Uri;
 use LogicException;
 use Psr\Http\Message\ServerRequestInterface;
 use TypeError;
@@ -49,6 +52,7 @@ use function array_key_exists;
 use function base64_decode;
 use function bin2hex;
 use function explode;
+use function is_array;
 use function is_string;
 use function random_bytes;
 use function substr;
@@ -290,6 +294,154 @@ abstract class AbstractGrant implements GrantTypeInterface
     }
 
     /**
+     * Apply RFC 8707 resource indicators as audience restrictions on an
+     * access token that has been built by {@see buildAccessToken()} but not
+     * yet persisted. Call this before {@see persistAccessToken()} so the
+     * misconfiguration branch below fails fast and never leaves an orphaned
+     * row behind in the token repository.
+     *
+     * @param list<non-empty-string> $audiences
+     *
+     * @throws LogicException When audiences are supplied but the entity does
+     *                        not implement {@see AudienceRestrictedTokenInterface}.
+     *                        This is a library-level misconfiguration, not a
+     *                        protocol error, hence a programmer exception.
+     */
+    protected function applyResourceIndicators(AccessTokenEntityInterface $accessToken, array $audiences): void
+    {
+        if ($audiences === []) {
+            // Intentional no-op: grants that do not process resource
+            // indicators, or whose client omitted the `resource` parameter,
+            // still call this method unconditionally. Short-circuiting here
+            // lets them remain oblivious to the feature.
+            return;
+        }
+
+        if (!$accessToken instanceof AudienceRestrictedTokenInterface) {
+            throw new LogicException(
+                'The access token entity must implement '
+                . AudienceRestrictedTokenInterface::class
+                . ' to support RFC 8707 resource indicators.'
+            );
+        }
+
+        $accessToken->setAudiences($audiences);
+    }
+
+    /**
+     * Parse and validate repeatable `resource` parameters per RFC 8707.
+     *
+     * Accepts either a single string or an array (PSR-7 normalizes repeated
+     * query/body params to arrays). Each entry must be an absolute URI without
+     * a fragment component.
+     *
+     * @param string|array<array-key, mixed>|null $raw Value as returned by
+     *                                                 {@see getRawRequestParameter()} / {@see getRawQueryStringParameter()}.
+     *
+     * @throws OAuthServerException When any entry is not a valid absolute URI.
+     *
+     * @return list<non-empty-string> The normalized list of resource indicators (empty if none provided).
+     */
+    protected function parseResourceIndicators(string|array|null $raw, ?string $redirectUri = null): array
+    {
+        if ($raw === null || $raw === '' || $raw === []) {
+            return [];
+        }
+
+        $values = is_string($raw) ? [$raw] : $raw;
+        $resources = [];
+
+        foreach ($values as $value) {
+            $resources[] = $this->validateResourceIndicator($value, $redirectUri);
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Validate a single RFC 8707 `resource` entry as an absolute URI without
+     * a fragment component.
+     *
+     * No trimming is performed: leading or trailing whitespace is treated as
+     * an invalid indicator rather than silently normalized. This keeps the
+     * exact-string comparison in
+     * {@see AuthCodeGrant::resolveTokenEndpointResources()} symmetric — the
+     * value stored in the auth code payload and the value presented at the
+     * token endpoint must both survive this method unchanged.
+     *
+     * @throws OAuthServerException
+     *
+     * @return non-empty-string
+     */
+    private function validateResourceIndicator(mixed $value, ?string $redirectUri): string
+    {
+        if (!is_string($value)) {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must be a string',
+                $redirectUri
+            );
+        }
+
+        if ($value === '') {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must not be empty',
+                $redirectUri
+            );
+        }
+
+        if ($value !== trim($value)) {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must not contain leading or trailing whitespace',
+                $redirectUri
+            );
+        }
+
+        try {
+            $uri = Uri::new($value);
+        } catch (SyntaxError) {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must be a valid URI',
+                $redirectUri
+            );
+        }
+
+        $scheme = $uri->getScheme();
+        if ($scheme === null || $scheme === '') {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must be an absolute URI',
+                $redirectUri
+            );
+        }
+
+        $fragment = $uri->getFragment();
+        if ($fragment !== null && $fragment !== '') {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must not contain a fragment component',
+                $redirectUri
+            );
+        }
+
+        // RFC 8707 §2: the resource URI must not contain credentials; a
+        // `userinfo` component (e.g. `https://user:pass@api.example.com/`)
+        // would leak through the token response into logs and audit trails.
+        $userInfo = $uri->getUserInfo();
+        if ($userInfo !== null && $userInfo !== '') {
+            throw OAuthServerException::invalidTarget(
+                'Resource indicator must not contain a userinfo component',
+                $redirectUri
+            );
+        }
+
+        // RFC 8707 §2 says the URI "SHOULD NOT" include a query component.
+        // We deliberately allow it: some APIs version themselves through
+        // query strings (`https://api.example.com/?version=2`), and the
+        // "SHOULD NOT" strength leaves the decision to the authorization
+        // server. A future release may gate this behind a flag.
+
+        return $value;
+    }
+
+    /**
      * Parse request parameter.
      *
      * @param array<array-key, mixed> $request
@@ -329,6 +481,50 @@ abstract class AbstractGrant implements GrantTypeInterface
     protected function getRequestParameter(string $parameter, ServerRequestInterface $request, ?string $default = null): ?string
     {
         return self::parseParam($parameter, (array) $request->getParsedBody(), $default);
+    }
+
+    /**
+     * Retrieve a raw request parameter without coercion. Used for parameters
+     * that may legitimately be repeated (and thus arrive as arrays), such as
+     * the RFC 8707 `resource` parameter.
+     *
+     * @throws OAuthServerException When the value is neither null, string, nor array.
+     *
+     * @return string|array<array-key, mixed>|null
+     */
+    protected function getRawRequestParameter(string $parameter, ServerRequestInterface $request): string|array|null
+    {
+        return $this->extractRawParameterValue((array) $request->getParsedBody(), $parameter);
+    }
+
+    /**
+     * Retrieve a raw query string parameter without coercion.
+     *
+     * @throws OAuthServerException When the value is neither null, string, nor array.
+     *
+     * @return string|array<array-key, mixed>|null
+     */
+    protected function getRawQueryStringParameter(string $parameter, ServerRequestInterface $request): string|array|null
+    {
+        return $this->extractRawParameterValue($request->getQueryParams(), $parameter);
+    }
+
+    /**
+     * @param array<array-key, mixed> $source
+     *
+     * @throws OAuthServerException When the value is neither null, string, nor array.
+     *
+     * @return string|array<array-key, mixed>|null
+     */
+    private function extractRawParameterValue(array $source, string $parameter): string|array|null
+    {
+        $value = $source[$parameter] ?? null;
+
+        if ($value === null || is_string($value) || is_array($value)) {
+            return $value;
+        }
+
+        throw OAuthServerException::invalidRequest($parameter);
     }
 
     /**
@@ -420,11 +616,42 @@ abstract class AbstractGrant implements GrantTypeInterface
         string|null $userIdentifier,
         array $scopes = []
     ): AccessTokenEntityInterface {
-        $maxGenerationAttempts = self::MAX_RANDOM_TOKEN_GENERATION_ATTEMPTS;
+        return $this->persistAccessToken(
+            $this->buildAccessToken($accessTokenTTL, $client, $userIdentifier, $scopes)
+        );
+    }
 
+    /**
+     * Build and configure an access token entity without persisting it. Grants
+     * that need to apply additional configuration (e.g. RFC 8707 resource
+     * indicators) before the token hits storage can call this method, mutate
+     * the returned entity, and then hand it to {@see persistAccessToken()}.
+     *
+     * @param ScopeEntityInterface[] $scopes
+     */
+    protected function buildAccessToken(
+        DateInterval $accessTokenTTL,
+        ClientEntityInterface $client,
+        string|null $userIdentifier,
+        array $scopes = []
+    ): AccessTokenEntityInterface {
         $accessToken = $this->accessTokenRepository->getNewToken($client, $scopes, $userIdentifier);
         $accessToken->setExpiryDateTime((new DateTimeImmutable())->add($accessTokenTTL));
         $accessToken->setPrivateKey($this->privateKey);
+
+        return $accessToken;
+    }
+
+    /**
+     * Persist a fully configured access token entity, retrying on unique
+     * identifier collisions.
+     *
+     * @throws OAuthServerException
+     * @throws UniqueTokenIdentifierConstraintViolationException
+     */
+    protected function persistAccessToken(AccessTokenEntityInterface $accessToken): AccessTokenEntityInterface
+    {
+        $maxGenerationAttempts = self::MAX_RANDOM_TOKEN_GENERATION_ATTEMPTS;
 
         while ($maxGenerationAttempts-- > 0) {
             $accessToken->setIdentifier($this->generateUniqueIdentifier());

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -28,12 +28,14 @@ use League\OAuth2\Server\RequestAccessTokenEvent;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestRefreshTokenEvent;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
+use League\OAuth2\Server\RequestTypes\ResourceIndicatorAwareInterface;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use League\OAuth2\Server\ResponseTypes\ResponseTypeInterface;
 use LogicException;
 use Psr\Http\Message\ServerRequestInterface;
 use stdClass;
 
+use function array_diff;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
@@ -42,6 +44,7 @@ use function hash_algos;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_string;
 use function json_decode;
 use function json_encode;
 use function preg_match;
@@ -137,8 +140,22 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             $this->validateCodeChallenge($authCodePayload, $codeVerifier);
         }
 
-        // Issue and persist new access token
-        $accessToken = $this->issueAccessToken($accessTokenTTL, $client, $authCodePayload->user_id, $scopes);
+        // RFC 8707: parse `resource` parameters and narrow against the authorized set
+        $authorizedResources = $this->extractAuthCodeResources($authCodePayload);
+        $requestedResources = $this->parseResourceIndicators(
+            $this->getRawRequestParameter('resource', $request)
+        );
+        $audiences = $this->resolveTokenEndpointResources($authorizedResources, $requestedResources);
+
+        // Build → apply audiences → persist, in that order. applyResourceIndicators()
+        // throws LogicException when the access token entity does not implement
+        // AudienceRestrictedTokenInterface; running it before persistAccessToken()
+        // ensures a misconfigured consumer fails fast without leaving an orphaned
+        // row in the token repository.
+        $accessToken = $this->buildAccessToken($accessTokenTTL, $client, $authCodePayload->user_id, $scopes);
+        $this->applyResourceIndicators($accessToken, $audiences);
+        $accessToken = $this->persistAccessToken($accessToken);
+
         $this->getEmitter()->emit(new RequestAccessTokenEvent(RequestEvent::ACCESS_TOKEN_ISSUED, $request, $accessToken));
         $responseType->setAccessToken($accessToken);
 
@@ -154,6 +171,99 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
         $this->authCodeRepository->revokeAuthCode($authCodePayload->auth_code_id);
 
         return $responseType;
+    }
+
+    /**
+     * Extract the RFC 8707 resource indicators persisted in the auth code
+     * payload. Older payloads that predate the RFC 8707 implementation will
+     * not carry this field, so a missing property is treated as "no audience
+     * restriction was asserted during authorization". Anything else (non-list
+     * data, non-string entries, empty entries) is a tampered or corrupted
+     * payload and must abort the exchange — silently dropping malformed
+     * entries would strip an audience restriction that the authorization
+     * step explicitly asserted.
+     *
+     * @throws OAuthServerException
+     *
+     * @return list<non-empty-string>
+     */
+    private function extractAuthCodeResources(stdClass $authCodePayload): array
+    {
+        if (!property_exists($authCodePayload, 'resources')) {
+            return [];
+        }
+
+        $resources = $authCodePayload->resources;
+
+        if (!is_array($resources)) {
+            throw OAuthServerException::invalidGrant('Authorization code malformed');
+        }
+
+        $normalized = [];
+
+        foreach ($resources as $resource) {
+            if (!is_string($resource) || $resource === '') {
+                throw OAuthServerException::invalidGrant('Authorization code malformed');
+            }
+
+            $normalized[] = $resource;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Apply RFC 8707 §2.2 narrowing rules for the token endpoint.
+     *
+     * If the client supplied `resource` parameters at the token endpoint, each
+     * must be a subset of the set authorized by the auth code. If the client
+     * omits `resource`, we carry the full authorized set through to the issued
+     * access token.
+     *
+     * Policy when the auth code carries no authorized resources but the token
+     * request supplies one: rejected with `invalid_target`. RFC 8707 §2.2
+     * permits servers to fall back to "all resources the client is authorized
+     * to access", which could be interpreted as allowing first-time resource
+     * indication at the token endpoint. This library takes the conservative
+     * stance of requiring the resource set to be established at `/authorize`,
+     * so audience restrictions cannot be tightened *or* introduced under a
+     * previously unrestricted authorization code.
+     *
+     * URI comparison follows RFC 3986 §6.2.1 "Simple String Comparison" — the
+     * byte sequences must match exactly. Clients are expected to send the
+     * same canonical form at `/authorize` and `/token`; this library does
+     * not perform scheme/host lower-casing or default-port normalization, so
+     * `https://api.example.com/` and `https://api.example.com` are considered
+     * distinct.
+     *
+     * @param list<non-empty-string> $authorized
+     * @param list<non-empty-string> $requested
+     *
+     * @throws OAuthServerException
+     *
+     * @return list<non-empty-string>
+     */
+    private function resolveTokenEndpointResources(array $authorized, array $requested): array
+    {
+        if ($requested === []) {
+            return $authorized;
+        }
+
+        if ($authorized === []) {
+            // See the class-level policy note above: first-time resource
+            // indication at the token endpoint is rejected on purpose.
+            throw OAuthServerException::invalidTarget(
+                'Requested resource was not authorized by the authorization code'
+            );
+        }
+
+        if (array_diff($requested, $authorized) !== []) {
+            throw OAuthServerException::invalidTarget(
+                'Requested resource exceeds the set authorized by the authorization code'
+            );
+        }
+
+        return $requested;
     }
 
     private function validateCodeChallenge(object $authCodePayload, ?string $codeVerifier): void
@@ -282,18 +392,27 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
 
         $stateParameter = $this->getQueryStringParameter('state', $request);
 
+        $finalRedirectUri = $this->makeRedirectUri(
+            $redirectUri ?? $this->getClientRedirectUri($client),
+            $stateParameter !== null ? ['state' => $stateParameter] : []
+        );
+
         $scopes = $this->validateScopes(
             $this->getQueryStringParameter('scope', $request, $this->defaultScope),
-            $this->makeRedirectUri(
-                $redirectUri ?? $this->getClientRedirectUri($client),
-                $stateParameter !== null ? ['state' => $stateParameter] : []
-            )
+            $finalRedirectUri
+        );
+
+        $resources = $this->parseResourceIndicators(
+            $this->getRawQueryStringParameter('resource', $request),
+            $finalRedirectUri
         );
 
         $authorizationRequest = $this->createAuthorizationRequest();
         $authorizationRequest->setGrantTypeId($this->getIdentifier());
         $authorizationRequest->setClient($client);
         $authorizationRequest->setRedirectUri($redirectUri);
+
+        $this->applyResourcesToAuthorizationRequest($authorizationRequest, $resources);
 
         if ($stateParameter !== null) {
             $authorizationRequest->setState($stateParameter);
@@ -374,6 +493,9 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
                 'expire_time'           => (new DateTimeImmutable())->add($this->authCodeTTL)->getTimestamp(),
                 'code_challenge'        => $authorizationRequest->getCodeChallenge(),
                 'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
+                'resources'             => $authorizationRequest instanceof ResourceIndicatorAwareInterface
+                    ? $authorizationRequest->getResources()
+                    : [],
             ];
 
             $jsonPayload = json_encode($payload);

--- a/src/RequestTypes/AuthorizationRequest.php
+++ b/src/RequestTypes/AuthorizationRequest.php
@@ -16,7 +16,7 @@ use League\OAuth2\Server\Entities\ClientEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 
-class AuthorizationRequest implements AuthorizationRequestInterface
+class AuthorizationRequest implements AuthorizationRequestInterface, ResourceIndicatorAwareInterface
 {
     /**
      * The grant type identifier
@@ -64,6 +64,13 @@ class AuthorizationRequest implements AuthorizationRequestInterface
      * The code challenge method (if provided)
      */
     protected string $codeChallengeMethod;
+
+    /**
+     * The requested resource indicators (RFC 8707). Each value is an absolute URI.
+     *
+     * @var list<non-empty-string>
+     */
+    protected array $resources = [];
 
     public function getGrantTypeId(): string
     {
@@ -159,5 +166,21 @@ class AuthorizationRequest implements AuthorizationRequestInterface
     public function setCodeChallengeMethod(string $codeChallengeMethod): void
     {
         $this->codeChallengeMethod = $codeChallengeMethod;
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    public function getResources(): array
+    {
+        return $this->resources;
+    }
+
+    /**
+     * @param list<non-empty-string> $resources
+     */
+    public function setResources(array $resources): void
+    {
+        $this->resources = $resources;
     }
 }

--- a/src/RequestTypes/ResourceIndicatorAwareInterface.php
+++ b/src/RequestTypes/ResourceIndicatorAwareInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+declare(strict_types=1);
+
+namespace League\OAuth2\Server\RequestTypes;
+
+/**
+ * Opt-in extension of {@see AuthorizationRequestInterface} for implementations
+ * that carry RFC 8707 resource indicators through the authorization flow.
+ *
+ * Implementing this interface is optional; grants that support RFC 8707 check
+ * for it via `instanceof` so existing consumer implementations of the base
+ * {@see AuthorizationRequestInterface} remain backwards compatible.
+ */
+interface ResourceIndicatorAwareInterface
+{
+    /**
+     * @return list<non-empty-string> The absolute URIs of the requested resources.
+     */
+    public function getResources(): array;
+
+    /**
+     * @param list<non-empty-string> $resources
+     */
+    public function setResources(array $resources): void;
+}

--- a/tests/Exception/OAuthServerExceptionTest.php
+++ b/tests/Exception/OAuthServerExceptionTest.php
@@ -149,4 +149,25 @@ class OAuthServerExceptionTest extends TestCase
 
         self::assertSame('invalid_grant', $exception->getErrorType());
     }
+
+    public function testInvalidTargetExposesRfc8707ErrorType(): void
+    {
+        $exception = OAuthServerException::invalidTarget('The requested resource is not allowed');
+
+        self::assertSame('invalid_target', $exception->getErrorType());
+        self::assertSame(400, $exception->getHttpStatusCode());
+        self::assertSame('The requested resource is not allowed', $exception->getPayload()['hint']);
+        self::assertNull($exception->getRedirectUri());
+    }
+
+    public function testInvalidTargetCanCarryRedirectUri(): void
+    {
+        $exception = OAuthServerException::invalidTarget(
+            'Invalid resource indicator',
+            'https://example.com/cb'
+        );
+
+        self::assertTrue($exception->hasRedirect());
+        self::assertSame('https://example.com/cb', $exception->getRedirectUri());
+    }
 }

--- a/tests/Grant/AuthCodeGrantTest.php
+++ b/tests/Grant/AuthCodeGrantTest.php
@@ -7,6 +7,9 @@ namespace LeagueTests\Grant;
 use DateInterval;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\UnencryptedToken;
 use League\OAuth2\Server\CryptKey;
 use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Exception\OAuthServerException;
@@ -21,8 +24,10 @@ use League\OAuth2\Server\RequestAccessTokenEvent;
 use League\OAuth2\Server\RequestEvent;
 use League\OAuth2\Server\RequestRefreshTokenEvent;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequestInterface;
 use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use LeagueTests\Stubs\AccessTokenEntity;
+use LeagueTests\Stubs\AudienceRestrictedAccessTokenEntity;
 use LeagueTests\Stubs\AuthCodeEntity;
 use LeagueTests\Stubs\ClientEntity;
 use LeagueTests\Stubs\CryptTraitStub;
@@ -33,10 +38,15 @@ use LeagueTests\Stubs\UserEntity;
 use LogicException;
 use PHPUnit\Framework\TestCase;
 
+use function json_decode;
 use function json_encode;
+use function parse_str;
+use function parse_url;
 use function str_repeat;
 use function time;
 use function uniqid;
+
+use const PHP_URL_QUERY;
 
 class AuthCodeGrantTest extends TestCase
 {
@@ -2568,5 +2578,833 @@ class AuthCodeGrantTest extends TestCase
 
             self::assertStringStartsWith('http://bar/foo', $response->getHeader('Location')[0]);
         }
+    }
+
+    public function testValidateAuthorizationRequestCapturesResourceIndicators(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => ['https://api.example.com/', 'https://files.example.com/'],
+            ]
+        );
+
+        $authRequest = $grant->validateAuthorizationRequest($request);
+
+        self::assertInstanceOf(AuthorizationRequest::class, $authRequest);
+        self::assertSame(
+            ['https://api.example.com/', 'https://files.example.com/'],
+            $authRequest->getResources()
+        );
+    }
+
+    public function testValidateAuthorizationRequestRejectsRelativeResource(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => '/relative/path',
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(15);
+
+        $grant->validateAuthorizationRequest($request);
+    }
+
+    public function testValidateAuthorizationRequestRejectsNonScalarResourceValue(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        // A raw integer (or any non-string/non-array/non-null value) reaches
+        // getRawQueryStringParameter → extractRawParameterValue, which rejects
+        // it as an invalid_request rather than propagating as `mixed` through
+        // parseResourceIndicators.
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 42,
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(3);
+
+        $grant->validateAuthorizationRequest($request);
+    }
+
+    public function testValidateAuthorizationRequestRejectsResourceWhenAuthRequestIsNotResourceAware(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        // A stripped-down authorization request that implements the base
+        // interface only — no ResourceIndicatorAwareInterface. The fallback
+        // branch in AbstractAuthorizeGrant::applyResourcesToAuthorizationRequest
+        // must reject any supplied `resource` with invalid_target instead of
+        // silently dropping it.
+        $nonAwareAuthRequest = $this->createMock(AuthorizationRequestInterface::class);
+
+        $grant = new class (
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M'),
+            $nonAwareAuthRequest
+        ) extends AuthCodeGrant {
+            public function __construct(
+                AuthCodeRepositoryInterface $authCodeRepository,
+                RefreshTokenRepositoryInterface $refreshTokenRepository,
+                DateInterval $authCodeTTL,
+                private AuthorizationRequestInterface $stubAuthRequest
+            ) {
+                parent::__construct($authCodeRepository, $refreshTokenRepository, $authCodeTTL);
+            }
+
+            protected function createAuthorizationRequest(): AuthorizationRequestInterface
+            {
+                return $this->stubAuthRequest;
+            }
+        };
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 'https://api.example.com/',
+            ]
+        );
+
+        $this->expectException(LogicException::class);
+
+        $grant->validateAuthorizationRequest($request);
+    }
+
+    public function testValidateAuthorizationRequestRejectsResourceWithUserInfo(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 'https://user:pass@api.example.com/',
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(15);
+
+        $grant->validateAuthorizationRequest($request);
+    }
+
+    public function testValidateAuthorizationRequestRejectsResourceWithFragment(): void
+    {
+        $client = new ClientEntity();
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setDefaultScope(self::DEFAULT_SCOPE);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            null,
+            'php://input',
+            [],
+            [],
+            [
+                'response_type' => 'code',
+                'client_id'     => 'foo',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 'https://api.example.com/#frag',
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(15);
+
+        $grant->validateAuthorizationRequest($request);
+    }
+
+    public function testRespondToAccessTokenRequestNarrowsResourcesIntoAudiences(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessToken = new AudienceRestrictedAccessTokenEntity();
+        $accessToken->setClient($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 'https://api.example.com/',
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/', 'https://files.example.com/'],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+
+        self::assertSame(['https://api.example.com/'], $accessToken->getAudiences());
+    }
+
+    public function testRespondToAccessTokenRequestUsesExactStringComparisonForResources(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AudienceRestrictedAccessTokenEntity());
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                // Trailing slash differs: RFC 3986 §6.2.1 Simple String Comparison
+                // treats these as distinct. We expect invalid_target.
+                'resource'      => 'https://api.example.com',
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/'],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(15);
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+    }
+
+    public function testRespondToAccessTokenRequestRejectsExpandedResources(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AudienceRestrictedAccessTokenEntity());
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'resource'      => 'https://other.example.com/',
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/'],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(15);
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+    }
+
+    public function testCompleteAuthorizationRequestPersistsResourcesIntoAuthCodePayload(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('clientId');
+        $client->setRedirectUri('http://foo/bar');
+
+        $authRequest = new AuthorizationRequest();
+        $authRequest->setAuthorizationApproved(true);
+        $authRequest->setClient($client);
+        $authRequest->setGrantTypeId('authorization_code');
+        $authRequest->setUser(new UserEntity());
+        $authRequest->setResources(['https://api.example.com/']);
+
+        $authCodeRepository = $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock();
+        $authCodeRepository->method('getNewAuthCode')->willReturn(new AuthCodeEntity());
+
+        $grant = new AuthCodeGrant(
+            $authCodeRepository,
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+
+        /** @var RedirectResponse $response */
+        $response = $grant->completeAuthorizationRequest($authRequest);
+
+        $location = $response->generateHttpResponse(new Response())->getHeader('Location')[0];
+        $query = parse_url($location, PHP_URL_QUERY);
+        self::assertIsString($query);
+
+        parse_str($query, $queryParams);
+        self::assertIsString($queryParams['code']);
+
+        $payload = json_decode($this->cryptStub->doDecrypt($queryParams['code']), true);
+        self::assertIsArray($payload);
+
+        self::assertSame(['https://api.example.com/'], $payload['resources']);
+    }
+
+    public function testRespondToAccessTokenRequestEmitsResourceIndicatorsAsJwtAudiences(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessToken = new AudienceRestrictedAccessTokenEntity();
+        $accessToken->setClient($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/', 'https://files.example.com/'],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+
+        $jwt = $accessToken->toString();
+        self::assertNotSame('', $jwt);
+
+        $token = (new Parser(new JoseEncoder()))->parse($jwt);
+        self::assertInstanceOf(UnencryptedToken::class, $token);
+
+        self::assertSame(
+            ['https://api.example.com/', 'https://files.example.com/'],
+            $token->claims()->get('aud')
+        );
+    }
+
+    public function testRespondToAccessTokenRequestThrowsLogicExceptionWhenEntityDoesNotSupportAudiences(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        // Vanilla AccessTokenEntity does NOT implement AudienceRestrictedTokenInterface.
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn(new AccessTokenEntity());
+        $accessTokenRepositoryMock->expects(self::never())->method('persistNewAccessToken');
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->expects(self::never())->method('persistNewRefreshToken');
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/'],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $this->expectException(LogicException::class);
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+    }
+
+    public function testRespondToAccessTokenRequestRejectsMalformedAuthCodeResourcesPayload(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                        'resources'    => ['https://api.example.com/', 42],
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(10);
+
+        $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+    }
+
+    public function testRespondToAccessTokenRequestPreservesExistingBehaviourWithoutResources(): void
+    {
+        $client = new ClientEntity();
+        $client->setIdentifier('foo');
+        $client->setRedirectUri(self::REDIRECT_URI);
+        $client->setConfidential();
+
+        $clientRepositoryMock = $this->getMockBuilder(ClientRepositoryInterface::class)->getMock();
+        $clientRepositoryMock->method('getClientEntity')->willReturn($client);
+        $clientRepositoryMock->method('validateClient')->willReturn(true);
+
+        $scopeRepositoryMock = $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock();
+        $scopeRepositoryMock->method('getScopeEntityByIdentifier')->willReturn(new ScopeEntity());
+        $scopeRepositoryMock->method('finalizeScopes')->willReturnArgument(0);
+
+        $accessToken = new AccessTokenEntity();
+        $accessToken->setClient($client);
+
+        $accessTokenRepositoryMock = $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock();
+        $accessTokenRepositoryMock->method('getNewToken')->willReturn($accessToken);
+        $accessTokenRepositoryMock->method('persistNewAccessToken')->willReturnSelf();
+
+        $refreshTokenRepositoryMock = $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock();
+        $refreshTokenRepositoryMock->method('persistNewRefreshToken')->willReturnSelf();
+        $refreshTokenRepositoryMock->method('getNewRefreshToken')->willReturn(new RefreshTokenEntity());
+
+        $grant = new AuthCodeGrant(
+            $this->getMockBuilder(AuthCodeRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(RefreshTokenRepositoryInterface::class)->getMock(),
+            new DateInterval('PT10M')
+        );
+        $grant->setClientRepository($clientRepositoryMock);
+        $grant->setScopeRepository($scopeRepositoryMock);
+        $grant->setAccessTokenRepository($accessTokenRepositoryMock);
+        $grant->setRefreshTokenRepository($refreshTokenRepositoryMock);
+        $grant->setEncryptionKey($this->cryptStub->getKey());
+        $grant->setPrivateKey(new CryptKey('file://' . __DIR__ . '/../Stubs/private.key'));
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            'php://input',
+            [],
+            [],
+            [],
+            [
+                'grant_type'    => 'authorization_code',
+                'client_id'     => 'foo',
+                'client_secret' => 'bar',
+                'redirect_uri'  => self::REDIRECT_URI,
+                'code'          => $this->cryptStub->doEncrypt(
+                    json_encode([
+                        'auth_code_id' => uniqid(),
+                        'expire_time'  => time() + 3600,
+                        'client_id'    => 'foo',
+                        'user_id'      => '123',
+                        'scopes'       => ['foo'],
+                        'redirect_uri' => self::REDIRECT_URI,
+                    ], JSON_THROW_ON_ERROR)
+                ),
+            ]
+        );
+
+        /** @var StubResponseType $response */
+        $response = $grant->respondToAccessTokenRequest($request, new StubResponseType(), new DateInterval('PT10M'));
+
+        self::assertInstanceOf(RefreshTokenEntityInterface::class, $response->getRefreshToken());
+
+        // The historical single-audience behaviour must survive the RFC 8707
+        // changes: when no `resource` was supplied at any step and the entity
+        // does not opt into AudienceRestrictedTokenInterface, the JWT `aud`
+        // claim falls back to the client id.
+        $jwt = $accessToken->toString();
+        self::assertNotSame('', $jwt);
+
+        $token = (new Parser(new JoseEncoder()))->parse($jwt);
+        self::assertInstanceOf(UnencryptedToken::class, $token);
+        self::assertSame(['foo'], $token->claims()->get('aud'));
     }
 }

--- a/tests/Stubs/AudienceRestrictedAccessTokenEntity.php
+++ b/tests/Stubs/AudienceRestrictedAccessTokenEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @author      Alex Bilbie <hello@alexbilbie.com>
+ * @copyright   Copyright (c) Alex Bilbie
+ * @license     http://mit-license.org/
+ *
+ * @link        https://github.com/thephpleague/oauth2-server
+ */
+
+declare(strict_types=1);
+
+namespace LeagueTests\Stubs;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\AudienceRestrictedTokenInterface;
+use League\OAuth2\Server\Entities\Traits\AccessTokenTrait;
+use League\OAuth2\Server\Entities\Traits\AudienceRestrictedTokenTrait;
+use League\OAuth2\Server\Entities\Traits\EntityTrait;
+use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
+
+class AudienceRestrictedAccessTokenEntity implements AccessTokenEntityInterface, AudienceRestrictedTokenInterface
+{
+    use AccessTokenTrait;
+    use AudienceRestrictedTokenTrait;
+    use TokenEntityTrait;
+    use EntityTrait;
+}


### PR DESCRIPTION
- Implement audience-restricted tokens (`aud` claim).
- Introduce `ResourceIndicatorAwareInterface` for authorization requests.
- Enforce validation of resource indicators in grants.
- Extend tests to cover resource indicator scenarios.


