### PR TITLE
Check for required `response_type` parameter in the authorization requests

### DIFF
--- a/src/AuthorizationServer.php
+++ b/src/AuthorizationServer.php
@@ -113,6 +113,10 @@ class AuthorizationServer implements EmitterAwareInterface
      */
     public function validateAuthorizationRequest(ServerRequestInterface $request): AuthorizationRequestInterface
     {
+        if (!isset($request->getQueryParams()['response_type'])) {
+            throw OAuthServerException::invalidRequest('response_type');
+        }
+
         foreach ($this->enabledGrantTypes as $grantType) {
             if ($grantType->canRespondToAuthorizationRequest($request)) {
                 return $grantType->validateAuthorizationRequest($request);

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -244,8 +244,7 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
     public function canRespondToAuthorizationRequest(ServerRequestInterface $request): bool
     {
         return (
-            array_key_exists('response_type', $request->getQueryParams())
-            && $request->getQueryParams()['response_type'] === 'code'
+            $request->getQueryParams()['response_type'] === 'code'
             && isset($request->getQueryParams()['client_id'])
         );
     }

--- a/src/Grant/ImplicitGrant.php
+++ b/src/Grant/ImplicitGrant.php
@@ -83,8 +83,7 @@ class ImplicitGrant extends AbstractAuthorizeGrant
     public function canRespondToAuthorizationRequest(ServerRequestInterface $request): bool
     {
         return (
-            isset($request->getQueryParams()['response_type'])
-            && $request->getQueryParams()['response_type'] === 'token'
+            $request->getQueryParams()['response_type'] === 'token'
             && isset($request->getQueryParams()['client_id'])
         );
     }

--- a/tests/AuthorizationServerTest.php
+++ b/tests/AuthorizationServerTest.php
@@ -63,7 +63,10 @@ class AuthorizationServerTest extends TestCase
 
         $server->enableGrantType(new GrantType(), new DateInterval('PT1M'));
 
-        $authRequest = $server->validateAuthorizationRequest($this->createMock(ServerRequestInterface::class));
+        $request = (new ServerRequest())->withQueryParams([
+            'response_type' => 'foo',
+        ]);
+        $authRequest = $server->validateAuthorizationRequest($request);
         self::assertSame(GrantType::class, $authRequest->getGrantTypeId());
     }
 
@@ -331,5 +334,23 @@ class AuthorizationServerTest extends TestCase
         $this->expectExceptionCode(2);
 
         $server->validateAuthorizationRequest($request);
+    }
+
+    public function testValidateAuthorizationRequestWithoutResponseType(): void
+    {
+        $server = new AuthorizationServer(
+            $this->getMockBuilder(ClientRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(AccessTokenRepositoryInterface::class)->getMock(),
+            $this->getMockBuilder(ScopeRepositoryInterface::class)->getMock(),
+            'file://' . __DIR__ . '/Stubs/private.key',
+            'file://' . __DIR__ . '/Stubs/public.key'
+        );
+
+        $server->enableGrantType(new GrantType(), new DateInterval('PT1M'));
+
+        $this->expectException(OAuthServerException::class);
+        $this->expectExceptionCode(3);
+
+        $server->validateAuthorizationRequest($this->createMock(ServerRequestInterface::class));
     }
 }


### PR DESCRIPTION
This PR adds early validation for the required `response_type` parameter in authorization requests, before any registered grant handler is invoked.

The issue was identified while implementing an OIDC-compliant authorization server and running the OpenID certification test suite. One of the test cases verifies that authorization requests missing the `response_type` parameter are properly rejected according to the OAuth 2.0 specification.

With this change, the authorization server now detects missing `response_type` values during the initial request validation phase and returns the appropriate OAuth error (`invalid_request`) before grant resolution occurs.

This behavior aligns the implementation with RFC 6749 Section 3.1.1, which defines `response_type` as a required parameter in authorization requests:
https://tools.ietf.org/html/rfc6749#section-3.1.1





