### PR TITLE
feat: Remove obsolete lcobucci/clock depdendency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "psr/http-message": "^2.0",
     "defuse/php-encryption": "^2.4",
     "ext-json": "*",
-    "lcobucci/clock": "^3.3",
-    "psr/http-server-middleware": "^1.0"
+    "psr/http-server-middleware": "^1.0",
+    "psr/clock": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^11.5.50",

--- a/src/AuthorizationValidators/BearerTokenValidator.php
+++ b/src/AuthorizationValidators/BearerTokenValidator.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace League\OAuth2\Server\AuthorizationValidators;
 
 use DateInterval;
+use DateTimeImmutable;
 use DateTimeZone;
-use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Exception;
 use Lcobucci\JWT\Signer\Key\InMemory;
@@ -27,6 +27,7 @@ use League\OAuth2\Server\CryptKeyInterface;
 use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use Psr\Clock\ClockInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
@@ -66,7 +67,12 @@ class BearerTokenValidator implements AuthorizationValidatorInterface
             InMemory::plainText('empty', 'empty')
         );
 
-        $clock = new SystemClock(new DateTimeZone(date_default_timezone_get()));
+        $clock = new class () implements ClockInterface {
+            public function now(): DateTimeImmutable
+            {
+                return new DateTimeImmutable('now', new DateTimeZone(date_default_timezone_get()));
+            }
+        };
 
         $publicKeyContents = $this->publicKey->getKeyContents();
 


### PR DESCRIPTION
Hey there :wave: 

We are currently using this library in our projects. As we have a full Symfony stack, we currently have two clock implementations in our vendor directory: `lcobucci/clock` and `symfony/clock`.

As indicated in this issue #1489, PSR interface are there to prevent such cases. 

There is only one place where the `lcobucci/clock` is used and as @eugene-borovov stated here https://github.com/thephpleague/oauth2-server/issues/1489#issuecomment-3232087071 this could easily be replaced with an inline anonymous class implementation of the ClockInterface. 

I am looking for feedback.
Best regards :v: 